### PR TITLE
Enable/Disable Stage Skipping

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -93,7 +93,16 @@ export function Settings(): JSX.Element {
             );
             break;
           }
-          case 'usb_mode': {
+          case 'save': {
+            const {
+              PreheatTimeLeft,
+              country,
+              countryLetter,
+              tempHeatingTimeout,
+              deviceInfo,
+              ...filteredGlobalSetings
+            } = globalSettings;
+            dispatch(updateSettings(filteredGlobalSetings));
             dispatch(
               setBubbleDisplay({ visible: true, component: 'usbSettings' })
             );

--- a/src/components/store/features/settings/settings-slice.ts
+++ b/src/components/store/features/settings/settings-slice.ts
@@ -3,11 +3,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 type InitialSettings = {
   countryLetter: string | null;
   country: string | null;
+  allow_stage_skipping: boolean;
 };
 
 export const initialState: InitialSettings = {
   countryLetter: null,
-  country: null
+  country: null,
+  allow_stage_skipping: false
 };
 
 const settingsSlice = createSlice({


### PR DESCRIPTION
## What was done?
Configurations were added to enable stage skipping.
![image](https://github.com/user-attachments/assets/5cbc1117-2671-48d0-8ea2-ed44db9cd5be)


## Why?
To enable/disable the ability to skip stages from the UI.