### PR TITLE
feat(gestures): rename start button to context button to reflect actu…

### DIFF
--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -56,9 +56,9 @@ export const SocketProviderValue = () => {
         ENCODER_PUSH: 'click',
         ENCODER_DOUBLE: 'doubleClick',
         ENCODER_LONG: 'longEncoder',
-        TARE_DUBLE: 'doubleTare',
+        TARE_DOUBLE: 'doubleTare',
         TARE_LONG: 'longTare',
-        START: 'start'
+        CONTEXT: 'context'
       };
 
       const gesture = eventGestureMap[data.type];
@@ -76,7 +76,7 @@ const keyGestureMap: Record<string, GestureType> = {
   ArrowLeft: 'left',
   ArrowRight: 'right',
   Space: 'click',
-  Enter: 'start',
+  Enter: 'context',
   KeyS: 'longTare',
   KeyE: 'longEncoder',
   KeyD: 'doubleTare',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,7 +37,7 @@ export type GestureType =
   | 'click'
   | 'doubleTare'
   | 'doubleClick'
-  | 'start'
+  | 'context'
   | 'longTare'
   | 'longEncoder';
 


### PR DESCRIPTION
…al use

We are removing the start button functionality from the machine and are adding a context menu button instead. This is already implemented in the backend where the old start message is translated to the context message