### PR TITLE
feat(src/components/quick-settings/quick-settings): add edit profile …

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -12,8 +12,13 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { WifiSettings } from '../Wifi/WifiSettings';
 import { Settings } from '../Settings/Settings';
 import { QuickPreheat } from '../Preheat/Preheat';
+import { resetActiveSetting } from '../store/features/preset/preset-slice';
 
 const settings = [
+  {
+    key: 'Edit',
+    label: 'Edit profile'
+  },
   {
     key: 'home',
     label: 'home'
@@ -73,6 +78,12 @@ export function QuickSettings(): JSX.Element {
           case 'home': {
             socket.emit('action', 'home');
             dispatch(setScreen('pressets'));
+            dispatch(setBubbleDisplay({ visible: false, component: null }));
+            break;
+          }
+          case 'Edit': {
+            dispatch(resetActiveSetting());
+            dispatch(setScreen('pressetSettings'));
             dispatch(setBubbleDisplay({ visible: false, component: null }));
             break;
           }


### PR DESCRIPTION
## What was done?
 
Edit profile option was added, now we can change to presset-settings screen from quick-setting modal.

## Why?

Currently we can not navigate to presset-settings from quick-settings modal.

App after changes: 

[edit-profile-change.webm](https://github.com/FFFuego/meticulous-dial/assets/36206351/0af64f9d-6c46-491e-80c1-df6908f64764)

App before changes:

[quick-settings.webm](https://github.com/FFFuego/meticulous-dial/assets/36206351/5756b196-2a70-4b6b-bbe3-ba5505a592ef)



## Additional comments & remarks

## Full detail of changes made to each function
