### PR TITLE
fix(presets): always clear the animating option even indenpendant of profile source

### DIFF
--- a/src/components/Pressets/Pressets.tsx
+++ b/src/components/Pressets/Pressets.tsx
@@ -170,6 +170,18 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
     dispatch(setBubbleDisplay({ visible: false, component: null }));
   }, [shouldGoToIdle]);
 
+  useEffect(() => {
+    if (option.animating == false) {
+      return;
+    }
+    setTimeout(() => {
+      setOption((prev) => ({
+        ...prev,
+        animating: false
+      }));
+    }, 300);
+  }, [option.animating]);
+
   const focusProfileHandle = () => {
     if (
       pressetSwiper &&
@@ -201,13 +213,6 @@ export function Pressets({ transitioning }: RouteProps): JSX.Element {
     handleAddIncreseAnimation(pressetSwiper);
 
     handleAddLeaveAnimation(pressetSwiper);
-
-    setTimeout(() => {
-      setOption((prev) => ({
-        ...prev,
-        animating: false
-      }));
-    }, 300);
   };
 
   useHandleGestures(


### PR DESCRIPTION
## What was done?
The option.animating is now always cleared starting at the  (re-)rendering instead of with a fixed timeout which can sometime be faster than the actual render call from setting the option.

## Why?
Issue:
When selecting and starting a profile from the mobile app the dial app would never leave the animating state after returning to the Pressets.tsx screen and therefore refuse all dial inputs.
We force a clearing of the animating state with an useEffect which helps with timeouts overlapping multiple redraws.