### PR TITLE
fix(notification): update notification correctly and hide this when m…

### DIFF
--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -9,7 +9,8 @@ import { getPresets } from './features/preset/preset-slice';
 import { handleEvents } from '../../HandleEvents';
 import {
   addOneNotification,
-  NotificationItem
+  NotificationItem,
+  removeOneNotification
 } from './features/notifications/notification-slice';
 
 const SERVER_URL: string = process.env.SERVER_URL ?? 'http://localhost:8080';
@@ -26,7 +27,11 @@ export const SocketProviderValue = () => {
         return;
       }
 
-      dispatch(addOneNotification(oNotification));
+      if (!oNotification.message) {
+        dispatch(removeOneNotification(oNotification.id));
+      } else {
+        dispatch(addOneNotification(oNotification));
+      }
     });
 
     socket.on('status', (data: ISensorData) => {

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -19,7 +19,7 @@ const notificationSlice = createSlice({
   name: 'notifications',
   initialState: notificationAdapter.getInitialState(),
   reducers: {
-    addOneNotification: notificationAdapter.addOne,
+    addOneNotification: notificationAdapter.upsertOne,
     removeOneNotification: notificationAdapter.removeOne,
     removeAllNotications: notificationAdapter.removeAll
   }


### PR DESCRIPTION
## What was done?

Update notification correctly and hide this when message is empty.

## Why?

Currently when a notification is updated the interface does not change.

## Additional comments & remarks

For now we remove the notification when the message is empty, but I am not sure if we need to make some changes to the backend to update the info, maybe a response with the value hidden.

## Full detail of changes made to each function
