### PR TITLE
Fix/notification behavior

### DIFF
--- a/src/components/Barometer/Barometer.tsx
+++ b/src/components/Barometer/Barometer.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setScreen } from '../store/features/screens/screens-slice';
 import { Meter } from './Meter';
 import { setWaitingForAction } from '../store/features/stats/stats-slice';
+import { notificationSelector } from '../store/features/notifications/notification-slice';
 
 export interface IBarometerProps {
   maxValue?: number;
@@ -13,9 +14,16 @@ export interface IBarometerProps {
 export function Barometer({ maxValue = 21 }: IBarometerProps): JSX.Element {
   const stats = useAppSelector((state) => state.stats);
   const dispatch = useAppDispatch();
+  const hasNotifications = useAppSelector(
+    notificationSelector.selectHasNotifications
+  );
 
   useEffect(() => {
-    if (stats.name === 'idle' && !stats.waitingForActionAlreadySent) {
+    if (
+      stats.name === 'idle' &&
+      !stats.waitingForActionAlreadySent &&
+      !hasNotifications
+    ) {
       dispatch(setScreen('pressets'));
     }
   }, [stats.name, stats.waitingForActionAlreadySent]);

--- a/src/components/BottomStatus/BottomStatus.tsx
+++ b/src/components/BottomStatus/BottomStatus.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { formatStatValue, hidden_ui_elements_enabled } from '../../utils';
 import { useSettings } from '../../hooks/useSettings';
 import { useAppSelector } from '../store/hooks';
+import { notificationSelector } from '../store/features/notifications/notification-slice';
 import './bottom-status.css';
 import Funnel from './Funnel';
 
@@ -15,7 +16,7 @@ export const BottomStatus: React.FC<{ hidden: boolean }> = ({ hidden }) => {
     (state) => state.stats.preheatTimeLeft
   );
 
-  const motorHot = useAppSelector((state) => state.settings.motorHot);
+  const motorHot = useAppSelector(notificationSelector.selectMotorHot);
 
   return (
     <div

--- a/src/components/BottomStatus/BottomStatus.tsx
+++ b/src/components/BottomStatus/BottomStatus.tsx
@@ -15,6 +15,8 @@ export const BottomStatus: React.FC<{ hidden: boolean }> = ({ hidden }) => {
     (state) => state.stats.preheatTimeLeft
   );
 
+  const motorHot = useAppSelector((state) => state.settings.motorHot);
+
   return (
     <div
       className={classNames('bottom-status', {
@@ -55,6 +57,11 @@ export const BottomStatus: React.FC<{ hidden: boolean }> = ({ hidden }) => {
             </div>
           )}
         </div>
+        {motorHot ? (
+          <div style={{ fontSize: '16px', color: '#f44336' }}>
+            Motor temperature too high
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/BottomStatus/bottom-status.css
+++ b/src/components/BottomStatus/bottom-status.css
@@ -13,7 +13,7 @@
 .bottom-status .bottom-content {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
 }
 
 .bottom-item {

--- a/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
+++ b/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
@@ -12,6 +12,7 @@ import { RemoveCupAnimation } from './RemoveCupAnimation';
 import { formatTime } from '../../utils';
 import { useEffect } from 'react';
 import { PurgePiston } from '../PurgePiston/PurgePiston';
+import { notificationSelector } from '../store/features/notifications/notification-slice';
 
 const WeightContainer = styled.div`
   display: flex;
@@ -63,6 +64,9 @@ export const BrewCompleteScreen = () => {
   const statsName = useAppSelector((state) => state.stats.name);
   const brewTime = useAppSelector((state) => state.stats.time);
   const lastBrewWeight = useAppSelector((state) => state.stats.sensors.w);
+  const hasNotifications = useAppSelector(
+    notificationSelector.selectHasNotifications
+  );
 
   const weight =
     Math.abs(lastBrewWeight) < 1000
@@ -72,7 +76,7 @@ export const BrewCompleteScreen = () => {
   const isPurging = statsName === 'purge';
 
   useEffect(() => {
-    if (statsName === 'idle') {
+    if (statsName === 'idle' && !hasNotifications) {
       dispatch(setScreen('pressets'));
     }
   }, [statsName]);

--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from '../ModularScreen/ModularScreen';
 import { formatTime } from '../../utils';
 import { BUBBLES_WIDTH, LottieBubbleAnimation } from './LottieBubbleAnimation';
+import { notificationSelector } from '../store/features/notifications/notification-slice';
 
 const PushToStartLabel = styled.div`
   font-size: 20px;
@@ -55,6 +56,9 @@ export const HeatingScreen = () => {
   const waterStatus = useAppSelector((state) => state.stats.waterStatus);
   const temperature = useAppSelector((state) =>
     Math.round(state.stats.sensors.t)
+  );
+  const hasNotifications = useAppSelector(
+    notificationSelector.selectHasNotifications
   );
 
   // The stages dont necessarily correctly report the temperature target
@@ -97,7 +101,7 @@ export const HeatingScreen = () => {
   // const updateSettings = useUpdateSettings();
 
   useEffect(() => {
-    if (statsName === 'idle') {
+    if (statsName === 'idle' && !hasNotifications) {
       dispatch(setScreen('pressets'));
     }
   }, [statsName]);

--- a/src/components/PurgePiston/PurgeScreen.tsx
+++ b/src/components/PurgePiston/PurgeScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { formatStatValue } from '../../utils';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { PurgePiston } from './PurgePiston';
+import { notificationSelector } from '../store/features/notifications/notification-slice';
 
 import './piston.css';
 import { setScreen } from '../store/features/screens/screens-slice';
@@ -9,11 +10,14 @@ import { setScreen } from '../store/features/screens/screens-slice';
 export function PurgeScreen(): JSX.Element {
   const dispatch = useAppDispatch();
 
-  const stats = useAppSelector((state) => state.stats);
-  const statsName = stats.name;
+  const statsName = useAppSelector((state) => state.stats.name);
+  const sensors = useAppSelector((state) => state.stats.sensors);
+  const hasNotifications = useAppSelector(
+    notificationSelector.selectHasNotifications
+  );
 
   useEffect(() => {
-    if (statsName === 'idle') {
+    if (statsName === 'idle' && !hasNotifications) {
       dispatch(setScreen('pressets'));
     }
   }, [statsName]);
@@ -23,12 +27,12 @@ export function PurgeScreen(): JSX.Element {
       <div className="piston-purge-container center">
         <div className="values">
           <div className="value">
-            {formatStatValue(stats.sensors.p, 1)}
+            {formatStatValue(sensors.p, 1)}
             <span>bar</span>
           </div>
           <PurgePiston />
           <div className="value">
-            {formatStatValue(stats.sensors.f, 1)}
+            {formatStatValue(sensors.f, 1)}
             <span>ml/s</span>
           </div>
         </div>

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -112,9 +112,7 @@ export function QuickSettings(): JSX.Element {
     ...allDefaultProfiles.default,
     ...allDefaultProfiles.community
   ];
-  const waitingForActionAlreadySent = useAppSelector(
-    (state) => state.stats.waitingForActionAlreadySent
-  );
+
   const { data: globalSettings } = useSettings();
   const updateSettings = useUpdateSettings();
 

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -294,7 +294,7 @@ export function QuickSettings(): JSX.Element {
         }
       }
     },
-    !bubbleDisplay.visible || waitingForActionAlreadySent
+    !bubbleDisplay.visible
   );
 
   const requiresProfileContext: boolean =

--- a/src/components/Scale/Scale.tsx
+++ b/src/components/Scale/Scale.tsx
@@ -6,24 +6,33 @@ import { memo } from 'react';
 
 const Weight = () => {
   const weight = useAppSelector((state) => state.stats.sensors.w || 0);
-  const formatted = weight.toFixed(1);
+  const scaleConnected = !isNaN(weight);
+  const formatted = scaleConnected ? weight.toFixed(1) : '';
   const padded = formatted.padStart(5, '0');
 
   return (
     <div className="scale-weight">
-      <span className="weight">
-        {padded.split('').map((char, i) => (
-          <span
-            key={i}
-            className={
-              i < padded.length - formatted.length ? 'dimmed' : undefined
-            }
-          >
-            {char}
+      {scaleConnected ? (
+        <div>
+          <span className="weight">
+            {padded.split('').map((char, i) => (
+              <span
+                key={i}
+                className={
+                  i < padded.length - formatted.length ? 'dimmed' : undefined
+                }
+              >
+                {char}
+              </span>
+            ))}
           </span>
-        ))}
-      </span>
-      <div className="weight-unit">g</div>
+          <div className="weight-unit">g</div>
+        </div>
+      ) : (
+        <div style={{ fontSize: '30px', color: '#f44336' }}>
+          Scale not connected
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -29,6 +29,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { OS_UPDATE_STATUS } from '../../hooks/useDeviceOSStatus';
 import { OSStatusResponse } from '@meticulous-home/espresso-api';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
+import { setMotorHot } from './features/settings/settings-slice';
 
 const SERVER_URL: string = window.env?.SERVER_URL || 'http://localhost:8080';
 const socket: Socket | null = io(SERVER_URL);
@@ -36,6 +37,11 @@ const socket: Socket | null = io(SERVER_URL);
 const isBrewComplete = (state: string) => {
   return state === 'remove cup' || state === 'click to purge';
 };
+
+const MOTOR_HOT_KEY = 'motor_hot;';
+const MOTOR_COLD_KEY = 'motor_cold;';
+const cleanMessage = (message: string, key: string | null): string =>
+  key ? message.replace(key, '').trim() : message;
 
 export const SocketProviderValue = () => {
   const dispatch = useAppDispatch();
@@ -49,12 +55,30 @@ export const SocketProviderValue = () => {
   useEffect(() => {
     socket.on('notification', (notification: string) => {
       resetIdleTimer();
+
       const oNotification: NotificationItem = JSON.parse(notification);
 
-      if (!oNotification.message && !oNotification.image) {
-        dispatch(removeOneNotification(oNotification.id));
+      console.log('Receive: notification', oNotification);
+      const keys = [MOTOR_HOT_KEY, MOTOR_COLD_KEY];
+      const detectedKey =
+        keys.find((key) => oNotification.message.includes(key)) || null;
+      console.log('Clave detectada:', detectedKey);
+
+      const updatedNotification: NotificationItem = {
+        ...oNotification,
+        message: cleanMessage(oNotification.message, detectedKey)
+      };
+
+      if (detectedKey === MOTOR_HOT_KEY) {
+        dispatch(setMotorHot(true));
+      } else if (detectedKey === MOTOR_COLD_KEY) {
+        dispatch(setMotorHot(false));
+      }
+
+      if (!updatedNotification.message && !updatedNotification.image) {
+        dispatch(removeOneNotification(updatedNotification.id));
       } else {
-        dispatch(addOneNotification(oNotification));
+        dispatch(addOneNotification(updatedNotification));
       }
     });
 

--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -21,15 +21,16 @@ import {
 import { handleEvents } from '../../HandleEvents';
 import {
   addOneNotification,
+  removeOneNotification,
+  setMotorHot,
   NotificationItem,
-  removeOneNotification
+  processNotification
 } from './features/notifications/notification-slice';
 import { api } from '../../api/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { OS_UPDATE_STATUS } from '../../hooks/useDeviceOSStatus';
 import { OSStatusResponse } from '@meticulous-home/espresso-api';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
-import { setMotorHot } from './features/settings/settings-slice';
 
 const SERVER_URL: string = window.env?.SERVER_URL || 'http://localhost:8080';
 const socket: Socket | null = io(SERVER_URL);
@@ -37,11 +38,6 @@ const socket: Socket | null = io(SERVER_URL);
 const isBrewComplete = (state: string) => {
   return state === 'remove cup' || state === 'click to purge';
 };
-
-const MOTOR_HOT_KEY = 'motor_hot;';
-const MOTOR_COLD_KEY = 'motor_cold;';
-const cleanMessage = (message: string, key: string | null): string =>
-  key ? message.replace(key, '').trim() : message;
 
 export const SocketProviderValue = () => {
   const dispatch = useAppDispatch();
@@ -58,22 +54,10 @@ export const SocketProviderValue = () => {
 
       const oNotification: NotificationItem = JSON.parse(notification);
 
-      console.log('Receive: notification', oNotification);
-      const keys = [MOTOR_HOT_KEY, MOTOR_COLD_KEY];
-      const detectedKey =
-        keys.find((key) => oNotification.message.includes(key)) || null;
-      console.log('Clave detectada:', detectedKey);
+      const { updatedNotification, isMotorHot } =
+        processNotification(oNotification);
 
-      const updatedNotification: NotificationItem = {
-        ...oNotification,
-        message: cleanMessage(oNotification.message, detectedKey)
-      };
-
-      if (detectedKey === MOTOR_HOT_KEY) {
-        dispatch(setMotorHot(true));
-      } else if (detectedKey === MOTOR_COLD_KEY) {
-        dispatch(setMotorHot(false));
-      }
+      if (isMotorHot !== null) dispatch(setMotorHot(isMotorHot));
 
       if (!updatedNotification.message && !updatedNotification.image) {
         dispatch(removeOneNotification(updatedNotification.id));

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -86,7 +86,11 @@ export const notificationSelector = {
   ...notificationAdapter.getSelectors<RootState>(
     (state) => state.notifications
   ),
-  selectMotorHot: (state: RootState) => state.notifications.motorHot
+  selectMotorHot: (state: RootState) => state.notifications.motorHot,
+  selectHasNotifications: (state: RootState) =>
+    notificationAdapter
+      .getSelectors<RootState>((s) => s.notifications)
+      .selectTotal(state) > 0
 };
 
 export default notificationSlice.reducer;

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -1,7 +1,14 @@
-import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import {
+  createEntityAdapter,
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
 import { RootState } from '../../store';
 
 type ResponseOption = 'Update' | 'Auto Update' | 'Skip';
+
+export const MOTOR_HOT_KEY = 'motor_hot;';
+export const MOTOR_COLD_KEY = 'motor_cold;';
 
 export interface NotificationItem {
   id: string;
@@ -15,24 +22,71 @@ const notificationAdapter = createEntityAdapter({
   selectId: (notification: NotificationItem) => notification.id
 });
 
+interface NotificationState
+  extends ReturnType<typeof notificationAdapter.getInitialState> {
+  motorHot: boolean;
+}
+
+const initialState: NotificationState = {
+  ...notificationAdapter.getInitialState(),
+  motorHot: false
+};
+
+export const cleanMessage = (message: string, key: string | null): string =>
+  key ? message.replace(key, '').trim() : message;
+
+export const processNotification = (
+  notification: NotificationItem
+): {
+  updatedNotification: NotificationItem;
+  isMotorHot: boolean | null;
+  detectedKey: string | null;
+} => {
+  const motorStateMap: Record<string, boolean> = {
+    [MOTOR_HOT_KEY]: true,
+    [MOTOR_COLD_KEY]: false
+  };
+
+  const keys = Object.keys(motorStateMap);
+
+  const detectedKey =
+    keys.find((key) => notification.message.includes(key)) || null;
+
+  const isMotorHot = detectedKey ? motorStateMap[detectedKey] : null;
+
+  const updatedNotification: NotificationItem = {
+    ...notification,
+    message: cleanMessage(notification.message, detectedKey)
+  };
+
+  return { updatedNotification, isMotorHot, detectedKey };
+};
+
 const notificationSlice = createSlice({
   name: 'notifications',
-  initialState: notificationAdapter.getInitialState(),
+  initialState,
   reducers: {
     addOneNotification: notificationAdapter.upsertOne,
     removeOneNotification: notificationAdapter.removeOne,
-    removeAllNotications: notificationAdapter.removeAll
+    removeAllNotications: notificationAdapter.removeAll,
+    setMotorHot: (state, action: PayloadAction<boolean>) => {
+      state.motorHot = action.payload;
+    }
   }
 });
 
 export const {
   addOneNotification,
   removeOneNotification,
-  removeAllNotications
+  removeAllNotications,
+  setMotorHot
 } = notificationSlice.actions;
 
-export const notificationSelector = notificationAdapter.getSelectors<RootState>(
-  (state) => state.notifications
-);
+export const notificationSelector = {
+  ...notificationAdapter.getSelectors<RootState>(
+    (state) => state.notifications
+  ),
+  selectMotorHot: (state: RootState) => state.notifications.motorHot
+};
 
 export default notificationSlice.reducer;

--- a/src/components/store/features/settings/settings-slice.ts
+++ b/src/components/store/features/settings/settings-slice.ts
@@ -3,11 +3,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 type InitialSettings = {
   countryLetter: string | null;
   country: string | null;
+  motorHot: boolean;
 };
 
 export const initialState: InitialSettings = {
   countryLetter: null,
-  country: null
+  country: null,
+  motorHot: false
 };
 
 const settingsSlice = createSlice({
@@ -19,9 +21,13 @@ const settingsSlice = createSlice({
     },
     setCountry: (state, action: PayloadAction<string>) => {
       state.country = action.payload;
+    },
+    setMotorHot: (state, action: PayloadAction<boolean>) => {
+      state.motorHot = action.payload;
     }
   }
 });
 
-export const { setCountryLetter, setCountry } = settingsSlice.actions;
+export const { setCountryLetter, setCountry, setMotorHot } =
+  settingsSlice.actions;
 export default settingsSlice.reducer;

--- a/src/components/store/features/settings/settings-slice.ts
+++ b/src/components/store/features/settings/settings-slice.ts
@@ -3,13 +3,11 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 type InitialSettings = {
   countryLetter: string | null;
   country: string | null;
-  motorHot: boolean;
 };
 
 export const initialState: InitialSettings = {
   countryLetter: null,
-  country: null,
-  motorHot: false
+  country: null
 };
 
 const settingsSlice = createSlice({
@@ -21,13 +19,9 @@ const settingsSlice = createSlice({
     },
     setCountry: (state, action: PayloadAction<string>) => {
       state.country = action.payload;
-    },
-    setMotorHot: (state, action: PayloadAction<boolean>) => {
-      state.motorHot = action.payload;
     }
   }
 });
 
-export const { setCountryLetter, setCountry, setMotorHot } =
-  settingsSlice.actions;
+export const { setCountryLetter, setCountry } = settingsSlice.actions;
 export default settingsSlice.reducer;


### PR DESCRIPTION
## What was done?
- A message is shown/hidden when the motor temperature protection is enabled/disabled.
- Fixed an issue where the context menu became unresponsive when motor temperature protection was enabled.
- Fixed a bug on the Scale screen that caused the app to crash when the scale was not connected.

<image src="https://github.com/user-attachments/assets/b38886df-0497-41e9-8926-fc63b9086020" width=300>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/59bc961b-8963-4136-9a5e-c3758c61d1d6" />

## Why?
The user must be notified that motor temperature protection is active and the machine is unavailable for coffee shots. The context menu would become unresponsive if this protection was enabled while trying to make a coffee shot.

## Additional comments & remarks
- Tests were conducted on available machines in the office, and the behavior is as expected.
- The message appears/disappears after interacting with a notification that informs whether the motor temperature protection is enabled/disabled.
- The location, style, and content of the message are subject to change; for now, functionality has been prioritized.
