### PR TITLE
fix(profile): create a new id for new profiles

### DIFF
--- a/src/components/Pressets/DefaultProfiles.tsx
+++ b/src/components/Pressets/DefaultProfiles.tsx
@@ -17,6 +17,7 @@ import {
 import './defaultProfile.css';
 import { api } from '../../api/api';
 import { Profile } from 'meticulous-typescript-profile';
+import { v4 as uuidv4 } from 'uuid';
 
 const API_URL = process.env.SERVER_URL || 'http://localhost:8080';
 
@@ -52,6 +53,7 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
             addPresetNewOne({
               profile: {
                 ...profileSelected,
+                id: uuidv4(),
                 display: {
                   shortDescription: profileSelected.display.shortDescription,
                   description: profileSelected.display.description


### PR DESCRIPTION
## What was done?
When creating a new profile a new ID needs to be set, else it overwrites the old profile

## Why?
more profiles!

