### PR TITLE
fix(idle): reset the idle timer when starting a profile from the app

### DIFF
--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -56,9 +56,11 @@ export const SocketProviderValue = () => {
 
     socket.on('status', (data: ISensorData) => {
       dispatch(setStats(data));
-      // When stat is not in idle, lock the screen at Barometer
 
       if (currentStateName !== data?.name) {
+        // Every status change resets the idle timer
+        resetIdleTimer();
+
         if (data?.name === 'purge' || data?.name === 'home') {
           dispatch(setScreen('manual-purge'));
           return;
@@ -68,6 +70,7 @@ export const SocketProviderValue = () => {
           return;
         }
 
+        // When the machine is not in idle, lock the screen at Barometer
         if (data?.name !== 'idle') {
           dispatch(setScreen('barometer'));
         }


### PR DESCRIPTION
## What was done?
The Idle Timer was only reset by actions originating from the machine.
This is not correct as profiles can be started from the app as well, we therefore reset it on app behaviour

## Why?

## Additional comments & remarks

## Full detail of changes made to each function
