### PR TITLE
fix(lint): remove two unused variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ const createWindow = (): void => {
     mainWindow = null;
   });
 
-  ipcMain.on('ready', async (event, arg) => {
+  ipcMain.on('ready', async () => {
     console.log('React indicates it is ready');
     if (!app.isPackaged) {
       return;


### PR DESCRIPTION
## What was done?

This fixes:
  70:30  error  'event' is defined but never used  @typescript-eslint/no-unused-vars
  70:37  error  'arg' is defined but never used    @typescript-eslint/no-unused-vars
