### PR TITLE
Fix: CircleKeyboard/capsLockActive 

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -181,7 +181,7 @@ export function CircleKeyboard(): JSX.Element {
         case 'capslock':
           setCapsLockActive({
             active: !capsLockActive.active,
-            keep: capsLockActive.keep ? false : capsLockActive.keep
+            keep: !capsLockActive.keep
           });
           return;
         default:


### PR DESCRIPTION
## What was done?
- Set correct value for property ***keep*** of capsLockActive state after capslock is activated

## Why?
- When capslock is activated, the property **keep** was not changing and the default value is ***false*** so capslock was not keeping it active. 

## Before

https://github.com/FFFuego/meticulous-dial/assets/35279945/92434f6b-ed1f-4a28-b754-cf3d1e65ba38


## After
https://github.com/FFFuego/meticulous-dial/assets/35279945/872405f7-a279-446e-8e65-5294419bb956

