### PR TITLE
fix(src/app): fix app flickers when change to scale screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { Provider, useSelector } from 'react-redux';
 import 'swiper/swiper-bundle.min.css';
@@ -9,8 +10,8 @@ import { useFetchData } from './hooks/useFetchData';
 import { useHandleGestures } from './hooks/useHandleGestures';
 import { setScreen } from './components/store/features/screens/screens-slice';
 import { Router } from './navigation/Router';
-import { useEffect } from 'react';
 import { notificationSelector } from './components/store/features/notifications/notification-slice';
+import { durationAnimation } from './navigation/Transitioner';
 
 const App = (): JSX.Element => {
   const dispatch = useAppDispatch();
@@ -31,12 +32,22 @@ const App = (): JSX.Element => {
     }
   }, [notifications]);
 
+  const getureTimeAgo = useRef(new Date());
+
   // This can be used for development purpose
   // useSocketKeyboardListeners();
   useFetchData();
   useHandleGestures(
     {
       doubleTare() {
+        const gestureTime = new Date();
+
+        const timeDiff = +gestureTime - +getureTimeAgo.current;
+
+        if (timeDiff < durationAnimation + 50) return;
+
+        getureTimeAgo.current = gestureTime;
+
         dispatch(
           setScreen(
             screen.value === 'scale'

--- a/src/navigation/Transitioner.tsx
+++ b/src/navigation/Transitioner.tsx
@@ -12,8 +12,8 @@ interface TransitionerProps {
   titleShared?: boolean;
 }
 
-const duration = 450;
-const animationStyle = { animationDuration: `${duration / 1000}s` };
+export const durationAnimation = 450;
+const animationStyle = { animationDuration: `${durationAnimation / 1000}s` };
 
 interface TitleProps {
   children: string;
@@ -117,7 +117,7 @@ export const Transitioner = (props: TransitionerProps): JSX.Element => {
           ...prev,
           previous: null
         }));
-      }, duration);
+      }, durationAnimation);
       return () => clearTimeout(timer);
     }
   }, [previous?.screen]);


### PR DESCRIPTION
## What was done?

Fix app flickers when change to scale screen.

App before changes:

https://github.com/FFFuego/meticulous-dial/assets/36206351/41de48a0-bb0f-4192-b70d-6274d0e51d51



App after changes:

https://github.com/FFFuego/meticulous-dial/assets/36206351/f0c3c884-8a7f-4cdd-9162-1c12a3e9ff3b


## Why?

Problem description: Currently when we switch between the scale screen and any other screen this has strange behavior (flickers).

Reason found:  This occurs because when we hold pressed the button to fire doubleTare event, we are changing fast between screen.

Solution: To fix this behavior, the solution may be to wait a few seconds for the transition between screens to finish.


## Additional comments & remarks

## Full detail of changes made to each function