### PR TITLE
    fix(os-status): round the progress number just in case

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -102,9 +102,9 @@ export function QuickSettings(): JSX.Element {
       case 'COMPLETE':
         return 'Update Complete';
       case 'DOWNLOADING':
-        return `Downloading Update: ${osStatusData.progress}%`;
+        return `Downloading Update: ${Math.round(osStatusData.progress)}%`;
       case 'INSTALLING':
-        return `Installing Update: ${osStatusData.progress}%`;
+        return `Installing Update: ${Math.round(osStatusData.progress)}%`;
     }
     return '';
   }, [osStatusData, osStatusError]);


### PR DESCRIPTION
The backend is supposed to send rounded percentages. This is currently
not the case. As rounding a number is not very computational
expensive we just use the double safety and do it in the dial app
as well.

Signed-off-by: Mimoja <mimoja@meticuloushome.com>