### PR TITLE
feat(electron): print gpu info on start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,10 @@ const createWindow = (): void => {
 
   ipcMain.on('ready', async () => {
     console.log('React indicates it is ready');
+
+    const status = app.getGPUFeatureStatus();
+    console.log('GPU Feature Status:', status);
+
     if (!app.isPackaged) {
       return;
     }


### PR DESCRIPTION
## What was done?
When the dial app is ready we print the GPU state to console to ensure we have those on log in the future
