### PR TITLE
feat(set_time): add menus and api for time and date setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.34.0",
       "license": "MIT",
       "dependencies": {
-        "@meticulous-home/espresso-api": "^0.7.1",
+        "@meticulous-home/espresso-api": "^0.7.3",
         "@meticulous-home/espresso-profile": "^0.4.2",
         "@reduxjs/toolkit": "^2.2.7",
         "@tanstack/react-query": "^5.56.2",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@meticulous-home/espresso-api": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.7.1.tgz",
-      "integrity": "sha512-evaeMmozSj7WLf5CEnHaqJygzeh1LpS8Rj1yxZP9STqgWKKxgAnrLD+bR5hPMcB4yR4uorAKsTjGT7TrlLVfrw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.7.3.tgz",
+      "integrity": "sha512-2iHqwsdjZQXNznj54rE/ON8vvZm37LizGn4QUQjQ+G2gxPnbDY/r3WoSWi5m8MW+j6pP3tPTKCvdyyHLLcInvQ==",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript-eslint": "^8.6.0"
   },
   "dependencies": {
-    "@meticulous-home/espresso-api": "^0.7.1",
+    "@meticulous-home/espresso-api": "^0.7.3",
     "@meticulous-home/espresso-profile": "^0.4.2",
     "@reduxjs/toolkit": "^2.2.7",
     "@tanstack/react-query": "^5.56.2",

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -44,3 +44,22 @@ export async function updateSettings(
     }
   }
 }
+
+export async function setTime(dateTime: Date): Promise<Settings> {
+  try {
+    const response = await api.setTime(dateTime);
+    const data = response.data;
+    if (data && 'error' in data) {
+      throw new Error((data as APIError).error);
+    }
+    return data as Settings;
+  } catch (error) {
+    if (error.response) {
+      console.error('Error setting time ', error.response.data);
+      throw new Error(error.response.data?.message || 'Error setting time');
+    } else {
+      console.error('Network error while setting time: ', error.message);
+      throw new Error('Network error while setting time');
+    }
+  }
+}

