### PR TITLE
fix(style/tittle): add overflow style for title

### DIFF
--- a/src/components/Pressets/TitlePressets.tsx
+++ b/src/components/Pressets/TitlePressets.tsx
@@ -10,7 +10,9 @@ export const TitlePressets = () => {
     <div className="pressets-title">
       <div id="pressets-title-content">
         <div>Catalog</div>
-        <div>{presets.activePreset.name}</div>
+        <div style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>
+          {presets.activePreset.name}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Before:
<img width="306" alt="image" src="https://github.com/MeticulousHome/meticulous-dial/assets/35279945/4c8b7b59-7062-440b-b720-f2bbeb2a589f">

After:
<img width="304" alt="image" src="https://github.com/MeticulousHome/meticulous-dial/assets/35279945/ebf19824-4da2-4822-b43c-bd3ab4909c2a">
