### PR TITLE
Fix image assets

### DIFF
--- a/src/components/IdleScreen/AnalogClock.tsx
+++ b/src/components/IdleScreen/AnalogClock.tsx
@@ -74,6 +74,15 @@ const Indicators = styled.span<{ $main: boolean }>`
   background: ${(props) => (props.$main ? '#898989' : '#494949')};
 `;
 
+const IconsConatiner = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
 export function AnalogClock() {
   const requestId = useRef<number>(-1);
   const hourRef = useRef(null);
@@ -115,16 +124,25 @@ export function AnalogClock() {
 
   return (
     <ClockContainer>
-      <WifiIndicator
-        enabled={isWifiConnected}
-        style={{
-          position: 'relative',
-          width: 27.57,
-          top: 347,
-          left: CLOCK_DIAMETER / 2 - 27.57 / 2
-        }}
-      />
-
+      <IconsConatiner>
+        <div
+          style={{
+            position: 'relative',
+            width: '30px',
+            top: '103px'
+          }}
+        >
+          <img src="assets/logo-white.svg" alt="Logo Meticulous white" />
+        </div>
+        <WifiIndicator
+          enabled={isWifiConnected}
+          style={{
+            position: 'relative',
+            width: '27.57px',
+            bottom: '103px'
+          }}
+        />
+      </IconsConatiner>
       {Array.from({ length: 60 }).map((_, i) => {
         return (
           <RotationContainer key={i} $rotation={(i * 360) / 60}>

--- a/src/components/Snake/Snake.tsx
+++ b/src/components/Snake/Snake.tsx
@@ -64,7 +64,7 @@ const isOutsideCircle = (
   return pointsOutside >= 3;
 };
 
-const APPLE_IMAGE = 'assets/images/logo.png';
+const APPLE_IMAGE = 'assets/logo.png';
 
 export const SnakeGame: React.FC = () => {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
## What was done?
fix image resource paths and placing the Meticulous logo on the AnalogClock
### Before changes
Snake
<img width="360" alt="image" src="https://github.com/user-attachments/assets/33f19255-4660-4507-b26f-a90c8f220a0d">

AnalogClock
<img width="360" alt="image" src="https://github.com/user-attachments/assets/ed52b0d3-a18f-41d1-89e7-e363edf3f625">

## Why?
They were not loading correctly

### After changes
Snake
<img width="360" alt="image" src="https://github.com/user-attachments/assets/80362fb7-cb44-40e7-85a6-5c526de2d83f">

AnalogClock
<img width="361" alt="image" src="https://github.com/user-attachments/assets/ce2d8408-c964-475e-a6dd-d0ecf8e73904">