### PR TITLE
Add description to special buttons.

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -308,7 +308,13 @@ export function CircleKeyboard(): JSX.Element {
         return (
           <div className="main-letter-space icon-capslock-selected">
             <div className="relative">
-              <span className="main-letter__label main-letter__label--bottom-20">
+              <span
+                className={`main-letter__label main-letter__label--bottom-20 ${
+                  capsLockActive.active
+                    ? 'main-letter__label-color--white'
+                    : 'main-letter__label-color--grey'
+                }`}
+              >
                 CAPSLock
               </span>
               <div

--- a/src/components/CircleKeyboard/circle-keyboard.css
+++ b/src/components/CircleKeyboard/circle-keyboard.css
@@ -60,6 +60,12 @@
 .main-letter__label--rigth-46 {
   right: 46%;
 }
+.main-letter__label-color--grey {
+  color: rgba(255, 255, 255, 0.4);
+}
+.main-letter__label-color--white {
+  color: #ffffff;
+}
 
 .transition-all {
   transition: all 250ms cubic-bezier(0.47, 1.63, 0.41, 0.8);


### PR DESCRIPTION
## What was done?

Description to special buttons was added to be more intuitive

App after changes: 

_Abort_
![image](https://github.com/FFFuego/meticulous-dial/assets/36206351/ccfc0830-ac40-4326-8977-bd12332164cd)


_CAPSLock_
![image](https://github.com/FFFuego/meticulous-dial/assets/36206351/0ab87d34-fed5-4599-9233-59c48bcc160a)


_Back_
![image](https://github.com/FFFuego/meticulous-dial/assets/36206351/c61b066a-4534-458d-a8c2-49eba18e40bb)


_Ok_
![image](https://github.com/FFFuego/meticulous-dial/assets/36206351/b6969675-5476-485f-b7ad-d77a7e482364)



## Why?

The Ok, CAPSLock, Back, and Abort buttons are not easy to understand.

## Additional comments & remarks

## Full detail of changes made to each function
