### PR TITLE
fix(heating-timeout): return to the brew settings

### DIFF
--- a/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
+++ b/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
@@ -3,7 +3,10 @@ import { useDispatch } from 'react-redux';
 import { useSettings, useUpdateSettings } from '../..//hooks/useSettings';
 import { Gauge } from '../../components/SettingNumerical/Gauge';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
-import { setBubbleDisplay } from '../store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../store/features/screens/screens-slice';
 import { AppDispatch } from '../store/store';
 
 const MAX_TIMEOUT = 10; // 60 minutes
@@ -29,6 +32,7 @@ export const HeatTimeoutAfterShot: React.FC = () => {
     },
     pressDown() {
       updateSettings.mutate({ heating_timeout: localHeatingTimeout });
+      dispatch(setScreen('pressets'));
       dispatch(setBubbleDisplay({ visible: true, component: 'brewSettings' }));
     }
   });

--- a/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
+++ b/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
@@ -3,10 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useSettings, useUpdateSettings } from '../..//hooks/useSettings';
 import { Gauge } from '../../components/SettingNumerical/Gauge';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
-import {
-  setBubbleDisplay,
-  setScreen
-} from '../store/features/screens/screens-slice';
+import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { AppDispatch } from '../store/store';
 
 const MAX_TIMEOUT = 10; // 60 minutes
@@ -32,8 +29,7 @@ export const HeatTimeoutAfterShot: React.FC = () => {
     },
     pressDown() {
       updateSettings.mutate({ heating_timeout: localHeatingTimeout });
-      dispatch(setBubbleDisplay({ visible: false, component: null }));
-      dispatch(setScreen('pressets'));
+      dispatch(setBubbleDisplay({ visible: true, component: 'brewSettings' }));
     }
   });
 


### PR DESCRIPTION
## What was done?
Instead of the preset screen we keep the bubbles open and return to the brew settings