### PR TITLE
Launch idle screen from shothgraph

### DIFF
--- a/src/components/ShotGraph/GraphAnnotations.tsx
+++ b/src/components/ShotGraph/GraphAnnotations.tsx
@@ -116,7 +116,7 @@ export const SelectionIndicator = ({
       {valueText(
         selectedPointX + 5 + simulatedFontCenter,
         -5,
-        (data[selectedPointIndex]?.time / 100 || 0.0).toFixed(1),
+        (data[selectedPointIndex]?.time / 1000 || 0.0).toFixed(1),
         's',
         'middle'
       )}

--- a/src/components/ShotGraph/ShotGraphScreen.tsx
+++ b/src/components/ShotGraph/ShotGraphScreen.tsx
@@ -14,10 +14,14 @@ import {
 } from './GraphAnnotations';
 import { getGraphPath } from './GraphPath';
 import { useAppSelector } from '../store/hooks';
-import { setScreen } from '../store/features/screens/screens-slice';
+import {
+  setScreen,
+  setBubbleDisplay
+} from '../store/features/screens/screens-slice';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from '../store/store';
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
+import { useIdleTimer } from '../../hooks/useIdleTimer';
 
 const GRAPH_WIDTH = 270;
 const GRAPH_WRAPPER_HEIGHT = 220;
@@ -119,6 +123,14 @@ export const ShotGraphScreen = () => {
     const length = Math.max(0, displayShot.data.length - 1);
     return Math.round(length / GRAPH_SCROLL_STEPS);
   }, [displayShot]);
+
+  const { isIdle: shouldGoToIdle } = useIdleTimer();
+
+  useEffect(() => {
+    if (!shouldGoToIdle) return;
+    dispatch(setScreen('idle'));
+    dispatch(setBubbleDisplay({ visible: false, component: null }));
+  }, [shouldGoToIdle]);
 
   useHandleGestures({
     left() {


### PR DESCRIPTION
## What was done?
* The idle screen is launched from the ShotsGraph screen.
* The SelectionIndicator time is now correctly displayed in seconds.

## Before & After
<img src="https://github.com/user-attachments/assets/3e16dc80-dacd-4f78-a7dc-6d1bc4be12c6" width=400 >

<img src="https://github.com/user-attachments/assets/21158099-ab93-4fe3-b2f8-b8f344fd7917" width=400 >

## Why?
Launching the idle screen should be consistent across screens like ShotsGraph, according to feedback from backers.

Seeing a shot duration of 539.0 seconds in the SelectionIndicator could be confusing.
