### PR TITLE
fix(gauge): fix unit for flow variable to ml/s instead of bar

### DIFF
--- a/src/components/SettingNumerical/Gauge.tsx
+++ b/src/components/SettingNumerical/Gauge.tsx
@@ -7,20 +7,22 @@ export const circumference = radius * 2 * Math.PI;
 const transform = `rotate(90, ${radius}, ${radius})`;
 const minDigits = 3;
 
-export type Unit = 'bar' | 'celcius' | 'gram' | 'sec';
+export type Unit = 'bar' | 'celcius' | 'gram' | 'sec' | 'ml';
 
 const unitNameMap: Record<Unit, string> = {
   bar: 'bar',
   celcius: '°C',
   gram: 'g',
-  sec: 's'
+  sec: 's',
+  ml: 'ml/s'
 };
 
 const unitClassNameMap: Record<Unit, string> = {
   bar: 'scale-pressure',
   celcius: 'scale-temp',
   gram: 'scale-weight-limit',
-  sec: 'scale-time'
+  sec: 'scale-time',
+  ml: 'scale-flow'
 };
 
 const formatValue = (value: number, precision: number) => {

--- a/src/components/SettingNumerical/SettingNumerical.tsx
+++ b/src/components/SettingNumerical/SettingNumerical.tsx
@@ -44,7 +44,7 @@ const unitSettingConfigMap: Record<NumericalSettingType, ISettingConfig> = {
   },
   flow: {
     interval: 0.1,
-    unit: 'bar',
+    unit: 'ml',
     maxValue: 12
   },
   time: {


### PR DESCRIPTION
## What was done?
fix unit for flow variable to ml/s instead of bar

## Why?
The unit for measuring flow is ml/s, not bars.

![image](https://github.com/user-attachments/assets/2b0291a1-8a31-4176-af61-b910085346b4)

## Additional comments & remarks
Result after the change

![image](https://github.com/user-attachments/assets/c7d4c1ca-11ab-46af-8a8a-6d2b4046d510)