### PR TITLE
feat(scale): tare quick->full scale interaction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { Provider, useSelector, useStore } from 'react-redux';
 
@@ -12,11 +12,11 @@ import {
 } from './components/store/features/screens/screens-slice';
 import { Router } from './navigation/Router';
 import { notificationSelector } from './components/store/features/notifications/notification-slice';
-import { durationAnimation } from './navigation/Transitioner';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IdleTimerProvider } from './hooks/useIdleTimer';
 import { setBrightness } from './api/api';
 import { Scale } from './components/Scale/Scale';
+import { VisibilityProvider } from './navigation/VisibilityContext';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -142,10 +142,13 @@ const App = (): JSX.Element => {
           {dev && <div className="main-circle-overlay" />}
           <IdleTimerProvider>
             <SocketManager>
-              <Router
-                currentScreen={screen.value}
-                previousScreen={screen.prev}
-              />
+              {/* Mark router as not visible when scale is overlaid to avoid gesture handlers firing */}
+              <VisibilityProvider value={!scaleState.visible}>
+                <Router
+                  currentScreen={screen.value}
+                  previousScreen={screen.prev}
+                />
+              </VisibilityProvider>
               <Scale {...scaleState} />
             </SocketManager>
           </IdleTimerProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import * as ReactDOM from 'react-dom/client';
-import { Provider, useSelector } from 'react-redux';
+import { Provider, useSelector, useStore } from 'react-redux';
 
 import { useAppDispatch, useAppSelector } from './components/store/hooks';
 import { SocketManager } from './components/store/SocketManager';
-import { store } from './components/store/store';
+import { RootState, store } from './components/store/store';
 import { useHandleGestures } from './hooks/useHandleGestures';
 import {
   setBubbleDisplay,
@@ -16,6 +16,7 @@ import { durationAnimation } from './navigation/Transitioner';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IdleTimerProvider } from './hooks/useIdleTimer';
 import { setBrightness } from './api/api';
+import { Scale } from './components/Scale/Scale';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -36,6 +37,7 @@ const queryClient = new QueryClient({
 
 const App = (): JSX.Element => {
   const dispatch = useAppDispatch();
+  const store = useStore<RootState>();
   const screen = useAppSelector(
     (state) => state.screen,
     (prev, next) => prev === next
@@ -63,32 +65,63 @@ const App = (): JSX.Element => {
     }
   }, [notifications]);
 
-  const getureTimeAgo = useRef(new Date());
+  const [scaleState, setScaleState] = useState<{
+    visible: boolean;
+    size: 'small' | 'full';
+  }>({ visible: false, size: 'small' });
+
+  const isQuickScaleVisible = scaleState.visible && scaleState.size === 'small';
+  useEffect(() => {
+    if (!isQuickScaleVisible) return;
+
+    const scheduleHide = () =>
+      setTimeout(() => {
+        setScaleState((state) => ({ ...state, visible: false }));
+      }, 10000);
+    let timer = scheduleHide();
+
+    let lastSignificantWeight = store.getState().stats.sensors.w;
+    const subscription = store.subscribe(() => {
+      const weight = store.getState().stats.sensors.w;
+      if (Math.abs(weight - lastSignificantWeight) > 2) {
+        lastSignificantWeight = weight;
+        clearTimeout(timer);
+        timer = scheduleHide();
+      }
+    });
+
+    return () => {
+      clearTimeout(timer);
+      subscription();
+    };
+  }, [isQuickScaleVisible]);
 
   useHandleGestures(
     {
+      // TODO: Ideally we'd get tare up/down events so we can zoom in full the scale gradually
+      singleTare() {
+        setScaleState(({ visible }) => ({
+          visible: true,
+          size: visible ? 'full' : 'small'
+        }));
+      },
+      longTare() {
+        setScaleState(({ visible, size }) => ({
+          visible: !visible || size === 'small',
+          size: 'full'
+        }));
+      },
       doubleTare() {
-        const gestureTime = new Date();
-
-        const timeDiff = +gestureTime - +getureTimeAgo.current;
-
-        if (timeDiff < durationAnimation + 50) return;
-
-        getureTimeAgo.current = gestureTime;
-
-        dispatch(
-          setScreen(
-            screen.value === 'scale'
-              ? screen.prev === 'settings'
-                ? 'barometer'
-                : screen.prev !== 'idle'
-                  ? screen.prev
-                  : 'pressets'
-              : 'scale'
-          )
-        );
+        setScaleState(({ size }) => ({
+          visible: false,
+          size
+        }));
       },
       context() {
+        setScaleState(({ size }) => ({
+          visible: false,
+          size
+        }));
         dispatch(
           setBubbleDisplay({
             visible: !bubbleDisplay.visible,
@@ -113,6 +146,7 @@ const App = (): JSX.Element => {
                 currentScreen={screen.value}
                 previousScreen={screen.prev}
               />
+              <Scale {...scaleState} />
             </SocketManager>
           </IdleTimerProvider>
         </div>

--- a/src/components/Scale/Scale.tsx
+++ b/src/components/Scale/Scale.tsx
@@ -1,40 +1,54 @@
-import { useEffect } from 'react';
-import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { CSSTransition, SwitchTransition } from 'react-transition-group';
+import { useAppSelector } from '../store/hooks';
 import './scale.css';
-import { useIdleTimer } from '../../hooks/useIdleTimer';
-import {
-  setScreen,
-  setBubbleDisplay
-} from '../store/features/screens/screens-slice';
+import { Fragment } from 'react/jsx-runtime';
+import { memo } from 'react';
 
-export function Scale(): JSX.Element {
+const Weight = () => {
   const weight = useAppSelector((state) => state.stats.sensors.w || 0);
-  const dispatch = useAppDispatch();
-  const { isIdle: shouldGoToIdle } = useIdleTimer();
-
-  useEffect(() => {
-    if (!shouldGoToIdle) return;
-    dispatch(setScreen('idle'));
-    dispatch(setBubbleDisplay({ visible: false, component: null }));
-  }, [shouldGoToIdle]);
+  const formatted = weight.toFixed(1);
+  const padded = formatted.padStart(5, '0');
 
   return (
-    <div
-      className={`main-layout`}
-      style={{
-        zIndex: 50
-      }}
-    >
-      <div className="main-layout-content">
-        <div className="pressets-options-conainer">
-          <div className="scale-weight">
-            <div>
-              <span className="weight">{weight.toFixed(1)}</span>
-            </div>
-            <div className="weight-data">g</div>
-          </div>
-        </div>
-      </div>
+    <div className="scale-weight">
+      <span className="weight">
+        {padded.split('').map((char, i) => (
+          <span
+            key={i}
+            className={
+              i < padded.length - formatted.length ? 'dimmed' : undefined
+            }
+          >
+            {char}
+          </span>
+        ))}
+      </span>
+      <div className="weight-unit">g</div>
     </div>
   );
-}
+};
+
+export const Scale = memo(
+  ({ visible, size }: { visible: boolean; size: 'small' | 'full' }) => (
+    <SwitchTransition>
+      <CSSTransition
+        key={visible ? 'off' : 'on'}
+        in={visible}
+        timeout={300}
+        classNames="animate"
+      >
+        {visible ? (
+          <div
+            className={`main-layout scale-container scale-container--${size}`}
+          >
+            <div className="main-layout-content">
+              <Weight />
+            </div>
+          </div>
+        ) : (
+          <Fragment />
+        )}
+      </CSSTransition>
+    </SwitchTransition>
+  )
+);

--- a/src/components/Scale/scale.css
+++ b/src/components/Scale/scale.css
@@ -1,26 +1,79 @@
+.scale-container {
+  z-index: 50;
+  transition: all 0.3s;
+}
+
+.scale-container--small {
+  width: 150%;
+  margin-left: -25%;
+  height: 250px;
+  padding-bottom: 50%;
+  transform: translateY(17.5%) scale(0.5);
+  transform-origin: center bottom;
+  background: #1b1b1b;
+  border-radius: 52px;
+}
+
+.scale-container--small.animate-enter {
+  transform: translateY(50%) scale(0.5);
+}
+.scale-container--small.animate-exit {
+  transform: translateY(17.5%) scale(0.5);
+}
+.scale-container--small.animate-enter-active {
+  transform: translateY(17.5%) scale(0.5);
+}
+.scale-container--small.animate-exit-active {
+  transform: translateY(50%) scale(0.5);
+}
+
+.scale-container--full {
+  top: 0%;
+  width: 100%;
+  height: 100%;
+  padding-bottom: 0;
+  transform: scale(1);
+  background: #000;
+}
+
+.scale-container--full.animate-enter {
+  transform: translateY(75%) scale(0.5);
+}
+.scale-container--full.animate-exit {
+  transform: translateY(0) scale(1);
+}
+.scale-container--full.animate-enter-active {
+  transform: translateY(0) scale(1);
+}
+.scale-container--full.animate-exit-active {
+  transform: translateY(75%) scale(0.5);
+}
+
 .scale-weight {
-  font-size: 120px;
+  position: relative;
+  font-size: 110px;
   display: flex;
   align-items: end;
   justify-content: center;
   line-height: 1;
-  width: 340px;
-  margin: 72px auto 0;
+  font-family: 'ABC Diatype Mono';
+  font-weight: 400;
+  color: #e7e7e7;
+  letter-spacing: -2%;
 }
-.scale-weight .weight span {
-  color: #ffffff20;
+
+.scale-weight .weight .dimmed {
+  opacity: 0.1;
 }
 
 .scale-weight .weight {
   text-align: center;
   flex: 1;
-  margin-right: 3px;
 }
 
-.scale-weight .weight-data {
-  font-size: 36px;
-}
-
-.pressets-options-conainer {
-  transform: translateY(-50px);
+.scale-weight .weight-unit {
+  position: absolute;
+  left: 100%;
+  margin-left: 5px;
+  font-size: 64px;
 }

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -14,7 +14,6 @@ export type ScreenType =
   | 'temperature'
   | 'dose'
   | 'output'
-  | 'scale'
   | 'settings'
   | 'timeDate'
   | 'timeZoneConfig'

--- a/src/navigation/Transitioner.tsx
+++ b/src/navigation/Transitioner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, cloneElement, ReactElement } from 'react';
 import { ScreenType } from '../components/store/features/screens/screens-slice';
-import { VisibilityProvider } from './VisibilityContext';
+import { useVisibility, VisibilityProvider } from './VisibilityContext';
 import './navigation.less';
 
 interface TransitionerProps {
@@ -69,6 +69,7 @@ export const Transitioner = (props: TransitionerProps): JSX.Element => {
     titleDirection: props.direction,
     animationSize: 'large'
   });
+  const isVisible = useVisibility();
 
   useEffect(() => {
     setStates((prev) => {
@@ -148,7 +149,7 @@ export const Transitioner = (props: TransitionerProps): JSX.Element => {
         }`}
         style={animationStyle}
       >
-        <VisibilityProvider value={true}>
+        <VisibilityProvider value={isVisible}>
           {cloneElement(children, { transitioning: !!previous })}
         </VisibilityProvider>
         {!shouldTransitionParentTitle && parentTitle && (

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -1,7 +1,6 @@
 import { ComponentType } from 'react';
 import { Barometer } from '../components/Barometer/Barometer';
 import { Pressets } from '../components/Pressets/Pressets';
-import { Scale } from '../components/Scale/Scale';
 import { PressetSettings } from '../components/PressetSettings/PressetSettings';
 import { SettingNumerical } from '../components/SettingNumerical/SettingNumerical';
 import { Settings } from '../components/Settings/Settings';
@@ -116,12 +115,6 @@ export const routes: Record<ScreenType, Route> = {
     component: Settings,
     title: 'settings',
     bottomStatusHidden: true
-  },
-  scale: {
-    component: Scale,
-    title: 'scale',
-    bottomStatusHidden: true,
-    parent: 'pressets'
   },
   pressets: {
     component: Pressets,


### PR DESCRIPTION
## What was done?

Implementation of the new quick/full scale interaction via the tare button. In quick scale mode it will self-dismiss if the weight has changed with less than 2g for 10s. These values are semi-random, so we'll probably need to tweak them in the future. 

## Why?

## Additional comments & remarks

* After checking with Carlos, the font is not same as Figma but the same we use for all other digits
* Carlos wanted to have the interaction be similar to "hold to start", but since AFAIK the machine won't emit those events for the tare button, only the regular dial I'm going of the singleTare/doubleTare/longTare events for now. 

## Full detail of changes made to each function

https://github.com/user-attachments/assets/7fb82e80-7ebe-450d-a182-cf5c9f4f6796

