### PR TITLE
fix(settings): remove unecesary prop from payload

### DIFF
--- a/src/components/Preheat/Preheat.tsx
+++ b/src/components/Preheat/Preheat.tsx
@@ -34,7 +34,10 @@ export function QuickPreheat(): JSX.Element {
     }
     const mTotal =
       total + (gesture === 'left' ? -INTERVAL_PREHEAT : +INTERVAL_PREHEAT);
-    setTotal(mTotal <= MIN_PREHEAT ? MIN_PREHEAT : roundPrecision(mTotal, 1));
+    const mTotalValue =
+      mTotal <= MIN_PREHEAT ? MIN_PREHEAT : roundPrecision(mTotal, 1);
+
+    setTotal(mTotalValue || 0);
   };
 
   const updatePreheat = () => {

--- a/src/components/store/features/settings/settings-slice.ts
+++ b/src/components/store/features/settings/settings-slice.ts
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { isAxiosError } from 'axios';
 import { api } from '../../../../api/api';
 
 import { Settings, SettingsType, DeviceInfo } from 'meticulous-api';
@@ -30,8 +29,10 @@ export const fetchSettigns = createAsyncThunk(
 
 export const updateSettings = createAsyncThunk(
   'settings/updateSettings',
-  async (body: Partial<Settings>, { rejectWithValue }) => {
+  async (body: Partial<InitialSettings>, { rejectWithValue }) => {
     try {
+      if (body.deviceInfo) body.deviceInfo = undefined;
+
       const { data } = await api.updateSetting(body);
 
       if (!data) rejectWithValue('Error updating settings');


### PR DESCRIPTION
## What was done?
- Removed property `deviceInfo` from payload to update settings. Was crashing because extra property
- Specify default value to avoid preheat undefined value 

## Why?
- App was not updating settings
