### PR TITLE
Fix preset transitions

### DIFF
--- a/src/components/Pressets/Pressets.tsx
+++ b/src/components/Pressets/Pressets.tsx
@@ -249,8 +249,6 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
                 navigationTitleRef.current.classList.add('title-bottom');
               }
 
-              dispatch(setPrevPreset());
-
               return dispatch(setScreen('defaultProfiles'));
             }
 


### PR DESCRIPTION
## What was done?
The preset screen has some leftover logic bits which are now causing visual glitches. Remove them
