### PR TITLE
fix(digital-clock): correctly calculate the 12 hours format

### DIFF
--- a/src/components/IdleScreen/DigitalClock.tsx
+++ b/src/components/IdleScreen/DigitalClock.tsx
@@ -14,7 +14,7 @@ function formatTime() {
   const pm = localeString.includes('PM') && 'PM';
   const midday = am || pm;
   return {
-    hours: midday ? time.getHours() % 12 : time.getHours(),
+    hours: midday ? ((time.getHours() + 11) % 12) + 1 : time.getHours(),
     minutes: time.getMinutes(),
     seconds: time.getSeconds(),
     midday: midday


### PR DESCRIPTION
## What was done?
The previous implementation was broken at midnight due to an early overflow.
Fixed by using a proper conversion logic