### PR TITLE
fix(layout): fix window and content sizing

### DIFF
--- a/src/components/Barometer/barometer.css
+++ b/src/components/Barometer/barometer.css
@@ -4,7 +4,7 @@ Barometer styles
 .barometer-container {
   height: 100%;
   width: 100%;
-  position: fixed;
+  position: absolute;
   display: flex;
   justify-content: center;
   /*background: url('/src/assets/images/arc.svg') center center no-repeat;*/

--- a/src/components/CircleKeyboard/circle-keyboard.css
+++ b/src/components/CircleKeyboard/circle-keyboard.css
@@ -1,7 +1,7 @@
 .circle-keyboard-container {
   height: 100%;
   width: 100%;
-  position: fixed;
+  position: absolute;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/PressetSettings/pressetSettings.css
+++ b/src/components/PressetSettings/pressetSettings.css
@@ -21,11 +21,11 @@
 }
 
 .presset-options {
-  width: 100vw;
-  height: 100vh;
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
+  right: 0;
+  bottom: 0;
   padding-left: 72px;
 }
 
@@ -109,8 +109,7 @@
 }
 
 .presset-container {
-  position: relative;
+  position: absolute;
   height: 100%;
-  position: fixed;
   width: 100%;
 }

--- a/src/components/Pressets/pressets.css
+++ b/src/components/Pressets/pressets.css
@@ -60,7 +60,7 @@
 .preset-wrapper {
   width: 100%;
   height: 100%;
-  position: fixed;
+  position: absolute;
 }
 
 .swiper-horizontal .swiper-slide {

--- a/src/components/SettingNumerical/gauge.css
+++ b/src/components/SettingNumerical/gauge.css
@@ -1,7 +1,9 @@
 .gauge-container {
-  height: 100%;
-  width: 100%;
-  position: fixed;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -26,10 +28,11 @@
 }
 
 .scalesLayout {
-  /* background-color: #000000; */
-  height: 100%;
-  width: 100%;
-  position: fixed;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
   display: flex;
   align-items: center;
   z-index: 12;

--- a/src/components/Settings/settings.css
+++ b/src/components/Settings/settings.css
@@ -1,14 +1,16 @@
 .settings-container {
-  width: 100%;
-  height: 100%;
-  position: fixed;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
 }
 .settings-options {
-  width: 100vw;
-  height: 100vh;
-  position: fixed;
+  position: absolute;
   top: 0;
+  right: 0;
   left: 0;
+  bottom: 0;
   padding-left: 72px;
 }
 .setting-option-item {

--- a/src/components/shared/multipleOptionSlider.css
+++ b/src/components/shared/multipleOptionSlider.css
@@ -1,7 +1,9 @@
 .multiple-option-wrapper {
-  height: 100%;
-  width: 100%;
-  position: fixed;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/globals.css
+++ b/src/globals.css
@@ -27,11 +27,22 @@
   font-weight: bolder;
 }
 
+html,
+body {
+  width: 480px;
+  height: 480px;
+  margin: 0;
+  overflow: hidden;
+}
+
 body {
   font-family: 'Open Sans';
   font-weight: 400;
   color: white;
-  margin: 0;
+  background-color: black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .text-gray {
   color: #5e5e5e;
@@ -47,13 +58,11 @@ body {
 /* Layouts */
 
 .main-layout {
-  height: 100%;
-  width: 100%;
-  position: fixed;
+  width: 480px;
+  height: 480px;
+  position: absolute;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
 }
 
 .main-layout-content {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const createWindow = (): void => {
     minHeight: 480,
     minWidth: 480,
     title: 'Meticulous',
+    useContentSize: true,
     darkTheme: true,
     backgroundColor: 'black',
     center: true,


### PR DESCRIPTION
Currently the window size is taking the title bar into account so the actual viewport is not matching the intended device display resolution. This also means there's always a scrollbar, and when devs interact with space bar it will also scroll the page. To counteract this most things are laid out with `position: fixed` so that when the page scrolls, the UI stays in position. 

This is problematic for a few different reasons, but one that has been noted in #143 is that `position: fixed` is implemented in a quite particular way in browsers which makes it behave oddly when doing GPU accelerated things. 

This PR fixes by passing the `useContentSize` option to Electron to make sure the content size is correct, disables scrolling, and refactors away all `position: fixed` in favour of `position: absolute`. 