### PR TITLE
fix(default_presets): dont break mid word but use word base typesetting

### DIFF
--- a/src/components/Pressets/defaultProfile.css
+++ b/src/components/Pressets/defaultProfile.css
@@ -32,7 +32,8 @@
 .default-profile-container__content__info__text {
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
+  word-break: auto-phrase; /* Not supported outside of chrome based browsers as of early 2025 */
 }
 .default-profile-container__content__info__text--active {
   color: #f5c444;


### PR DESCRIPTION
## What was done?
The word break was fixed

Before:
![image](https://github.com/user-attachments/assets/01194620-d2a1-44cb-96ea-09de0f85025b)


After:
![image](https://github.com/user-attachments/assets/d1d7459b-ca66-4ffb-9c33-dbecb3285a74)

