### PR TITLE
feat(graph): implement historic graph rendering

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -38,6 +38,10 @@ const profileContextSettings: QuickSettingOption[] = [
     label: 'Edit profile'
   },
   {
+    key: 'last_shot',
+    label: 'Last shot'
+  },
+  {
     key: 'delete',
     label: 'Hold to delete profile',
     longpress: true,
@@ -47,7 +51,8 @@ const profileContextSettings: QuickSettingOption[] = [
 
 const prevScreenSetting: QuickSettingOption = {
   key: 'prevScreen',
-  label: 'Back'
+  label: 'Back',
+  hasSeparator: true
 };
 
 const defaultSettings: QuickSettingOption[] = [
@@ -212,6 +217,11 @@ export function QuickSettings(): JSX.Element {
           case 'edit': {
             dispatch(resetActiveSetting());
             dispatch(setScreen('pressetSettings'));
+            dispatch(setBubbleDisplay({ visible: false, component: null }));
+            break;
+          }
+          case 'last_shot': {
+            dispatch(setScreen('shot_history'));
             dispatch(setBubbleDisplay({ visible: false, component: null }));
             break;
           }

--- a/src/components/ShotGraph/GraphAnnotations.tsx
+++ b/src/components/ShotGraph/GraphAnnotations.tsx
@@ -1,0 +1,183 @@
+import { HistoryDataPoint } from '@meticulous-home/espresso-api';
+import { useMemo } from 'react';
+import { colorBrandRed, colorGrayScale3 } from '../../constants/colors';
+import { GRAPH_AXIS_COLOR } from './ShotGraphScreen';
+
+export interface GraphDividersProps {
+  width: number;
+  height: number;
+  numDeviders: number;
+}
+
+export const GraphDividers = ({
+  width,
+  height,
+  numDeviders
+}: GraphDividersProps) => {
+  const lineSpacing = height / (numDeviders - 1);
+  return (
+    <>
+      {Array.from({ length: numDeviders }, (_, i) => {
+        const x = 0;
+        const y = lineSpacing * i;
+        return (
+          <path
+            key={i}
+            d={`M${x} ${y} L${width} ${y}`}
+            stroke={colorGrayScale3}
+            strokeWidth={1}
+            strokeDasharray={'4,8'}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+function valueText(
+  x: number,
+  y: number,
+  dataValue: string,
+  unitValue: string,
+  anchor?: string
+) {
+  return (
+    <text
+      x={x}
+      y={y}
+      fontFamily="ABC Diatype Mono"
+      fontSize={5}
+      fontVariant="tabular-nums"
+      textAnchor={anchor}
+    >
+      <tspan fontSize={15} fill="#E7E7E7">
+        {dataValue}
+      </tspan>
+      ;
+      <tspan fontSize={15} fill="#E7E7E799">
+        {unitValue}
+      </tspan>
+      ;
+    </text>
+  );
+}
+const TRIANGLE_SIZE = 12;
+// 0.8660 is the sin of 60 degrees or Math.sqrt(3) / 2
+const triangleRightPoints = `0 0, ${0.866 * TRIANGLE_SIZE} ${TRIANGLE_SIZE / 2}, 0 ${TRIANGLE_SIZE}`;
+const triangleLeftPoints = `${TRIANGLE_SIZE} 0, ${(1 - 0.866) * TRIANGLE_SIZE} ${TRIANGLE_SIZE / 2}, ${TRIANGLE_SIZE} ${TRIANGLE_SIZE}`;
+
+export const SelectionIndicator = ({
+  data,
+  selectedPointIndex,
+  width,
+  height
+}: {
+  data: HistoryDataPoint[];
+  selectedPointIndex: number;
+  width: number;
+  height: number;
+}) => {
+  const selectedPointX = useMemo(() => {
+    if (!data) {
+      return 0;
+    }
+    const selectedPoint = data[selectedPointIndex];
+    const first = data[0];
+    const last = data[data.length - 1];
+    const startTime = first.time;
+    const endTime = last.time;
+    return (selectedPoint.time - startTime) * (width / (endTime - startTime));
+  }, [data, selectedPointIndex]);
+
+  if (!data) {
+    return <></>;
+  }
+  const indexPercentage = selectedPointIndex / data.length;
+  const fontDisplacement = Math.cos(indexPercentage * Math.PI);
+  const simulatedFontCenter =
+    fontDisplacement > 0 ? fontDisplacement * 20 : fontDisplacement * 35;
+  const leftColoring = Math.round(
+    (indexPercentage === 0
+      ? 0
+      : indexPercentage < 0.1
+        ? indexPercentage / 0.1
+        : 1) * 255
+  )
+    .toString(16)
+    .padStart(2, '0');
+  const rightColoring = Math.round(
+    (indexPercentage > 0.9 ? (1 - indexPercentage) / 0.1 : 1) * 255
+  )
+    .toString(16)
+    .padStart(2, '0');
+
+  return (
+    <>
+      {valueText(
+        selectedPointX + 5 + simulatedFontCenter,
+        -5,
+        (data[selectedPointIndex]?.time / 100 || 0.0).toFixed(1),
+        's',
+        'middle'
+      )}
+      <path
+        d={`M${selectedPointX} ${0} L${selectedPointX} ${height + 5}`}
+        stroke={colorBrandRed}
+        strokeWidth={'3'}
+        strokeLinecap="round"
+      />
+
+      <polygon
+        transform={`translate(${selectedPointX - 5 - TRIANGLE_SIZE}, ${height + 6})`}
+        // points="5 1.5, 10 10, 0 10"
+        points={triangleLeftPoints}
+        fill={colorBrandRed + leftColoring}
+      />
+
+      <polygon
+        transform={`translate(${selectedPointX + 5}, ${height + 6})`}
+        // points="5 1.5, 10 10, 0 10"
+        points={triangleRightPoints}
+        fill={colorBrandRed + rightColoring}
+      />
+    </>
+  );
+};
+
+export const StartEndIndicator = ({
+  data,
+  width,
+  height
+}: {
+  data: HistoryDataPoint[];
+  width: number;
+  height: number;
+}) => {
+  if (!data) {
+    return <></>;
+  }
+  const last = data[data.length - 1];
+  return (
+    <>
+      {valueText(width + 5, -5, (last?.shot.weight || 0.0).toFixed(1), 'g')}
+      {valueText(
+        width + 5,
+        height + 20,
+        (last?.time / 1000 || 0.0).toFixed(1),
+        's'
+      )}
+      <path
+        d={`M${width} ${0} L${width} ${height}`}
+        stroke={GRAPH_AXIS_COLOR}
+        strokeWidth={'2'}
+        strokeDasharray={'4,4'}
+      />
+      <path
+        d={`M${0} ${0} L${0} ${height}`}
+        stroke={GRAPH_AXIS_COLOR}
+        strokeWidth={'2'}
+        strokeDasharray={'4,4'}
+      />
+    </>
+  );
+};

--- a/src/components/ShotGraph/GraphPath.ts
+++ b/src/components/ShotGraph/GraphPath.ts
@@ -1,0 +1,43 @@
+import { HistoryDataPoint } from '@meticulous-home/espresso-api';
+import { DataTypeKey, dataTypes } from '../../types/dataTypes';
+
+export const getYPosition = (
+  value: number,
+  type: DataTypeKey,
+  height: number
+) => {
+  const { minValue, maxValue } = dataTypes[type];
+  return (
+    height *
+    (1 -
+      (Math.min(maxValue, Math.max(minValue, value)) - minValue) /
+        (maxValue - minValue))
+  );
+};
+
+export const getGraphPath = (
+  dataPoints: HistoryDataPoint[],
+  key: DataTypeKey,
+  width: number,
+  height: number
+) => {
+  if (dataPoints.length === 0) {
+    return '';
+  }
+
+  const first = dataPoints[0];
+  const last = dataPoints[dataPoints.length - 1];
+  const startTime = first.time;
+  const endTime = last.time;
+  const points: [number, number][] = dataPoints.map((data) => [
+    (data.time - startTime) * (width / (endTime - startTime)),
+    getYPosition(data.shot[key], key, height)
+  ]);
+  const startIndex = Math.max(0, points.findIndex(([x]) => x >= 0) - 1);
+  const activePoints = points.slice(startIndex);
+  const strokePath = `M${activePoints.map(([x, y]) => `${x} ${y}`).join(' L')}`;
+  const maskPath = `${strokePath} L${
+    activePoints[activePoints.length - 1][0]
+  } ${height} L0 ${height} Z`;
+  return [strokePath, maskPath];
+};

--- a/src/components/ShotGraph/ShotGraphScreen.tsx
+++ b/src/components/ShotGraph/ShotGraphScreen.tsx
@@ -1,0 +1,236 @@
+import { HistoryDataPoint } from '@meticulous-home/espresso-api';
+import { useEffect, useMemo, useState } from 'react';
+import { styled } from 'styled-components';
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import {
+  lastShotForProfileQuery,
+  useHistoryShot
+} from '../../hooks/useHistory';
+import { DataTypeKey, dataTypes } from '../../types/dataTypes';
+import {
+  GraphDividers,
+  SelectionIndicator,
+  StartEndIndicator
+} from './GraphAnnotations';
+import { getGraphPath } from './GraphPath';
+import { useAppSelector } from '../store/hooks';
+import { setScreen } from '../store/features/screens/screens-slice';
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '../store/store';
+import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
+
+const GRAPH_WIDTH = 270;
+const GRAPH_WRAPPER_HEIGHT = 220;
+const GRAPH_HEIGHT = 175;
+const GRAPH_HORIZONTAL_PADDING = (480 - GRAPH_WIDTH) / 2;
+const GRAPH_VERTICAL_PADDING = (GRAPH_WRAPPER_HEIGHT - GRAPH_HEIGHT) / 2;
+const GRAPH_SCROLL_STEPS = 50;
+const GRAPH_LINE_SIZE = 2;
+const GRAPH_LABEL_DOT_SIZE = 10;
+
+export const GRAPH_AXIS_COLOR = '#00475B';
+
+const GraphContainer = styled.div`
+  width: 480px;
+  height: 480px;
+  display: flex;
+  padding-top: 20px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 8px;
+`;
+
+const GraphLabels = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 15px;
+  justify-content: flex-end;
+`;
+
+const GraphLabel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  align-items: center;
+  font-family: 'ABC Diatype Mono';
+`;
+
+const GraphLabelText = styled.span`
+  font-size: 15px;
+  color: #e7e7e799;
+  font-family: 'ABC Diatype Mono';
+  letter-spacing: 3px;
+  text-transform: uppercase;
+`;
+
+const GraphValueSquare = styled.div`
+  width: ${GRAPH_LABEL_DOT_SIZE}px;
+  height: ${GRAPH_LABEL_DOT_SIZE}px;
+`;
+
+const GraphValueText = styled.span`
+  display: flex;
+  display-direction: row;
+  font-size: 15px
+  font-family: 'Abc_light';
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 3px
+  color: '#E7E7E7';
+  text-align: center;
+  align-items: center;
+  gap: 5px;
+`;
+
+type PathsType = Record<DataTypeKey, { path: string; maskPath: string }>;
+
+export const ShotGraphScreen = () => {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const [paths, setPaths] = useState<PathsType>({
+    flow: { path: '', maskPath: '' },
+    pressure: { path: '', maskPath: '' },
+    weight: { path: '', maskPath: '' }
+  });
+
+  const [selectedPointIndex, setSelectedPointIndex] = useState<number>(0);
+  const [selectedPoint, setSelectedPoint] = useState<HistoryDataPoint | null>(
+    null
+  );
+
+  const activeProfile = useAppSelector((state) => state.presets.activePreset);
+
+  if (!activeProfile) {
+    console.error('History was opened without a profile selected');
+    dispatch(setScreen('pressets'));
+  }
+
+  const { data: profileHistory, isLoading } = useHistoryShot(
+    lastShotForProfileQuery(activeProfile)
+  );
+
+  const displayShot = profileHistory?.history[0];
+
+  const gestureProgress = useMemo(() => {
+    if (!displayShot) {
+      return 0;
+    }
+    const length = Math.max(0, displayShot.data.length - 1);
+    return Math.round(length / GRAPH_SCROLL_STEPS);
+  }, [displayShot]);
+
+  useHandleGestures({
+    left() {
+      setSelectedPointIndex((prev) => Math.max(0, prev - gestureProgress));
+    },
+    right() {
+      setSelectedPointIndex((prev) =>
+        Math.min(prev + gestureProgress, displayShot?.data.length - 1)
+      );
+    }
+  });
+
+  useEffect(() => {
+    if (!displayShot) {
+      return;
+    }
+    const flowPaths = getGraphPath(
+      displayShot.data,
+      'flow',
+      GRAPH_WIDTH,
+      GRAPH_HEIGHT
+    );
+    const pressurePaths = getGraphPath(
+      displayShot.data,
+      'pressure',
+      GRAPH_WIDTH,
+      GRAPH_HEIGHT
+    );
+    const weightPaths = getGraphPath(
+      displayShot.data,
+      'weight',
+      GRAPH_WIDTH,
+      GRAPH_HEIGHT
+    );
+
+    setPaths({
+      flow: { path: flowPaths[0], maskPath: flowPaths[1] },
+      pressure: { path: pressurePaths[0], maskPath: pressurePaths[1] },
+      weight: { path: weightPaths[0], maskPath: weightPaths[1] }
+    });
+  }, [displayShot]);
+
+  useEffect(() => {
+    if (!displayShot) {
+      return;
+    }
+    setSelectedPoint(displayShot.data[selectedPointIndex]);
+  }, [selectedPointIndex, displayShot]);
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <GraphContainer>
+      {/* SVG */}
+      <svg width={480} height={GRAPH_WRAPPER_HEIGHT}>
+        {/* X AXIS spanning the entire screen */}
+        <g transform={`translate(0, ${GRAPH_VERTICAL_PADDING})`}>
+          <path
+            d={`M${0} ${GRAPH_HEIGHT} L${480} ${GRAPH_HEIGHT}`}
+            stroke={GRAPH_AXIS_COLOR}
+            strokeWidth={'3'}
+          />
+        </g>
+        {/* The Graph - translated into the middle of the screen */}
+        <g
+          transform={`translate(${GRAPH_HORIZONTAL_PADDING}, ${GRAPH_VERTICAL_PADDING})`}
+        >
+          <GraphDividers
+            numDeviders={7}
+            width={480 + GRAPH_HORIZONTAL_PADDING}
+            height={GRAPH_HEIGHT}
+          />
+          {Object.keys(paths).map((key: Partial<DataTypeKey>) => (
+            <path
+              key={key}
+              d={paths[key].path}
+              fill="transparent"
+              stroke={dataTypes[key].color}
+              strokeWidth={GRAPH_LINE_SIZE}
+            />
+          ))}
+          <StartEndIndicator
+            data={displayShot?.data}
+            width={GRAPH_WIDTH}
+            height={GRAPH_HEIGHT}
+          />
+          <SelectionIndicator
+            data={displayShot?.data}
+            selectedPointIndex={selectedPointIndex}
+            width={GRAPH_WIDTH}
+            height={GRAPH_HEIGHT}
+          />
+        </g>
+      </svg>
+      {/* Labels */}
+      <GraphLabels>
+        {Object.keys(paths).map((dataType: DataTypeKey) => (
+          <GraphLabel key={dataType}>
+            <GraphLabelText>{dataType}</GraphLabelText>
+            <GraphValueText>
+              <GraphValueSquare
+                style={{ backgroundColor: dataTypes[dataType].color }}
+              />
+              {(selectedPoint?.shot[dataType] || 0.0).toFixed(
+                dataTypes[dataType].precision
+              )}
+            </GraphValueText>
+          </GraphLabel>
+        ))}
+      </GraphLabels>
+    </GraphContainer>
+  );
+};

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -49,7 +49,8 @@ export type ScreenType =
   | 'timeConfig'
   | 'dateConfig'
   | 'calibrateScale'
-  | 'usbSettings';
+  | 'usbSettings'
+  | 'shot_history';
 
 interface ScreenState {
   value: ScreenType;

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,22 @@
+// Changes here should be synced with the mobile apps src/tokens/palette.ts
+
+export const colorBrandRed = '#FC1D22';
+export const colorBrandBrown = '#A56751';
+export const colorBrandYellow = '#F5C444';
+export const colorBlack = '#000000';
+export const colorWhite = '#ffffff';
+export const colorGrayScale1 = '#202020';
+export const colorGrayScale2 = '#272727';
+export const colorGrayScale3 = '#403F3F';
+export const colorGrayScale4 = '#585856';
+export const colorGrayScale5 = '#70706E';
+export const colorGrayScale6 = '#898886';
+export const colorGrayScale7 = '#A1A09E';
+export const colorGrayScale8 = '#B9B9B5';
+export const colorGrayScale9 = '#D2D1CD';
+export const colorGrayScale10 = '#EAE9E5';
+export const colorDataBlueLight = '#78D6FF';
+export const colorDataRed = '#FF5844';
+export const colorDataGreenLight = '#7BEEBF';
+export const colorDataYellow = '#FDC352';
+export const colorDataWhite = '#FFFFFF';

--- a/src/hooks/useHistory.tsx
+++ b/src/hooks/useHistory.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../api/api';
+import { HistoryQueryParams } from '@meticulous-home/espresso-api';
+import { Profile } from '@meticulous-home/espresso-profile';
+
+export const QUERY_KEY_HISTORY_LAST_SHOT = 'history_last_shot';
+export const QUERY_KEY_HISTORY = 'history';
+
+export const useLastShot = () => {
+  return useQuery({
+    queryKey: [QUERY_KEY_HISTORY_LAST_SHOT],
+    queryFn: () => api.getLastShot().then((res) => res.data),
+    staleTime: 0,
+    refetchInterval: 10000
+  });
+};
+
+export function lastShotForProfileQuery(profile: Profile) {
+  if (!profile) {
+    return null;
+  }
+  const query: Partial<HistoryQueryParams> = {
+    ids: [profile.id],
+    dump_data: true,
+    max_results: 1
+  };
+  return query;
+}
+
+export function useHistoryShot(query: Partial<HistoryQueryParams>) {
+  return useQuery({
+    queryKey: [QUERY_KEY_HISTORY, query],
+    queryFn: () => api.searchHistory(query).then((res) => res.data),
+    enabled: query != null
+  });
+}

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -45,6 +45,7 @@ import { USBSettings } from '../components/Settings/USBSettings';
 import { BrewSettings } from '../components/Settings/BrewSettings';
 import { TimeConfig } from '../components/Settings/Advanced/TimeDate/TimeConfig';
 import { DateConfig } from '../components/Settings/Advanced/TimeDate/DateConfig';
+import { ShotGraphScreen } from '../components/ShotGraph/ShotGraphScreen';
 
 interface Route {
   component: ComponentType;
@@ -315,6 +316,12 @@ export const routes: Record<ScreenType, Route> = {
   },
   defaultProfileDetails: {
     component: DefaultProfileDetails,
+    bottomStatusHidden: true
+  },
+  shot_history: {
+    component: ShotGraphScreen,
+    title: selectActivePresetName,
+    parent: 'pressets',
     bottomStatusHidden: true
   },
   idle: {

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -1,0 +1,57 @@
+import {
+  colorDataBlueLight,
+  colorDataGreenLight,
+  colorDataRed,
+  colorDataYellow
+} from '../constants/colors';
+
+export type DataTypeKey = 'weight' | 'pressure' | 'flow';
+
+export interface DataType {
+  minValue: number;
+  maxValue: number;
+  axisLabelStep: number;
+  name: string;
+  unit: string;
+  color: string;
+  precision: 0 | 1;
+}
+
+export const dataTypes: Record<DataTypeKey | 'temperature', DataType> = {
+  weight: {
+    name: 'Weight',
+    minValue: 0,
+    maxValue: 100,
+    axisLabelStep: 25,
+    unit: 'g',
+    color: colorDataYellow,
+    precision: 1
+  },
+  temperature: {
+    name: 'Temp',
+    minValue: 0,
+    maxValue: 100,
+    axisLabelStep: 25,
+    unit: '°C',
+    color: colorDataRed,
+    precision: 0
+  },
+  pressure: {
+    name: 'Pressure',
+    minValue: 0,
+    maxValue: 12,
+    axisLabelStep: 2,
+    unit: 'bar',
+    color: colorDataBlueLight,
+    precision: 1
+  },
+  flow: {
+    name: 'Flow',
+    minValue: 0,
+    maxValue: 12,
+    axisLabelStep: 2,
+    unit: 'ml/s',
+    color: colorDataGreenLight,
+    precision: 1
+  }
+};


### PR DESCRIPTION
## What was done?
A historic graph was added to be loaded from the backend and rendered with a simple inspecition scroll

https://github.com/user-attachments/assets/686eedaf-a278-4017-b872-41335bb8b3d4

