### PR TITLE
fix(barometer): tweak needle transition for better perf

### DIFF
--- a/src/components/Barometer/Meter.tsx
+++ b/src/components/Barometer/Meter.tsx
@@ -68,7 +68,7 @@ export function Meter({ min, max, value, step, className }: MeterProps) {
         transform={`rotate(${Math.round(
           needleAngle * (CIRCLE_DEG / CIRCLE)
         )}, ${ARC_RADIUS}, ${ARC_RADIUS})`}
-        style={{ transition: 'all 0.3s ease-in' }}
+        style={{ transition: 'all 0.15s linear' }}
       />
     </svg>
   );


### PR DESCRIPTION
I'm unable to reproduce it myself, but @AluUriel reported that the needle of the barometer would behave oddly for big changes (like going from 8 to 0). I suspect this being due to the high frequency of updates which would cause a new transition to start every 100ms or so, and since the current transition is set to have an easing function and take 300ms that clashes. 

This PR tries to address that by disabling easing function (setting to linear) and reducing timing to 150ms. If this doesn't help we might need to remove the animation altogether. 

This is how it looks on my machine with high frequency updates:

https://github.com/PrivSocial/meticulous-ui/assets/378279/b94cb6ac-bec5-4afc-8fe0-b88e49a7174e

