### PR TITLE
fix(src/components/pressets/pressets): fix misalignment profile when …

### DIFF
--- a/src/components/Pressets/Pressets.tsx
+++ b/src/components/Pressets/Pressets.tsx
@@ -66,7 +66,7 @@ const initialValue: AnimationData = {
   extraDelay: 500
 };
 
-export function Pressets({ transitioning }: RouteProps): JSX.Element {
+export function PressetsContent({ transitioning }: RouteProps): JSX.Element {
   const dispatch = useAppDispatch();
   const presets = useAppSelector((state) => state.presets);
   const presetSwiperRef = useRef<SwiperRef | null>(null);
@@ -676,4 +676,24 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
       )}
     </div>
   );
+}
+
+export function Pressets(props: RouteProps) {
+  const presets = useAppSelector((state) => state.presets);
+  const [previousPressetsLength, setPreviousPressetsLength] = useState(
+    presets.value.length
+  );
+
+  // This key will be used to mount and unmount the component to reset all vars.
+  // The key value will change just when a presset is deleted.
+  const [key, setKey] = useState(`pressets-content-${previousPressetsLength}`);
+
+  useEffect(() => {
+    if (presets.value.length < previousPressetsLength) {
+      setKey(`pressets-content-${presets.value.length}`);
+    }
+    setPreviousPressetsLength(presets.value.length);
+  }, [presets.value.length]);
+
+  return <PressetsContent key={key} {...props} />;
 }

--- a/src/components/store/features/preset/preset-slice.ts
+++ b/src/components/store/features/preset/preset-slice.ts
@@ -562,7 +562,7 @@ const presetSlice = createSlice({
                 // Dont select the temporary profile untill absolutely necessary
                 defaultIndex = Math.min(
                   profileCount > 0 ? profileCount - 1 : payload.length - 1,
-                  state.activeIndexSwiper + 1
+                  state.activeIndexSwiper - 1
                 );
               }
               break;


### PR DESCRIPTION
## What was done?

Fix misalignment profile when it is deleted.

## Why?

Currently when a profile is deleted and the user is in presets screen it provokes misalignment for profiles layout, so to avoid this we will reset the component. 

## Additional comments & remarks

Related bug: https://github.com/MeticulousHome/meticulous-dial/issues/324

Result

[fix-layout-profile.webm](https://github.com/user-attachments/assets/cbe9b2c0-61ab-452f-ab63-044a2518d132)


## Full detail of changes made to each function
