### PR TITLE
Avoid heatingscreen from detecting context menu gestures

### DIFF
--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -34,21 +34,18 @@ export default function Bubble() {
     memoizedRoutes[bubbleDisplay.component || prevComponentRef.current]
       ?.component;
 
-  useHandleGestures(
-    {
-      context() {
-        dispatch(
-          setBubbleDisplay({
-            visible: !bubbleDisplay.visible,
-            component: !bubbleDisplay.visible
-              ? 'quick-settings'
-              : bubbleDisplay.component
-          })
-        );
-      }
-    },
-    prevComponentRef.current !== null
-  );
+  useHandleGestures({
+    context() {
+      dispatch(
+        setBubbleDisplay({
+          visible: !bubbleDisplay.visible,
+          component: !bubbleDisplay.visible
+            ? 'quick-settings'
+            : bubbleDisplay.component
+        })
+      );
+    }
+  });
 
   if (!animationState.isVisible && !animationState.isAnimating) return null;
 

--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, createElement } from 'react';
 import { useHandleGestures } from '../../../src/hooks/useHandleGestures';
 import { memoizedRoutes } from '../../../src/utils';
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
@@ -13,11 +13,11 @@ export default function Bubble() {
     isAnimating: false
   });
 
-  const componentRef = useRef(null);
+  const prevComponentRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    if (bubbleDisplay.component) componentRef.current = bubbleDisplay.component;
-  }, [bubbleDisplay.component]);
+  if (bubbleDisplay.component) {
+    prevComponentRef.current = bubbleDisplay.component;
+  }
 
   useEffect(() => {
     if (bubbleDisplay.visible)
@@ -30,22 +30,25 @@ export default function Bubble() {
       setAnimationState((prev) => ({ ...prev, isAnimating: true }));
   }, [bubbleDisplay.visible]);
 
-  const route = componentRef.current
-    ? memoizedRoutes[componentRef.current]
-    : null;
+  const ActiveComponent =
+    memoizedRoutes[bubbleDisplay.component || prevComponentRef.current]
+      ?.component;
 
-  useHandleGestures({
-    context() {
-      dispatch(
-        setBubbleDisplay({
-          visible: !bubbleDisplay.visible,
-          component: !bubbleDisplay.visible
-            ? 'quick-settings'
-            : bubbleDisplay.component
-        })
-      );
-    }
-  });
+  useHandleGestures(
+    {
+      context() {
+        dispatch(
+          setBubbleDisplay({
+            visible: !bubbleDisplay.visible,
+            component: !bubbleDisplay.visible
+              ? 'quick-settings'
+              : bubbleDisplay.component
+          })
+        );
+      }
+    },
+    prevComponentRef.current !== null
+  );
 
   if (!animationState.isVisible && !animationState.isAnimating) return null;
 
@@ -75,7 +78,9 @@ export default function Bubble() {
       } large`}
       onAnimationEnd={handleAnimationEnd}
     >
-      <div className="bubble-container">{route && <route.component />}</div>
+      <div className="bubble-container">
+        {ActiveComponent && createElement(ActiveComponent)}
+      </div>
     </div>
   );
 }

--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -21,6 +21,7 @@ import {
 } from './Keys';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { useSettings } from '../../hooks/useSettings';
+import { useAppSelector } from '../store/hooks';
 
 interface IKeyboardProps {
   name: string;
@@ -34,6 +35,7 @@ interface IKeyboardProps {
 
 export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
   const { data: globalSettings } = useSettings();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const [rotate, setRotate] = useState<number>(FIRST_POSITION);
   const [keyboardType, setKeyboardType] = useState<KEYBOARD_TYPE>(() =>
     props.onlyLetters ? KEYBOARD_TYPE.OnlyLetters : KEYBOARD_TYPE.Default
@@ -155,148 +157,151 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
     }
   };
 
-  useHandleGestures({
-    left() {
-      if (globalSettings?.reverse_scrolling.keyboard) {
-        moveElements(false);
-      } else {
-        moveElements(true);
-      }
-    },
-    right() {
-      if (globalSettings?.reverse_scrolling.keyboard) {
-        moveElements(true);
-      } else {
-        moveElements(false);
-      }
-    },
-    doubleClick() {
-      if (mainLetter === 'capslock') {
-        if (capsLockActive.active && caption.length === 0) {
-          setCapsLockActive({ ...capsLockActive, keep: true });
-          return;
+  useHandleGestures(
+    {
+      left() {
+        if (globalSettings?.reverse_scrolling.keyboard) {
+          moveElements(false);
+        } else {
+          moveElements(true);
         }
-
-        setCapsLockActive({
-          active: !capsLockActive.active,
-          keep: !capsLockActive.keep
-        });
-      }
-    },
-    pressDown() {
-      if (caption.length >= inputLimit && mainLetter !== 'backspace') {
-        if (mainLetter === 'ok') {
-          onSubmit(caption.join('').trim());
+      },
+      right() {
+        if (globalSettings?.reverse_scrolling.keyboard) {
+          moveElements(true);
+        } else {
+          moveElements(false);
         }
-        if (mainLetter === 'cancel') {
-          setCaption(defaultValue);
-          onCancel();
-        }
-        return;
-      }
-      if (captionRef.current) {
-        //remove class to trigger animation if caption is empty next time
-        captionRef.current.classList.remove('caption_shake');
-      }
-      switch (mainLetter) {
-        case 'space': {
-          if (caption.length >= inputLimit - 1) {
-            addAnimation();
+      },
+      doubleClick() {
+        if (mainLetter === 'capslock') {
+          if (capsLockActive.active && caption.length === 0) {
+            setCapsLockActive({ ...capsLockActive, keep: true });
             return;
           }
 
-          if (
-            caption.length < inputLimit &&
-            caption.join('').trim().length === 0
-          ) {
-            addAnimation();
-            return;
-          }
-          const captioValue = caption.concat(' ');
-          setCaption(captioValue);
-          if (onChange) onChange(captioValue.join(''));
-          return;
-        }
-        case 'ok':
-          if (caption.length === 0 || caption.join('').trim().length === 0) {
-            addAnimation();
-            return;
-          }
-          onSubmit(caption.join('').trim());
-          return;
-        case 'backspace':
-          if (caption.length > 0) {
-            const captionValue = caption.slice(0, -1);
-            setCaption(captionValue);
-            if (onChange) onChange(captionValue.join(''));
-          }
-          return;
-        case 'cancel':
-          onCancel();
-          return;
-        case 'capslock':
           setCapsLockActive({
             active: !capsLockActive.active,
-            keep: capsLockActive.keep ? false : capsLockActive.keep
+            keep: !capsLockActive.keep
           });
-          return;
-        case 'keyboardType':
-          if (keyboardType === KEYBOARD_TYPE.Default) {
-            setKeyboardType(KEYBOARD_TYPE.AccentCharacters);
-            if (capsLockActive.active) {
-              setAlphabet(
-                massageAlphabetWithMainChar(
-                  CAPITAL_ACCENT_CHARACTERS,
-                  CAPITAL_ACCENT_CHARACTERS.length - 2
-                )
-              );
-            } else {
-              setAlphabet(
-                massageAlphabetWithMainChar(
-                  SMALL_ACCENT_CHARACTERS,
-                  SMALL_ACCENT_CHARACTERS.length - 2
-                )
-              );
-            }
-            setRotate(467);
-          } else if (keyboardType === KEYBOARD_TYPE.AccentCharacters) {
-            setKeyboardType(KEYBOARD_TYPE.SpecialCharacters);
-            setAlphabet(
-              massageAlphabetWithMainChar(
-                SPECIAL_CHARACTERS,
-                SPECIAL_CHARACTERS.length - 2
-              )
-            );
-            setRotate(466);
-          } else {
-            setKeyboardType(KEYBOARD_TYPE.Default);
-            setAlphabet(
-              massageAlphabetWithMainChar(
-                DEFAULT_ALPHABET,
-                DEFAULT_ALPHABET.length - 2
-              )
-            );
-            setRotate(423);
+        }
+      },
+      pressDown() {
+        if (caption.length >= inputLimit && mainLetter !== 'backspace') {
+          if (mainLetter === 'ok') {
+            onSubmit(caption.join('').trim());
+          }
+          if (mainLetter === 'cancel') {
+            setCaption(defaultValue);
+            onCancel();
           }
           return;
-        default: {
-          const captionValue = caption.concat(mainLetter);
-          setCaption(captionValue);
-          if (onChange) onChange(captionValue.join(''));
-          if (!/^[A-Za-z]$/.test(mainLetter) && capsLockActive.active) {
+        }
+        if (captionRef.current) {
+          //remove class to trigger animation if caption is empty next time
+          captionRef.current.classList.remove('caption_shake');
+        }
+        switch (mainLetter) {
+          case 'space': {
+            if (caption.length >= inputLimit - 1) {
+              addAnimation();
+              return;
+            }
+
+            if (
+              caption.length < inputLimit &&
+              caption.join('').trim().length === 0
+            ) {
+              addAnimation();
+              return;
+            }
+            const captioValue = caption.concat(' ');
+            setCaption(captioValue);
+            if (onChange) onChange(captioValue.join(''));
             return;
           }
-          if (!capsLockActive.keep && capsLockActive.active) {
+          case 'ok':
+            if (caption.length === 0 || caption.join('').trim().length === 0) {
+              addAnimation();
+              return;
+            }
+            onSubmit(caption.join('').trim());
+            return;
+          case 'backspace':
+            if (caption.length > 0) {
+              const captionValue = caption.slice(0, -1);
+              setCaption(captionValue);
+              if (onChange) onChange(captionValue.join(''));
+            }
+            return;
+          case 'cancel':
+            onCancel();
+            return;
+          case 'capslock':
             setCapsLockActive({
-              ...capsLockActive,
-              active: false
+              active: !capsLockActive.active,
+              keep: capsLockActive.keep ? false : capsLockActive.keep
             });
+            return;
+          case 'keyboardType':
+            if (keyboardType === KEYBOARD_TYPE.Default) {
+              setKeyboardType(KEYBOARD_TYPE.AccentCharacters);
+              if (capsLockActive.active) {
+                setAlphabet(
+                  massageAlphabetWithMainChar(
+                    CAPITAL_ACCENT_CHARACTERS,
+                    CAPITAL_ACCENT_CHARACTERS.length - 2
+                  )
+                );
+              } else {
+                setAlphabet(
+                  massageAlphabetWithMainChar(
+                    SMALL_ACCENT_CHARACTERS,
+                    SMALL_ACCENT_CHARACTERS.length - 2
+                  )
+                );
+              }
+              setRotate(467);
+            } else if (keyboardType === KEYBOARD_TYPE.AccentCharacters) {
+              setKeyboardType(KEYBOARD_TYPE.SpecialCharacters);
+              setAlphabet(
+                massageAlphabetWithMainChar(
+                  SPECIAL_CHARACTERS,
+                  SPECIAL_CHARACTERS.length - 2
+                )
+              );
+              setRotate(466);
+            } else {
+              setKeyboardType(KEYBOARD_TYPE.Default);
+              setAlphabet(
+                massageAlphabetWithMainChar(
+                  DEFAULT_ALPHABET,
+                  DEFAULT_ALPHABET.length - 2
+                )
+              );
+              setRotate(423);
+            }
+            return;
+          default: {
+            const captionValue = caption.concat(mainLetter);
+            setCaption(captionValue);
+            if (onChange) onChange(captionValue.join(''));
+            if (!/^[A-Za-z]$/.test(mainLetter) && capsLockActive.active) {
+              return;
+            }
+            if (!capsLockActive.keep && capsLockActive.active) {
+              setCapsLockActive({
+                ...capsLockActive,
+                active: false
+              });
+            }
+            break;
           }
-          break;
         }
       }
-    }
-  });
+    },
+    bubbleDisplay.visible
+  );
 
   const toUpperOrLowerCase = (
     cpAlphabet: string[] | string

--- a/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
+++ b/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { useSettings, useUpdateSettings } from '../..//hooks/useSettings';
 import { Gauge } from '../../components/SettingNumerical/Gauge';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
@@ -7,7 +6,7 @@ import {
   setBubbleDisplay,
   setScreen
 } from '../store/features/screens/screens-slice';
-import { AppDispatch } from '../store/store';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
 
 import { useDimScreen } from '../../hooks/useDimScreen';
 
@@ -15,7 +14,8 @@ const MAX_TIMEOUT = 10; // 60 minutes
 const INTERVAL = 1; // 1 minute intervals
 
 export const HeatTimeoutAfterShot: React.FC = () => {
-  const dispatch = useDispatch<AppDispatch>();
+  const dispatch = useAppDispatch();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const { data: globalSettings } = useSettings();
   const updateSettings = useUpdateSettings();
 
@@ -25,21 +25,26 @@ export const HeatTimeoutAfterShot: React.FC = () => {
 
   useDimScreen();
 
-  useHandleGestures({
-    left() {
-      const newValue = Math.max(localHeatingTimeout - INTERVAL, 0);
-      setLocalHeatingTimeout(newValue);
+  useHandleGestures(
+    {
+      left() {
+        const newValue = Math.max(localHeatingTimeout - INTERVAL, 0);
+        setLocalHeatingTimeout(newValue);
+      },
+      right() {
+        const newValue = Math.min(localHeatingTimeout + INTERVAL, MAX_TIMEOUT);
+        setLocalHeatingTimeout(newValue);
+      },
+      pressDown() {
+        updateSettings.mutate({ heating_timeout: localHeatingTimeout });
+        dispatch(setScreen('pressets'));
+        dispatch(
+          setBubbleDisplay({ visible: true, component: 'brewSettings' })
+        );
+      }
     },
-    right() {
-      const newValue = Math.min(localHeatingTimeout + INTERVAL, MAX_TIMEOUT);
-      setLocalHeatingTimeout(newValue);
-    },
-    pressDown() {
-      updateSettings.mutate({ heating_timeout: localHeatingTimeout });
-      dispatch(setScreen('pressets'));
-      dispatch(setBubbleDisplay({ visible: true, component: 'brewSettings' }));
-    }
-  });
+    bubbleDisplay.visible
+  );
 
   return (
     <div className="gauge-container">

--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -16,6 +16,7 @@ import {
 import { formatTime } from '../../utils';
 import { BUBBLES_WIDTH, LottieBubbleAnimation } from './LottieBubbleAnimation';
 import { notificationSelector } from '../store/features/notifications/notification-slice';
+import { useHandleGestures } from '../../hooks/useHandleGestures';
 
 const PushToStartLabel = styled.div`
   font-size: 20px;
@@ -60,7 +61,7 @@ export const HeatingScreen = () => {
   const hasNotifications = useAppSelector(
     notificationSelector.selectHasNotifications
   );
-
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   // The stages dont necessarily correctly report the temperature target
   // so we need to cache it with the state below
   const temperatureTargetStatus = useAppSelector(
@@ -120,6 +121,21 @@ export const HeatingScreen = () => {
     transition: `transform ${transitionDuration / 1000}s`
   };
 
+  useHandleGestures(
+    {
+      pressDown() {
+        console.log('HeatingScreen::pressDown');
+      },
+      left() {
+        console.log('HeatingScreen::left');
+      },
+      right() {
+        console.log('HeatingScreen::right');
+      }
+    },
+    bubbleDisplay.visible
+  );
+
   return (
     <ModularScreen>
       <ModularLeft style={transitionStyle}>
@@ -129,20 +145,21 @@ export const HeatingScreen = () => {
         />
       </ModularLeft>
       <ModularRight style={transitionStyle}>
-        {/* <CSSTransition
+        <CSSTransition
           in={!heatingFinished}
           unmountOnExit
           timeout={transitionDuration}
           classNames="fade-options"
         >
-          <ModularRightOptions
+          {/* <ModularRightOptions
             options={OPTIONS}
             value={globalSettings?.auto_start_shot ? 'auto' : 'manual'}
             onValueChange={(value) => {
               updateSettings.mutate({ auto_start_shot: value === 'auto' });
             }}
-          />
-        </CSSTransition> */}
+            shouldIgnoreGesture={bubbleDisplay.visible}
+          /> */}
+        </CSSTransition>
         <div
           style={{
             display: 'flex',

--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -145,21 +145,21 @@ export const HeatingScreen = () => {
         />
       </ModularLeft>
       <ModularRight style={transitionStyle}>
-        <CSSTransition
+        {/* <CSSTransition
           in={!heatingFinished}
           unmountOnExit
           timeout={transitionDuration}
           classNames="fade-options"
         >
-          {/* <ModularRightOptions
+          <ModularRightOptions
             options={OPTIONS}
             value={globalSettings?.auto_start_shot ? 'auto' : 'manual'}
             onValueChange={(value) => {
               updateSettings.mutate({ auto_start_shot: value === 'auto' });
             }}
             shouldIgnoreGesture={bubbleDisplay.visible}
-          /> */}
-        </CSSTransition>
+          />
+        </CSSTransition> */}
         <div
           style={{
             display: 'flex',

--- a/src/components/ModularScreen/ModularScreen.tsx
+++ b/src/components/ModularScreen/ModularScreen.tsx
@@ -52,11 +52,13 @@ export function ModularRightOptions<
 >({
   options,
   value,
-  onValueChange
+  onValueChange,
+  shouldIgnoreGesture
 }: {
   options: T;
   value: T[number]['id'];
   onValueChange: (value: T[number]['id']) => void;
+  shouldIgnoreGesture?: boolean;
 }) {
   const handleTurn = (delta: -1 | 1) => {
     const currentIndex = options.findIndex(({ id }) => id === value);
@@ -65,14 +67,17 @@ export function ModularRightOptions<
       onValueChange(options[newIndex].id);
     }
   };
-  useHandleGestures({
-    left: () => {
-      handleTurn(-1);
+  useHandleGestures(
+    {
+      left: () => {
+        handleTurn(-1);
+      },
+      right: () => {
+        handleTurn(1);
+      }
     },
-    right: () => {
-      handleTurn(1);
-    }
-  });
+    shouldIgnoreGesture
+  );
 
   return (
     <div className="modular-options">

--- a/src/components/ShotGraph/ShotGraphScreen.tsx
+++ b/src/components/ShotGraph/ShotGraphScreen.tsx
@@ -91,7 +91,7 @@ type PathsType = Record<DataTypeKey, { path: string; maskPath: string }>;
 
 export const ShotGraphScreen = () => {
   const dispatch = useDispatch<AppDispatch>();
-
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const [paths, setPaths] = useState<PathsType>({
     flow: { path: '', maskPath: '' },
     pressure: { path: '', maskPath: '' },
@@ -132,16 +132,23 @@ export const ShotGraphScreen = () => {
     dispatch(setBubbleDisplay({ visible: false, component: null }));
   }, [shouldGoToIdle]);
 
-  useHandleGestures({
-    left() {
-      setSelectedPointIndex((prev) => Math.max(0, prev - gestureProgress));
+  useHandleGestures(
+    {
+      left() {
+        setSelectedPointIndex((prev) => Math.max(0, prev - gestureProgress));
+      },
+      right() {
+        setSelectedPointIndex((prev) =>
+          Math.min(prev + gestureProgress, displayShot?.data.length - 1)
+        );
+      },
+      doubleClick() {
+        dispatch(setBubbleDisplay({ visible: false, component: null }));
+        dispatch(setScreen('pressets'));
+      }
     },
-    right() {
-      setSelectedPointIndex((prev) =>
-        Math.min(prev + gestureProgress, displayShot?.data.length - 1)
-      );
-    }
-  });
+    bubbleDisplay.visible
+  );
 
   useEffect(() => {
     if (!displayShot) {


### PR DESCRIPTION
## What was done?
- I fixed the bug that required a double click to access submenus from QuickSettings when on a screen other than Presets.
- I fixed the bug where some components responded to gestures in the context menu.

| Before | After | 
|:----------|:--------:|
| <img src="https://github.com/user-attachments/assets/f90667fd-b28d-4773-8129-3fe16b40b6c2" width="300px"> | <img src="https://github.com/user-attachments/assets/aa37f387-bc97-4512-b539-c4e8b883c45c" width="300px"> |
| <img src="https://github.com/user-attachments/assets/149f499b-7756-42c3-93bb-0b844f24bce6" width="300px"> | <img src="https://github.com/user-attachments/assets/0e364c18-1693-4f82-8a79-8d03b7c2df84" width="300px"> |
| <img src="https://github.com/user-attachments/assets/f38b09bd-8e39-41db-8ac6-0de50605c821" width="300px"> | <img src="https://github.com/user-attachments/assets/c85f6ee5-b005-49e1-b9cd-b967fbde6ead" width="300px"> |

## Why?
- It caused inconsistent behavior on some screens of the application.

## Additional comments & remarks
On the Heating screen, adding useHandleGestures with the flag to ignore gestures when the context menu is open does not prevent stage skipping, as it is managed internally by the firmware, not the UI. 😥
