### PR TITLE
feat(src/components/pressets/presset-profile-image): add cover art effect

### DIFF
--- a/src/components/Pressets/PressetProfileImage.tsx
+++ b/src/components/Pressets/PressetProfileImage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Swiper, SwiperSlide, SwiperRef } from 'swiper/react';
-import { Pagination as PaginationSwiper } from 'swiper';
+import { Pagination as PaginationSwiper, EffectCoverflow } from 'swiper';
 
 import { getProfileDefaultImages } from '../../api/profile';
 import { setScreen } from '../store/features/screens/screens-slice';
@@ -87,10 +87,19 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
   }
 
   return (
-    <div className="preset-wrapper">
+    <div className="image-swiper">
       <Swiper
-        slidesPerView={2.15}
-        spaceBetween={79}
+        effect={'coverflow'}
+        coverflowEffect={{
+          rotate: 20,
+          stretch: -50,
+          scale: 1.1,
+          depth: 200,
+          modifier: 1.0,
+          slideShadows: false
+        }}
+        slidesPerView={8}
+        spaceBetween={20}
         initialSlide={activeIndex}
         centeredSlides={true}
         allowTouchMove={false}
@@ -99,11 +108,9 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
           clearSlides(e);
           handlePresetSlideChange(e);
         }}
-        modules={[PaginationSwiper]}
+        modules={[PaginationSwiper, EffectCoverflow]}
         pagination={{
-          dynamicBullets: images.length > 5,
-          bulletActiveClass: 'swiper-pagination-bullet-active',
-          bulletClass: 'swiper-pagination-bullet'
+          type: 'fraction'
         }}
       >
         {images.length &&

--- a/src/components/Pressets/pressets.less
+++ b/src/components/Pressets/pressets.less
@@ -89,6 +89,16 @@
   position: absolute;
 }
 
+.image-swiper {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+}
+
+.image-swiper .swiper-horizontal .swiper-slide {
+  opacity: 1;
+}
+
 .swiper-horizontal .swiper-slide {
   opacity: 0.15;
 }
@@ -97,9 +107,9 @@
   opacity: 1;
 }
 
-.swiper-horizontal .swiper-slide-prev,
-.swiper-horizontal .swiper-slide-next,
-.swiper-horizontal .swiper-slide-active {
+.preset-wrapper .swiper-horizontal .swiper-slide-prev,
+.preset-wrapper .swiper-horizontal .swiper-slide-next,
+.preset-wrapper .swiper-horizontal .swiper-slide-active {
   transition: opacity 0.4s ease;
 }
 
@@ -170,6 +180,11 @@
 
 .animation-bounce-left {
   animation: bounce-left 500ms ease-out;
+}
+
+.image-swiper .animation-bounce-right,
+.image-swiper .animation-bounce-left {
+  animation: none !important;
 }
 
 @keyframes pressets-left-leave {

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -241,7 +241,8 @@ export const routes: Record<ScreenType, Route> = {
   },
   pressetProfileImage: {
     component: PressetProfileImage,
-    title: selectActivePresetName
+    title: selectActivePresetName,
+    bottomStatusHidden: true
   },
   deviceInfo: {
     component: DeviceInfo


### PR DESCRIPTION
## What was done?
The image selection screen now uses the coverart effect to display the options to choose from

## Why?
Why not


https://github.com/MeticulousHome/meticulous-dial/assets/10907336/8075be3b-4003-4aba-904f-c1c206573d19

