### PR TITLE
fix(wifi): dont capitalize the first letter in a password

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -28,6 +28,7 @@ interface IKeyboardProps {
   onCancel: () => void;
   onChange?: (text: string) => void;
   onlyLetters?: boolean;
+  capitalizeFirstLetter?: boolean;
 }
 
 export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
@@ -326,7 +327,10 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
   // Recalculate caption style when the caption changes length
   useEffect(() => {
     if (caption.length === 0) {
-      setCapsLockActive({ ...capsLockActive, active: true });
+      setCapsLockActive({
+        ...capsLockActive,
+        active: props.capitalizeFirstLetter ?? true
+      });
     }
 
     if (captionRef.current) {

--- a/src/components/Wifi/EnterWifiPassword.tsx
+++ b/src/components/Wifi/EnterWifiPassword.tsx
@@ -120,6 +120,7 @@ export function EnterWifiPassword(): JSX.Element {
       onChange={(text: string) => {
         setKnownPassword(text);
       }}
+      capitalizeFirstLetter={false}
     />
   );
 }


### PR DESCRIPTION
## What was done?
The first letter of a password is rarely needed to be capitalized. Add an additional config flag to the circle keyboard for this purpose.

![image](https://github.com/user-attachments/assets/f3875fc3-5387-4a35-981d-ada0cd64a648)
