### PR TITLE
Fix/quick settings index mismatch

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -224,41 +224,31 @@ export function QuickSettings(): JSX.Element {
   }, [settings.length]);
 
   useEffect(() => {
-    if (
+    const context: QuickSettingOption[] = profileContextSettings;
+
+    const requiresProfileContext: boolean = !(
       presets.value.length === 0 ||
       presets.activeIndexSwiper === presets.value.length ||
       (presets.option !== 'HOME' && presets.option !== 'PRESSETS')
-    ) {
-      setSettings([
-        {
-          key: 'os_update',
-          label: osStatusInfo
-        },
-        ...defaultSettings
-      ]);
-      return;
-    }
+    );
 
-    const context: QuickSettingOption[] = profileContextSettings;
+    const osStatusSettingOption: QuickSettingOption = {
+      key: 'os_update',
+      label: osStatusInfo
+    };
 
     switch (currentScreen) {
       case 'defaultProfiles':
         setSettings([
-          {
-            key: 'os_update',
-            label: osStatusInfo
-          },
+          osStatusSettingOption,
           ...[{ key: 'details', label: 'Show details' }],
           ...defaultSettings
         ]);
         break;
       default:
         setSettings([
-          {
-            key: 'os_update',
-            label: osStatusInfo
-          },
-          ...context,
+          osStatusSettingOption,
+          ...(requiresProfileContext === true ? context : []),
           ...defaultSettings
         ]);
         break;


### PR DESCRIPTION
## What was done?
Fixed the quick settings menu to correctly show the os status correctly

Fixed the quick settings menu to correctly show the option to see default profiles description

## Why?
After adding the os status option, there was a case in which the os status option was not being included into the settings array and so it was not shown in those scenarios.

The option to see the description of the default profiles was never shown when accessing the quick settings from the `defaultPresets` screen

## Additional comments & remarks

### Before
https://github.com/user-attachments/assets/bec2b090-b3fe-4fea-955b-e52cb66f3117

### After

https://github.com/user-attachments/assets/05ab2eb4-78b2-4bb2-a0ef-30e919b391c0



