### PR TITLE
fix(settings): update settings to have fade per figma

### DIFF
--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -10,9 +10,21 @@ interface Props {
   optionSelected: (option: string) => void;
 }
 
+const formatSetting = (setting: IPresetSetting) => {
+  let mValue = '';
+
+  if (
+    (setting.value || setting.label) &&
+    (typeof setting.value === 'number' || typeof setting.value === 'string')
+  ) {
+    mValue = `: ${setting.value} ${(setting as any)?.unit || ''}`;
+  }
+
+  return `${setting.label}${mValue}`;
+};
+
 export function PressetSettings({ optionSelected }: Props): JSX.Element {
   const [animationStyle, setAnimationStyle] = useState('');
-  const [init, setInit] = useState(false);
   const [swiper, setSwiper] = useState(null);
   const { screen, presetSetting } = useAppSelector((state) => state);
   const settings = useMemo(
@@ -124,27 +136,8 @@ export function PressetSettings({ optionSelected }: Props): JSX.Element {
     return animation;
   }, [screen]);
 
-  const displaySetting = (setting: IPresetSetting, isActive: boolean) => {
-    if (isActive) {
-      let mValue = '';
-
-      if (
-        typeof setting.value === 'number' ||
-        typeof setting.value === 'string'
-      ) {
-        mValue = `: ${setting.value}`;
-      }
-
-      return `${setting.label}${mValue} ${(setting as any)?.unit || ''}`;
-    }
-    return setting.label;
-  };
-
   return (
     <div className={`presset-container ${getAnimation()}`}>
-      {/* <div className="presset-title title-main-2">Filter 2.1</div> */}
-      <div className="blur blur-top"></div>
-      <div className="blur blur-bottom"></div>
       <div className="presset-options">
         <Swiper
           onSwiper={setSwiper}
@@ -153,11 +146,8 @@ export function PressetSettings({ optionSelected }: Props): JSX.Element {
           direction="vertical"
           autoHeight={false}
           centeredSlides={true}
+          initialSlide={presetSetting.activeSetting}
           onSlideNextTransitionStart={() => {
-            if (!init) {
-              setInit(true);
-              return;
-            }
             setAnimationStyle('animation-next');
           }}
           onSlidePrevTransitionStart={() => setAnimationStyle('animation-prev')}
@@ -168,19 +158,19 @@ export function PressetSettings({ optionSelected }: Props): JSX.Element {
               className="presset-option-item"
               key={`option-${index}`}
             >
-              {({ isActive }) => (
-                <div
-                  className={`${animationStyle} ${
-                    isActive ? `item-active` : ''
-                  } ${setting.key === 'delete' ? 'delete-option-item' : ''}`}
-                >
-                  {displaySetting(setting, isActive)}
-                </div>
-              )}
+              <div
+                className={`${animationStyle} ${
+                  setting.key === 'delete' ? 'delete-option-item' : ''
+                }`}
+              >
+                {formatSetting(setting)}
+              </div>
             </SwiperSlide>
           ))}
         </Swiper>
       </div>
+      <div className="fade fade-top"></div>
+      <div className="fade fade-bottom"></div>
     </div>
   );
 }

--- a/src/components/PressetSettings/pressetSettings.css
+++ b/src/components/PressetSettings/pressetSettings.css
@@ -1,5 +1,4 @@
 .presset-option-item {
-  color: #5e5e5e;
   font-size: 40px;
   line-height: 52px;
   font-weight: 500;
@@ -7,17 +6,8 @@
   justify-content: start;
 }
 
