### PR TITLE
fix(components/pressets/pressets): change to previous presset

### DIFF
--- a/src/components/Pressets/Pressets.tsx
+++ b/src/components/Pressets/Pressets.tsx
@@ -67,7 +67,7 @@ const initialValue: AnimationData = {
 export function Pressets({ transitioning }: RouteProps): JSX.Element {
   const socket = useSocket();
   const dispatch = useAppDispatch();
-  const { presets } = useAppSelector((state) => state);
+  const { presets, screen } = useAppSelector((state) => state);
   const presetSwiperRef = useRef<SwiperRef | null>(null);
   const [pressetSwiper, setPressetsSwiper] = useState<SwiperS | null>(null);
   const [pressetTitleSwiper, setPressetTitleSwiper] = useState(null);
@@ -531,6 +531,17 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
   useEffect(() => {
     dispatch(setWaitingForAction(false));
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (
+        presets.activeIndexSwiper === presets.value.length &&
+        screen.prev === 'pressets'
+      ) {
+        dispatch(setPrevPreset());
+      }
+    };
+  }, [presets.activeIndexSwiper, presets.value.length, screen.prev]);
 
   return (
     <div className="preset-wrapper">


### PR DESCRIPTION
## What was done?

Change to previous presset,

## Why?

Change to previous presset, because when the user is selecting "new" option and he changes between screen  then goes back to presset screen provokes a wrong behavior so to avoid this we will change to previous presset.

App after changes:

[app-after-change-fix-pressets.webm](https://github.com/MeticulousHome/meticulous-dial/assets/36206351/2f82331e-57db-4cc7-8550-2e6b7aeb1b89)

App before changes:

[app-before-changes-fix-pressets.webm](https://github.com/MeticulousHome/meticulous-dial/assets/36206351/40b8df06-8843-44f5-b87d-36e0cd33d69e)



## Additional comments & remarks

## Full detail of changes made to each function
