### PR TITLE
Dim screen in menu components

### DIFF
--- a/src/components/EditNameScreen/EditNameScreen.tsx
+++ b/src/components/EditNameScreen/EditNameScreen.tsx
@@ -7,7 +7,7 @@ import { useAppSelector } from '../store/hooks';
 import { updatePresetSetting } from '../store/features/preset/preset-slice';
 import { setScreen } from '../store/features/screens/screens-slice';
 import { CircleKeyboard } from '../CircleKeyboard/CircleKeyboard';
-
+import { useDimScreen } from '../../hooks/useDimScreen';
 export function EditNameScreen(): JSX.Element {
   const { presets } = useAppSelector((state) => state);
   const setting = presets.updatingSettings.settings[
@@ -16,6 +16,8 @@ export function EditNameScreen(): JSX.Element {
   const originalName = presets.activePreset.name;
 
   const dispatch = useDispatch();
+
+  useDimScreen();
 
   const updateSetting = (updatedText: string) => {
     const updatedSetting = {

--- a/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
+++ b/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
@@ -9,6 +9,8 @@ import {
 } from '../store/features/screens/screens-slice';
 import { AppDispatch } from '../store/store';
 
+import { useDimScreen } from '../../hooks/useDimScreen';
+
 const MAX_TIMEOUT = 10; // 60 minutes
 const INTERVAL = 1; // 1 minute intervals
 
@@ -20,6 +22,8 @@ export const HeatTimeoutAfterShot: React.FC = () => {
   const [localHeatingTimeout, setLocalHeatingTimeout] = useState(
     globalSettings.heating_timeout
   );
+
+  useDimScreen();
 
   useHandleGestures({
     left() {

--- a/src/components/IdleScreen/IdleScreen.tsx
+++ b/src/components/IdleScreen/IdleScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import { setBrightness } from '../../api/api';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
 import { setScreen } from '../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -9,6 +8,7 @@ import { DigitalClock } from './DigitalClock';
 import { BaristaClock } from './BaristaClock';
 import { DVDIdleScreen } from './DVD';
 import { useSettings } from '../../hooks/useSettings';
+import { updateBrightness } from '../../hooks/useDimScreen';
 import { routes } from '../../navigation/routes';
 
 export function IdleScreen(): JSX.Element {
@@ -18,12 +18,13 @@ export function IdleScreen(): JSX.Element {
   const { data: globalSettings } = useSettings();
 
   useEffect(() => {
-    setBrightness({ brightness: 0 });
+    updateBrightness({ brightness: 0 });
 
     return () => {
-      setBrightness({ brightness: 1 });
+      updateBrightness({ brightness: 1 });
     };
   }, []);
+
   useEffect(() => {
     if (shouldGoToIdle || prevScreen === 'idle') return;
     if (!prevScreen || routes[prevScreen].ignoreAsPrevious) {

--- a/src/components/IdleScreen/IdleScreen.tsx
+++ b/src/components/IdleScreen/IdleScreen.tsx
@@ -31,7 +31,6 @@ export function IdleScreen(): JSX.Element {
       dispatch(setScreen('pressets'));
     }
     dispatch(setScreen(prevScreen));
-    setBrightness({ brightness: 1 });
   }, [shouldGoToIdle]);
 
   switch (globalSettings?.idle_screen) {

--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { css, keyframes, styled } from 'styled-components';
 import { api } from '../../api/api';
 import { IPresetNumericalUnit } from '../../types';
+import { useDimScreen } from '../../hooks/useDimScreen';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
 

--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -123,6 +123,7 @@ export function PressetSettings(): JSX.Element {
 
   const activeSetting = settings[presets.activeSetting];
 
+  useDimScreen();
   useHandleGestures(
     {
       left() {

--- a/src/components/Pressets/DefaultProfiles.tsx
+++ b/src/components/Pressets/DefaultProfiles.tsx
@@ -18,6 +18,7 @@ import './defaultProfile.css';
 import { api } from '../../api/api';
 import { Profile } from '@meticulous-home/espresso-profile';
 import { v4 as uuidv4 } from 'uuid';
+import { useDimScreen } from '../../hooks/useDimScreen';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
 
@@ -40,6 +41,8 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
 
   const presetSwiperRef = useRef<SwiperRef | null>(null);
   const titleSwiperRef = useRef<SwiperRef | null>(null);
+
+  useDimScreen();
 
   useHandleGestures(
     {

--- a/src/components/Pressets/PressetProfileImage.tsx
+++ b/src/components/Pressets/PressetProfileImage.tsx
@@ -13,6 +13,7 @@ import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { IPresetImage, IPresetSetting } from '../../types';
 import { useDispatch } from 'react-redux';
 import { updatePresetSetting } from '../store/features/preset/preset-slice';
+import { useDimScreen } from '../../hooks/useDimScreen';
 import { api } from '../../api/api';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
@@ -31,6 +32,7 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
   const presetSwiperRef = useRef<SwiperRef | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
+  useDimScreen();
   const updateSetting = (updatedText: string) => {
     const updatedSetting = {
       ...setting,

--- a/src/components/SettingNumerical/SettingNumerical.tsx
+++ b/src/components/SettingNumerical/SettingNumerical.tsx
@@ -13,6 +13,7 @@ import { updatePresetSetting } from '../store/features/preset/preset-slice';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { setScreen } from '../store/features/screens/screens-slice';
 import { useAppSelector } from '../store/hooks';
+import { useDimScreen } from '../../hooks/useDimScreen';
 
 interface ISettingConfig {
   interval: number;
@@ -80,6 +81,8 @@ export function SettingNumerical({ type }: Props): JSX.Element {
   };
 
   const dispatch = useDispatch();
+
+  useDimScreen();
 
   const updateValue = (gesture: 'left' | 'right') => {
     if (

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/CountrySettings.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/CountrySettings.tsx
@@ -7,6 +7,7 @@ import { setScreen } from '../../../../store/features/screens/screens-slice';
 import { setCountry } from '../../../../store/features/settings/settings-slice';
 import { getTimezoneRegion } from '../../../../../api/api';
 import { Regions } from '@meticulous-home/espresso-api';
+import { useDimScreen } from '../../../../../hooks/useDimScreen';
 
 export default function CountrySettings() {
   const [swiper, setSwiper] = useState(null);
@@ -21,6 +22,8 @@ export default function CountrySettings() {
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
 
   const dispatch = useAppDispatch();
+
+  useDimScreen();
 
   useEffect(() => {
     if (swiper) swiper.slideTo(activeIndex);

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/SelectLetterCountry.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/SelectLetterCountry.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { CircleKeyboard } from '../../../../CircleKeyboard/CircleKeyboard';
 import { useAppDispatch } from '../../../../store/hooks';
 import {
@@ -6,9 +6,18 @@ import {
   setScreen
 } from '../../../../store/features/screens/screens-slice';
 import { setCountryLetter } from '../../../../store/features/settings/settings-slice';
+import { useIdleTimer } from '../../../../../hooks/useIdleTimer';
 
 export default function SelectLetterCountry() {
   const dispatch = useAppDispatch();
+  const { isIdle: shouldGoToIdle } = useIdleTimer();
+
+  useEffect(() => {
+    if (!shouldGoToIdle) return;
+
+    dispatch(setScreen('idle'));
+    dispatch(setBubbleDisplay({ visible: false, component: null }));
+  }, [shouldGoToIdle]);
 
   const onCancel = useCallback(() => {
     dispatch(setScreen('pressets'));

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/SelectLetterCountry.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/SelectLetterCountry.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { CircleKeyboard } from '../../../../CircleKeyboard/CircleKeyboard';
 import { useAppDispatch } from '../../../../store/hooks';
 import {
@@ -6,19 +6,11 @@ import {
   setScreen
 } from '../../../../store/features/screens/screens-slice';
 import { setCountryLetter } from '../../../../store/features/settings/settings-slice';
-import { useIdleTimer } from '../../../../../hooks/useIdleTimer';
+import { useDimScreen } from '../../../../../hooks/useDimScreen';
 
 export default function SelectLetterCountry() {
   const dispatch = useAppDispatch();
-  const { isIdle: shouldGoToIdle } = useIdleTimer();
-
-  useEffect(() => {
-    if (!shouldGoToIdle) return;
-
-    dispatch(setScreen('idle'));
-    dispatch(setBubbleDisplay({ visible: false, component: null }));
-  }, [shouldGoToIdle]);
-
+  useDimScreen();
   const onCancel = useCallback(() => {
     dispatch(setScreen('pressets'));
     dispatch(setBubbleDisplay({ visible: true, component: 'timeZoneConfig' }));

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings.tsx
@@ -10,6 +10,7 @@ import { Option, TextContainer, Title } from './Timezone.styled';
 import { getTimezoneRegion, setTimezone } from '../../../../../api/api';
 import { styled } from 'styled-components';
 import { Regions } from '@meticulous-home/espresso-api';
+import { useDimScreen } from '../../../../../hooks/useDimScreen';
 
 const TimeZone = styled.span<{ isactive?: boolean }>`
   color: #f3f4f6;
@@ -28,6 +29,8 @@ export default function TimeZoneSettings() {
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
 
   const dispatch = useAppDispatch();
+
+  useDimScreen();
 
   useEffect(() => {
     if (swiper) swiper.slideTo(activeIndex);

--- a/src/components/Wifi/EnterWifiPassword.tsx
+++ b/src/components/Wifi/EnterWifiPassword.tsx
@@ -11,6 +11,7 @@ import { useConnectToWiFi, useNetworkConfig } from '../../hooks/useWifi';
 import { useEffect, useMemo, useState } from 'react';
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
+import { useDimScreen } from '../../hooks/useDimScreen';
 
 import './wifiResult.css';
 
@@ -29,6 +30,7 @@ export function EnterWifiPassword(): JSX.Element {
 
   const { data, isLoading } = useNetworkConfig();
   const connectToWifiMutation = useConnectToWiFi();
+  useDimScreen();
   useHandleGestures({
     pressDown() {
       if (connectToWifiMutation.isSuccess || connectToWifiMutation.isError) {

--- a/src/hooks/useDimScreen.ts
+++ b/src/hooks/useDimScreen.ts
@@ -1,0 +1,23 @@
+import { useIdleTimer } from './useIdleTimer';
+import { useEffect, useRef } from 'react';
+import { setBrightness } from '../api/api';
+import { BrightnessRequest } from '@meticulous-home/espresso-api';
+
+export const updateBrightness = async ({ brightness }: BrightnessRequest) => {
+  await setBrightness({ brightness });
+};
+
+export const useDimScreen = () => {
+  const { isIdle: shouldGoToIdle } = useIdleTimer();
+  const prevShouldGoToIdle = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (
+      prevShouldGoToIdle.current !== null &&
+      prevShouldGoToIdle.current !== shouldGoToIdle
+    ) {
+      updateBrightness({ brightness: shouldGoToIdle ? 0 : 1 });
+    }
+    prevShouldGoToIdle.current = shouldGoToIdle;
+  }, [shouldGoToIdle]);
+};


### PR DESCRIPTION
## What was done?
Now the display brightness is reduced in components that are menus and require interaction, preventing the idle screen from being triggered.

## Why?
To maintain consistent behavior by performing an action when the screen or the espresso machine has been inactive for a certain period of time.

