### PR TITLE
fix(device_info): dont render objects

### DIFF
--- a/src/components/Settings/Advanced/DeviceInfoScreen.tsx
+++ b/src/components/Settings/Advanced/DeviceInfoScreen.tsx
@@ -69,6 +69,11 @@ export const DeviceInfoScreen = () => {
         {Object.entries(settingsKeys).map((item, index: number) => {
           const isActive = index === activeIndex;
           const name = item[1] as keyof DeviceInfo;
+          let entry = deviceInfo[name];
+          const displayName = name.replace(/_/g, ' ');
+          if (typeof entry === 'object') {
+            entry = 'available via the API';
+          }
           return (
             <SwiperSlide
               key={index}
@@ -80,7 +85,7 @@ export const DeviceInfoScreen = () => {
                   style={{ wordBreak: 'break-word' }}
                 >
                   {marqueeIfNeeded({
-                    val: `${name}${deviceInfo[name] !== undefined ? `: ${deviceInfo[name] || 'UNSET'}` : ''}`,
+                    val: `${displayName}: ${entry !== undefined ? `${entry || 'UNSET'}` : ''}`,
                     enabled: isActive
                   })}
                 </span>


### PR DESCRIPTION
## What was done?
The complex repository_info object was rendered as [Object object] which was never intended. Replace with an explanation string instead
![image](https://github.com/user-attachments/assets/e183fc30-b285-4aaf-91f8-33d7c9303ce2)

## Why?

## Additional comments & remarks

## Full detail of changes made to each function
