### PR TITLE
fix(webpack.plugins.ts): Use SERVER_URL on the client side to connect…

### DIFF
--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -12,7 +12,8 @@ import {
   NotificationItem
 } from './features/notifications/notification-slice';
 
-const socket: Socket | null = io('http://localhost:8080');
+const SERVER_URL: string = process.env.SERVER_URL ?? 'http://localhost:8080';
+const socket: Socket | null = io(SERVER_URL);
 
 export const SocketProviderValue = () => {
   const dispatch = useAppDispatch();

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -1,4 +1,5 @@
 import type IForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import { DefinePlugin } from 'webpack';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
@@ -6,5 +7,8 @@ const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require('
 export const plugins = [
   new ForkTsCheckerWebpackPlugin({
     logger: 'webpack-infrastructure'
+  }),
+  new DefinePlugin({
+    'process.env.SERVER_URL': JSON.stringify(process.env.SERVER_URL)
   })
 ];


### PR DESCRIPTION
… to API

The meticulous backend which is offering the server API for the dial app is usually running on the same machine as the dail. However in certain cases we want to be able to change this, either for development purposes or when we want the dial to be able to be displayed on the users phone for accessibility reasons later.
The documentation calls for setting SERVER_URL however it is never actually used. Export it through the well known process.env interface which is usually not available in setups like ours where we are running a frontend application. To still use this we are changing the config to export the env as an additional plugin.