### PR TITLE
fix(bubble.tsx): fix context button, it returns to the previous scree…

### DIFF
--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -13,19 +13,16 @@ export default function Bubble() {
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const route = memoizedRoutes[Bubble.component];
 
-  useHandleGestures(
-    {
-      context() {
-        dispatch(
-          setBubbleDisplay({
-            visible: !bubbleDisplay.visible,
-            component: !bubbleDisplay.visible ? 'quick-settings' : null
-          })
-        );
-      }
-    },
-    bubbleDisplay.visible
-  );
+  useHandleGestures({
+    context() {
+      dispatch(
+        setBubbleDisplay({
+          visible: !bubbleDisplay.visible,
+          component: !bubbleDisplay.visible ? 'quick-settings' : null
+        })
+      );
+    }
+  });
 
   if (!Bubble || !Bubble.component) return <></>;
 


### PR DESCRIPTION
Fix context button behavior

## What was done?
Now, when you press the context button, you return to the previous screen regardless of the submenu you're in
## Why?
It caused you to press the 'back' button as many times as the number of submenus you had opened to return to the previous screen