### PR TITLE
fix(src/components/pressets/default-profiles): fix navigation

### DIFF
--- a/src/components/Pressets/DefaultProfiles.tsx
+++ b/src/components/Pressets/DefaultProfiles.tsx
@@ -59,12 +59,12 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
       },
       left() {
         if (!transitioning) {
-          dispatch(setNextDefaultProfileOption());
+          dispatch(setPrevDefaultProfileOption());
         }
       },
       right() {
         if (!transitioning) {
-          dispatch(setPrevDefaultProfileOption());
+          dispatch(setNextDefaultProfileOption());
         }
       }
     },


### PR DESCRIPTION
## What was done?

Fix navigation

## Why?

Currently the navigation was wrong implemented (default profile screen)

## Additional comments & remarks

Bug https://github.com/MeticulousHome/meticulous-dial/issues/334

## Full detail of changes made to each function