-.item-active {
-  color: #fff;
-}
-
 .delete-option-item {
   color: #e74d4d;
-  opacity: 0.5;
-}
-
-.item-active.delete-option-item {
-  opacity: 1;
 }
 
 .presset-options {
@@ -27,6 +17,10 @@
   right: 0;
   bottom: 0;
   padding-left: 72px;
+}
+
+.presset-options .swiper {
+  z-index: 0;
 }
 
 .test-mid-screen {
@@ -42,12 +36,11 @@
 @keyframes bounce-next {
   0%,
   100% {
-    transform: translateY(-36px);
+    transform: translateY(-16px);
   }
   20% {
     transform: translateY(0);
   }
-
   34% {
     transform: translateY(0);
   }
@@ -60,12 +53,11 @@
 @keyframes bounce-prev {
   0%,
   100% {
-    transform: translateY(36px);
+    transform: translateY(16px);
   }
   20% {
     transform: translateY(0);
   }
-
   34% {
     transform: translateY(0);
   }
@@ -82,24 +74,36 @@
   animation: bounce-prev 1800ms ease-in-out;
 }
 
-.blur {
-  background: black;
-  z-index: 1;
-  width: 100%;
-  height: 200px;
-  opacity: 0.9;
+.fade {
+  position: absolute;
+  left: 0;
+  right: 0;
 }
 
-.blur-top {
-  position: absolute;
-  top: -100px;
-  left: 0;
+.fade-top {
+  top: 0;
+  height: 220px;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 1) 25%,
+    rgba(0, 0, 0, 0.7) 60%,
+    rgba(0, 0, 0, 0.7) 95%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
-.blur-bottom {
-  position: absolute;
-  bottom: -100px;
-  left: 0;
+.fade-bottom {
+  bottom: 0;
+  height: 215px;
+  background: linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 1) 25%,
+    rgba(0, 0, 0, 0.7) 60%,
+    rgba(0, 0, 0, 0.7) 95%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
 .presset-title {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -8,7 +8,6 @@ import { useAppSelector } from '../store/hooks';
 export function Settings(): JSX.Element {
   const [animationStyle, setAnimationStyle] = useState('');
   const [swiper, setSwiper] = useState(null);
-  const [init, setInit] = useState(false);
   const { settings, screen } = useAppSelector((state) => state);
   const reset = useRef<boolean>(false);
 
@@ -54,14 +53,11 @@ export function Settings(): JSX.Element {
           onSwiper={setSwiper}
           slidesPerView={9}
           allowTouchMove={false}
+          initialSlide={settings.activeIndexSetting}
           direction="vertical"
           autoHeight={false}
           centeredSlides={true}
           onSlideNextTransitionStart={() => {
-            if (!init) {
-              setInit(true);
-              return;
-            }
             setAnimationStyle('animation-next');
           }}
           onSlidePrevTransitionStart={() => setAnimationStyle('animation-prev')}
@@ -85,6 +81,8 @@ export function Settings(): JSX.Element {
           ))}
         </Swiper>
       </div>
+      <div className="fade fade-top"></div>
+      <div className="fade fade-bottom"></div>
     </div>
   );
 }

--- a/src/components/Settings/settings.css
+++ b/src/components/Settings/settings.css
@@ -13,8 +13,10 @@
   bottom: 0;
   padding-left: 72px;
 }
+.settings-options .swiper {
+  z-index: 0;
+}
 .setting-option-item {
-  color: #5e5e5e;
   font-size: 40px;
   line-height: 52px;
   font-weight: 500;


### PR DESCRIPTION
This PR updates the settings screens to be more in line with designs with a fade in the edges and have the "focus area" fixed like on iOS date picker instead of "running ahead" like it works on alpha. 

I also made the snap animation slightly less pronounced. If we want to make it more pronounced, we probably should refactor the whole thing to be proper a snap animation (right now it looks quite odd when changing scroll direction, it's a big jump).

<img width="592" alt="Screenshot 2023-07-14 at 09 29 27" src="https://github.com/PrivSocial/meticulous-ui/assets/378279/24865969-e72a-4726-92ba-4f4370e9532a">

https://github.com/PrivSocial/meticulous-ui/assets/378279/6b16ba18-ce8e-4424-bb91-b2bc54e8c0f9