--- a/src/components/Settings/Advanced/TimeDate/DateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/DateConfig.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+
+import '../../../QuickSettings/quick-settings.css';
+import { useHandleGestures } from '../../../../hooks/useHandleGestures';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { setBubbleDisplay } from '../../../store/features/screens/screens-slice';
+
+import { AnimatedCounter } from 'react-animated-counter/dist/esm';
+import { styled } from 'styled-components';
+import './TimeConfig.css';
+import { useSetTime } from '../../../../hooks/useSettings';
+
+const CLOCK_FONT_SIZE = 60;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  height: 320px;
+  padding-top: 100px;
+  padding-right: 20px;
+
+  justify-content: space-evenly;
+  align-items: center;
+
+  font-family: 'ABC Diatype Mono';
+  font-size: 20px;
+`;
+
+const ClockWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  justify-content: center;
+  align-items: center;
+
+  font-family: 'ABC Diatype Mono';
+  font-weight: 300;
+  letter-spacing: '-0.02em';
+  padding-top: 60px;
+`;
+
+const HelpText = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  justify-content: space-between;
+  align-items: center;
+  font-size: 15px;
+  line-height: 1.2;
+  padding-top: 50px;
+  letter-spacing: 0.1em;
+`;
+
+const DigitContainerStyle = {
+  margin: 0,
+  fontSize: CLOCK_FONT_SIZE,
+  fontFamily: 'ABC Diatype Mono',
+  fontWeight: 300,
+  letterSpacing: '-0.02em'
+};
+
+const ACTIVE_COLOR = '#f5c444';
+const INACTIVE_COLOR = '#E6E6E6';
+
+export function DateConfig(): JSX.Element {
+  const dispatch = useAppDispatch();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const [newTime, setNewTime] = useState(new Date());
+  const [activeField, setActiveField] = useState<'day' | 'month' | 'year'>(
+    'day'
+  );
+  const setDateTime = useSetTime();
+
+  useHandleGestures(
+    {
+      right() {
+        if (activeField === 'day') {
+          setNewTime((prev) => {
+            const next = new Date(prev.getTime());
+            next.setDate(next.getDate() + 1);
+            return next;
+          });
+        } else if (activeField === 'month') {
+          setNewTime((prev) => {
+            const next = new Date(prev.getTime());
+            next.setMonth(next.getMonth() + 1);
+            return next;
+          });
+        } else {
+          setNewTime((prev) => {
+            const next = new Date(prev.getTime());
+            next.setFullYear(next.getFullYear() + 1);
+            return next;
+          });
+        }
+      },
+      left() {
+        if (activeField === 'day') {
+          setNewTime((prev) => {
+            const next = new Date(prev.getTime());
+            next.setDate(next.getDate() - 1);
+            return next;
+          });
+        } else if (activeField === 'month') {
+          setNewTime((prev) => {
+            const next = new Date(prev.getTime());
+            next.setMonth(next.getMonth() - 1);
+            return next;
+          });
+        } else {
+          setNewTime((prev) => {
+            const next = new Date(prev.getTime());
+            next.setFullYear(next.getFullYear() - 1);
+            return next;
+          });
+        }
+      },
+      pressDown() {
+        setActiveField((prev) => {
+          if (prev === 'day') {
+            return 'month';
+          }
+          if (prev === 'month') {
+            return 'year';
+          }
+          return 'day';
+        });
+        console.log(activeField);
+      },
+      longEncoder() {
+        const set = new Date();
+        set.setFullYear(newTime.getFullYear());
+        set.setMonth(newTime.getMonth());
+        set.setDate(newTime.getDate());
+        setDateTime.mutate(set);
+        dispatch(setBubbleDisplay({ visible: true, component: 'timeDate' }));
+      },
+      doubleClick() {
+        dispatch(setBubbleDisplay({ visible: true, component: 'timeDate' }));
+      }
+    },
+    !bubbleDisplay.visible
+  );
+
+  return (
+    <Container>
+      <ClockWrapper>
+        {/* The Animated Counter will not redraw on color change so we force it via css */}
+        <div className={activeField === 'day' ? 'activeClock' : ''}>
+          <AnimatedCounter
+            value={newTime.getDate()}
+            color={INACTIVE_COLOR}
+            decrementColor={ACTIVE_COLOR}
+            incrementColor={ACTIVE_COLOR}
+            includeDecimals={false}
+            fontSize={`${CLOCK_FONT_SIZE}px`}
+            containerStyles={{ ...DigitContainerStyle, minWidth: 70 }}
+          />
+        </div>
+
+        {/* Clock seperating : */}
+        <div style={DigitContainerStyle}>.</div>
+
+        {/* Month */}
+        <div className={activeField === 'month' ? 'activeClock' : ''}>
+          <AnimatedCounter
+            value={newTime.getMonth() + 1}
+            color={INACTIVE_COLOR}
+            decrementColor={ACTIVE_COLOR}
+            incrementColor={ACTIVE_COLOR}
+            includeDecimals={false}
+            fontSize={`${CLOCK_FONT_SIZE}px`}
+            containerStyles={{ ...DigitContainerStyle, minWidth: 70 }}
+          />
+        </div>
+        {/* Clock seperating : */}
+        <div style={DigitContainerStyle}>.</div>
+
+        {/* Year */}
+        <div className={activeField === 'year' ? 'activeClock' : ''}>
+          <AnimatedCounter
+            value={newTime.getFullYear()}
+            color={INACTIVE_COLOR}
+            decrementColor={ACTIVE_COLOR}
+            incrementColor={ACTIVE_COLOR}
+            includeDecimals={false}
+            fontSize={`${CLOCK_FONT_SIZE}px`}
+            containerStyles={{ ...DigitContainerStyle, minWidth: 70 }}
+          />
+        </div>
+      </ClockWrapper>
+      <HelpText>
+        <span>long-press to confirm</span>
+        <span>double-press to abort</span>
+      </HelpText>
+    </Container>
+  );
+}

--- a/src/components/Settings/Advanced/TimeDate/DateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/DateConfig.tsx
@@ -72,49 +72,35 @@ export function DateConfig(): JSX.Element {
   );
   const setDateTime = useSetTime();
 
+  const changeTime = (direction: number) => {
+    if (activeField === 'day') {
+      setNewTime((prev) => {
+        const next = new Date(prev.getTime());
+        next.setDate(next.getDate() + direction);
+        return next;
+      });
+    } else if (activeField === 'month') {
+      setNewTime((prev) => {
+        const next = new Date(prev.getTime());
+        next.setMonth(next.getMonth() + direction);
+        return next;
+      });
+    } else {
+      setNewTime((prev) => {
+        const next = new Date(prev.getTime());
+        next.setFullYear(next.getFullYear() + direction);
+        return next;
+      });
+    }
+  };
+
   useHandleGestures(
     {
       right() {
-        if (activeField === 'day') {
-          setNewTime((prev) => {
-            const next = new Date(prev.getTime());
-            next.setDate(next.getDate() + 1);
-            return next;
-          });
-        } else if (activeField === 'month') {
-          setNewTime((prev) => {
-            const next = new Date(prev.getTime());
-            next.setMonth(next.getMonth() + 1);
-            return next;
-          });
-        } else {
-          setNewTime((prev) => {
-            const next = new Date(prev.getTime());
-            next.setFullYear(next.getFullYear() + 1);
-            return next;
-          });
-        }
+        changeTime(1);
       },
       left() {
-        if (activeField === 'day') {
-          setNewTime((prev) => {
-            const next = new Date(prev.getTime());
-            next.setDate(next.getDate() - 1);
-            return next;
-          });
-        } else if (activeField === 'month') {
-          setNewTime((prev) => {
-            const next = new Date(prev.getTime());
-            next.setMonth(next.getMonth() - 1);
-            return next;
-          });
-        } else {
-          setNewTime((prev) => {
-            const next = new Date(prev.getTime());
-            next.setFullYear(next.getFullYear() - 1);
-            return next;
-          });
-        }
+        changeTime(-1);
       },
       pressDown() {
         setActiveField((prev) => {

--- a/src/components/Settings/Advanced/TimeDate/TimeConfig.css
+++ b/src/components/Settings/Advanced/TimeDate/TimeConfig.css
@@ -1,0 +1,3 @@
+.activeClock span {
+  color: #f5c444;
+}

--- a/src/components/Settings/Advanced/TimeDate/TimeConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeConfig.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+
+import '../../../QuickSettings/quick-settings.css';
+import { useHandleGestures } from '../../../../hooks/useHandleGestures';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { setBubbleDisplay } from '../../../store/features/screens/screens-slice';
+
+import { useSetTime, useSettings } from '../../../../hooks/useSettings';
+import { AnimatedCounter } from 'react-animated-counter/dist/esm';
+import { styled } from 'styled-components';
+import './TimeConfig.css';
+
+const CLOCK_FONT_SIZE = 110;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  height: 320px;
+  padding-top: 100px;
+  padding-right: 20px;
+
+  justify-content: space-evenly;
+  align-items: center;
+
+  font-family: 'ABC Diatype Mono';
+  font-size: 20px;
+`;
+
+const ClockWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  justify-content: center;
+  align-items: center;
+
+  font-family: 'ABC Diatype Mono';
+  font-weight: 300;
+  letter-spacing: '-0.02em';
+  padding-top: 60px;
+`;
+
+const MinuteClock = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  justify-content: center;
+  align-items: center;
+`;
+
+const HelpText = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  justify-content: space-between;
+  align-items: center;
+  font-size: 15px;
+  line-height: 1.2;
+  padding-top: 50px;
+  letter-spacing: 0.1em;
+`;
+
+const DigitContainerStyle = {
+  margin: 0,
+  fontSize: CLOCK_FONT_SIZE,
+  fontFamily: 'ABC Diatype Mono',
+  fontWeight: 300,
+  letterSpacing: '-0.02em'
+};
+
+const ACTIVE_COLOR = '#f5c444';
+const INACTIVE_COLOR = '#E6E6E6';
+
+export function TimeConfig(): JSX.Element {
+  const dispatch = useAppDispatch();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const { data: globalSettings } = useSettings();
+  const [newTime, setNewTime] = useState(new Date());
+  const [activeField, setActiveField] = useState<'hours' | 'minutes'>('hours');
+  const setDateTime = useSetTime();
+
+  useHandleGestures(
+    {
+      left() {
+        if (activeField === 'hours') {
+          const oneHour = 60 * 60 * 1000;
+          setNewTime((prev) => new Date(prev.getTime() - oneHour));
+        } else {
+          const oneMinute = 60 * 1000;
+          setNewTime((prev) => new Date(prev.getTime() - oneMinute));
+        }
+      },
+      right() {
+        if (activeField === 'hours') {
+          const oneHour = 60 * 60 * 1000;
+          setNewTime((prev) => new Date(prev.getTime() + oneHour));
+        } else {
+          const oneMinute = 60 * 1000;
+          setNewTime((prev) => new Date(prev.getTime() + oneMinute));
+        }
+      },
+      pressDown() {
+        setActiveField((prev) => (prev === 'hours' ? 'minutes' : 'hours'));
+      },
+      longEncoder() {
+        const set = new Date();
+        set.setMinutes(newTime.getMinutes());
+        set.setHours(newTime.getHours());
+        setDateTime.mutate(set);
+        dispatch(setBubbleDisplay({ visible: true, component: 'timeDate' }));
+      },
+      doubleClick() {
+        dispatch(setBubbleDisplay({ visible: true, component: 'timeDate' }));
+      }
+    },
+    !bubbleDisplay.visible
+  );
+
+  return (
+    <Container>
+      <span>{globalSettings?.time_zone}</span>
+      {/* We render "HOURS : Minute/10 Minute%10" to ensure zero padding*/}
+      <ClockWrapper>
+        {/* The Animated Counter will not redraw on color change so we force it via css */}
+        <div className={activeField === 'hours' ? 'activeClock' : ''}>
+          <AnimatedCounter
+            value={newTime.getHours()}
+            color={INACTIVE_COLOR}
+            decrementColor={ACTIVE_COLOR}
+            incrementColor={ACTIVE_COLOR}
+            includeDecimals={false}
+            fontSize={`${CLOCK_FONT_SIZE}px`}
+            containerStyles={{ ...DigitContainerStyle, minWidth: 130 }}
+          />
+        </div>
+
+        {/* Clock seperating : */}
+        <div style={DigitContainerStyle}>:</div>
+
+        {/* Minutes */}
+        <MinuteClock className={activeField === 'minutes' ? 'activeClock' : ''}>
+          <AnimatedCounter
+            value={Math.floor(newTime.getMinutes() / 10.0)}
+            color={INACTIVE_COLOR}
+            decrementColor={ACTIVE_COLOR}
+            incrementColor={ACTIVE_COLOR}
+            includeDecimals={false}
+            fontSize={`${CLOCK_FONT_SIZE}px`}
+            containerStyles={{ ...DigitContainerStyle, minWidth: 130 / 2 }}
+          />
+          <AnimatedCounter
+            value={newTime.getMinutes() % 10}
+            color={INACTIVE_COLOR}
+            decrementColor={ACTIVE_COLOR}
+            incrementColor={ACTIVE_COLOR}
+            includeDecimals={false}
+            fontSize={`${CLOCK_FONT_SIZE}px`}
+            containerStyles={{ ...DigitContainerStyle, minWidth: 130 / 2 }}
+          />
+        </MinuteClock>
+      </ClockWrapper>
+      <HelpText>
+        <span>long-press to confirm</span>
+        <span>double-press to abort</span>
+      </HelpText>
+    </Container>
+  );
+}

--- a/src/components/Settings/Advanced/TimeDate/TimeConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeConfig.tsx
@@ -79,25 +79,23 @@ export function TimeConfig(): JSX.Element {
   const [activeField, setActiveField] = useState<'hours' | 'minutes'>('hours');
   const setDateTime = useSetTime();
 
+  const changeTime = (direction: number) => {
+    if (activeField === 'hours') {
+      const oneHour = 60 * 60 * 1000;
+      setNewTime((prev) => new Date(prev.getTime() + oneHour * direction));
+    } else {
+      const oneMinute = 60 * 1000;
+      setNewTime((prev) => new Date(prev.getTime() + oneMinute * direction));
+    }
+  };
+
   useHandleGestures(
     {
       left() {
-        if (activeField === 'hours') {
-          const oneHour = 60 * 60 * 1000;
-          setNewTime((prev) => new Date(prev.getTime() - oneHour));
-        } else {
-          const oneMinute = 60 * 1000;
-          setNewTime((prev) => new Date(prev.getTime() - oneMinute));
-        }
+        changeTime(-1);
       },
       right() {
-        if (activeField === 'hours') {
-          const oneHour = 60 * 60 * 1000;
-          setNewTime((prev) => new Date(prev.getTime() + oneHour));
-        } else {
-          const oneMinute = 60 * 1000;
-          setNewTime((prev) => new Date(prev.getTime() + oneMinute));
-        }
+        changeTime(1);
       },
       pressDown() {
         setActiveField((prev) => (prev === 'hours' ? 'minutes' : 'hours'));

--- a/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
@@ -22,8 +22,14 @@ const defaultSettings: SettingsItem[] = [
     value: false
   },
   {
-    key: 'set_date_time',
-    label: 'Set date & time',
+    key: 'set_time',
+    label: 'Set Time',
+    visible: true,
+    value: false
+  },
+  {
+    key: 'set_date',
+    label: 'Set Date',
     visible: true,
     value: false
   },
@@ -73,9 +79,15 @@ export function TimeDate(): JSX.Element {
             );
             break;
           }
-          case 'conset_date_time': {
+          case 'set_time': {
             dispatch(
-              setBubbleDisplay({ visible: true, component: 'timeDate' }) //Does nothing for now
+              setBubbleDisplay({ visible: true, component: 'timeConfig' })
+            );
+            break;
+          }
+          case 'set_date': {
+            dispatch(
+              setBubbleDisplay({ visible: true, component: 'dateConfig' })
             );
             break;
           }

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -46,6 +46,8 @@ export type ScreenType =
   | 'selectLetterCountry'
   | 'countrySettings'
   | 'timeZoneSettings'
+  | 'timeConfig'
+  | 'dateConfig'
   | 'calibrateScale'
   | 'usbSettings';
 

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getSettings, updateSettings } from '../api/settings';
+import { getSettings, setTime, updateSettings } from '../api/settings';
 
 const USER_SETTINGS_QUERY_KEY = 'user-settings';
 
@@ -26,6 +26,16 @@ export const useUpdateSettings = () => {
     onSuccess: (data) => {
       console.log('User Settings updated successfully.');
       queryClient.setQueryData([USER_SETTINGS_QUERY_KEY], data);
+    }
+  });
+};
+
+// Hook to set the system time
+export const useSetTime = () => {
+  return useMutation({
+    mutationFn: setTime,
+    onError: (error) => {
+      console.error('Error updating User Settings:', error);
     }
   });
 };

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -43,6 +43,8 @@ import { IdleScreenSetting } from '../components/Settings/Advanced/IdleScreenSet
 import CalibrateScale from '../components/Scale/CalibrateScale';
 import { USBSettings } from '../components/Settings/USBSettings';
 import { BrewSettings } from '../components/Settings/BrewSettings';
+import { TimeConfig } from '../components/Settings/Advanced/TimeDate/TimeConfig';
+import { DateConfig } from '../components/Settings/Advanced/TimeDate/DateConfig';
 
 interface Route {
   component: ComponentType;
@@ -73,6 +75,16 @@ export const routes: Record<ScreenType, Route> = {
   timeDate: {
     component: TimeDate,
     title: 'TimeDate',
+    bottomStatusHidden: true
+  },
+  timeConfig: {
+    component: TimeConfig,
+    title: 'Time',
+    bottomStatusHidden: true
+  },
+  dateConfig: {
+    component: DateConfig,
+    title: 'Time',
     bottomStatusHidden: true
   },
   OSStatus: {


### PR DESCRIPTION
## What was done?
Added two new config screens to set the time and date

![Screenshot From 2025-02-08 15-14-48](https://github.com/user-attachments/assets/f9f91022-84ee-47d5-89c4-4e81a949a68a)

![Screenshot From 2025-02-08 15-14-58](https://github.com/user-attachments/assets/b36f28f7-5326-4929-9824-98499bbb2205)
## Why?
Machines might not be able to connect to the internet where they cannot use NTP
