### PR TITLE
Display profile name from event

### DIFF
--- a/src/components/store/features/preset/preset-slice.ts
+++ b/src/components/store/features/preset/preset-slice.ts
@@ -337,9 +337,13 @@ export const savePreset = createAsyncThunk(
     const state = getState() as RootState;
     const presetState = { ...state.presets } as PresetsState;
     const updateSetting = presetState.updatingSettings;
+    const nameSetting = updateSetting.settings.find(
+      (setting) => setting.key === 'name'
+    );
     const activePreset = {
       ...presetState.activePreset,
-      settings: [...updateSetting.settings]
+      settings: [...updateSetting.settings],
+      name: nameSetting.value as string
     };
     presetState.activePreset = { ...activePreset };
 

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -24,6 +24,11 @@ interface Route {
 const selectActivePresetName = (state: RootState) =>
   state.presets.activePreset.name;
 
+// Profile from "start" event may not exist in LCD. Prefer using
+// that profile name over selected preset
+const selectStatProfileName = (state: RootState) =>
+  state.stats.profile || state.presets.activePreset.name;
+
 export const routes: Record<ScreenType, Route> = {
   settings: {
     component: Settings,
@@ -43,7 +48,7 @@ export const routes: Record<ScreenType, Route> = {
   barometer: {
     component: Barometer,
     parentTitle: null,
-    title: selectActivePresetName,
+    title: selectStatProfileName,
     titleShared: true,
     bottomStatusHidden: true
   },


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/865cwrwj3

Changes:
- Fix bug that does not update selected preset name on screen after edit
- Display profile name received from start event (if available) instead of default preset name

Result:
https://github.com/PrivSocial/meticulous-ui/assets/105055997/d01e6050-9821-459d-8f82-70b5a899ba74

