### PR TITLE
fix(src/components/pressets/profile-image): show image correctly

### DIFF
--- a/src/components/Pressets/ProfileImage.tsx
+++ b/src/components/Pressets/ProfileImage.tsx
@@ -67,7 +67,15 @@ export const ProfileImage = ({ preset }: { preset: IProfileImage }) => {
         image
       })
     );
-  }, [preset.id]);
+  }, [preset.id, image]);
+
+  useEffect(() => {
+    setImage(
+      preset.display?.image
+        ? `${API_URL}${api.getProfileImageUrl(preset.display.image)}`
+        : pImage?.image ?? `assets/images/${presetIndex}.png`
+    );
+  }, [preset.display?.image]);
 
   return (
     <img

--- a/src/components/store/features/images/images-slice.ts
+++ b/src/components/store/features/images/images-slice.ts
@@ -15,7 +15,7 @@ const profileImageSlice = createSlice({
   name: 'tmp-profile-images',
   initialState: imageProfileAdapter.getInitialState(),
   reducers: {
-    addNewImageProfile: imageProfileAdapter.addOne
+    addNewImageProfile: imageProfileAdapter.upsertOne
   }
 });
 


### PR DESCRIPTION
## What was done?

Fix image selected

App: after changes:

[fix-image-selected-dial.webm](https://github.com/user-attachments/assets/1f4b4ee2-20b6-4062-a4df-9a7a406861be)


## Why?

Currently when we change the image profile it still show the previous image.

## Additional comments & remarks

## Full detail of changes made to each function
