### PR TITLE
fix(router): overwrite the transition direction for certain screens

### DIFF
--- a/src/components/Pressets/Pressets.tsx
+++ b/src/components/Pressets/Pressets.tsx
@@ -22,7 +22,7 @@ import {
   setOptionPressets,
   setPrevPreset
 } from '../store/features/preset/preset-slice';
-import { Title, RouteProps } from '../../navigation';
+import { RouteProps } from '../../navigation';
 import '../../navigation/navigation.less';
 import { ProfileImage } from './ProfileImage';
 import { setScreen } from '../store/features/screens/screens-slice';
@@ -91,6 +91,7 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
   const [percentaje, setPercentaje] = useState(0);
   const [startCoffe, setStartCoffe] = useState(false);
   const ready = useRef(false);
+  const currentScreen = useAppSelector((state) => state.screen.value);
 
   const pressetTitleContenExistValidation = useCallback(() => {
     if (!pressetsTitleContentRef.current) {
@@ -149,6 +150,13 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
   useEffect(() => {
     setOption({ screen: presets.option, animating: false });
   }, [presets.option]);
+
+  useEffect(() => {
+    if (currentScreen === 'pressets') {
+      return;
+    }
+    animationInProgress.current = false;
+  }, [currentScreen]);
 
   const focusProfileHandle = () => {
     if (

--- a/src/navigation/Router.tsx
+++ b/src/navigation/Router.tsx
@@ -2,7 +2,7 @@ import { Freeze } from 'react-freeze';
 import { ScreenType } from '../components/store/features/screens/screens-slice';
 import BottomStatus from '../components/BottomStatus';
 import { Transitioner } from './Transitioner';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { useAppSelector } from '../components/store/hooks';
 import Bubble from '../../src/components/Bubble/Bubble';
 import { memoizedRoutes } from '../../src/utils';
@@ -39,11 +39,26 @@ export const Router = memo(
         : parentRoute?.title
     );
 
-    const direction =
+    const calculatedDirection =
       !previousScreen ||
-      routeKeys.indexOf(currentScreen) > routeKeys.indexOf(previousScreen)
+      routeKeys.indexOf(currentScreen) >= routeKeys.indexOf(previousScreen)
         ? 'in'
         : 'out';
+
+    const directionMap = routes[currentScreen].animationDirectionFrom;
+    const direction =
+      (previousScreen && directionMap && directionMap[previousScreen]) ||
+      calculatedDirection;
+
+    useEffect(() => {
+      console.log(
+        'Router',
+        previousScreen,
+        '->',
+        currentScreen,
+        `${direction}(${calculatedDirection})`
+      );
+    }, [currentScreen, previousScreen]);
 
     return (
       <>

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -41,6 +41,7 @@ interface Route {
   bottomStatusHidden?: boolean;
   bottomTitle?: string;
   props?: object;
+  animationDirectionFrom?: Partial<Record<ScreenType, 'in' | 'out'>>;
 }
 
 const selectActivePresetName = (state: RootState) =>
@@ -72,7 +73,10 @@ export const routes: Record<ScreenType, Route> = {
     parentTitle: null,
     title: selectStatProfileName,
     // titleShared: true,
-    bottomStatusHidden: true
+    bottomStatusHidden: true,
+    animationDirectionFrom: {
+      'manual-purge': 'in'
+    }
   },
   pressetSettings: {
     component: PressetSettings,
@@ -142,7 +146,10 @@ export const routes: Record<ScreenType, Route> = {
   },
   'manual-purge': {
     component: PurgePiston,
-    bottomStatusHidden: true
+    bottomStatusHidden: true,
+    animationDirectionFrom: {
+      barometer: 'in'
+    }
   },
   dose: {
     component: () => null, // Multiple choice to be implemented

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,8 +24,6 @@ export type ActionType =
 export type StageType =
   | 'idle'
   | 'initialize'
-  | 'preinfusion'
-  | 'infusion'
   | 'purge'
   | 'tare'
   | 'home'
@@ -48,7 +46,7 @@ export type IPresetSettings = string[];
 
 export interface ISensorData {
   time: string;
-  name: StageType;
+  name: StageType | string;
   waitingForActionAlreadySent: boolean;
   sensors: {
     p: string; // Pressure - Bars


### PR DESCRIPTION
## What was done?
The transitioner has the tendency to resetting the animation due to the direction being (indirect) part of an useEffect array. To stop this certain transitions are now hardcoded in some directions.

## Why?
This is causing massive flickering if one animation is playing over another. Addressing this in the transitioned is not feasible right now, so we patch the only relevant error cases
