### PR TITLE
fix(bubble-display): ensure the bubble display is overlaying the bottom status

### DIFF
--- a/src/components/Bubble/bubble.less
+++ b/src/components/Bubble/bubble.less
@@ -22,7 +22,7 @@
   height: 100%;
   width: 100%;
   position: absolute;
-  z-index: 1;
+  z-index: 10;
   top: 0;
   left: 0;
   display: flex;

--- a/src/navigation/Router.tsx
+++ b/src/navigation/Router.tsx
@@ -19,7 +19,6 @@ interface RouterProps {
 
 export const Router = memo(
   ({ currentScreen, previousScreen }: RouterProps): JSX.Element => {
-    const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
     const route = memoizedRoutes[currentScreen];
     const RouteComponent = route.component;
     const title = useAppSelector((state) =>
@@ -69,9 +68,7 @@ export const Router = memo(
           <RouteComponent {...route.props} />
         </Transitioner>
         <Freeze freeze={route.bottomStatusHidden}>
-          <BottomStatus
-            hidden={route.bottomStatusHidden || bubbleDisplay.visible}
-          />
+          <BottomStatus hidden={route.bottomStatusHidden} />
         </Freeze>
       </>
     );


### PR DESCRIPTION
## What was done?
The bottom status was fading out when the bubble menu was opened. However it was still overlaying it for a few moments when being hidden which looked glitchy. Change the z-ordering so avoid this in the future.
