### PR TITLE
feat(notifications): fetch old notifications on machine startup

### DIFF
--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -16,7 +16,7 @@ export function Notification(): JSX.Element {
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const messageRef = useRef<HTMLDivElement>(null);
   const notifications = useSelector(notificationSelector.selectAll);
-  const [currentNotification] = notifications;
+  const [currentNotification] = notifications.slice(-1);
   const [isScrollable, setIsScrollable] = useState(false);
   const [selectedOption, setSelectedOption] = useState(0);
   const [canSelectOption, setCanSelectOption] = useState(false);

--- a/src/components/Notification/notification.css
+++ b/src/components/Notification/notification.css
@@ -41,6 +41,8 @@
 
 .notification-message.scrollable {
   justify-content: flex-start;
+  padding-top: 20px;
+  padding-bottom: 40px;
   mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
   -webkit-mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
 }
@@ -52,6 +54,7 @@
   margin: 0;
   hyphens: auto;
   word-break: break-word;
+  white-space: pre-line;
 }
 
 .notification-image-container {

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -1,9 +1,12 @@
 import {
   createEntityAdapter,
   createSlice,
-  PayloadAction
+  PayloadAction,
+  createAsyncThunk
 } from '@reduxjs/toolkit';
 import { RootState } from '../../store';
+import { api } from '../../../../api/api';
+import { APIError } from '@meticulous-home/espresso-api/dist';
 
 type ResponseOption = 'Update' | 'Auto Update' | 'Skip';
 
@@ -17,6 +20,23 @@ export interface NotificationItem {
   responses: ResponseOption[];
   timestamp: Date;
 }
+
+export const loadNotifications = createAsyncThunk(
+  'notificationData/loadNotifications',
+  async () => {
+    const notifications = (await api.getNotifications(false)).data;
+
+    if ((notifications as APIError)?.error) {
+      throw new Error((notifications as APIError).error);
+    }
+
+    if (notifications == undefined) {
+      throw new Error('No notifications found');
+    }
+
+    return notifications as unknown as NotificationItem[];
+  }
+);
 
 const notificationAdapter = createEntityAdapter({
   selectId: (notification: NotificationItem) => notification.id
@@ -72,9 +92,13 @@ const notificationSlice = createSlice({
     setMotorHot: (state, action: PayloadAction<boolean>) => {
       state.motorHot = action.payload;
     }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(loadNotifications.fulfilled, (state, action) => {
+      notificationAdapter.setAll(state, action.payload);
+    });
   }
 });
-
 export const {
   addOneNotification,
   removeOneNotification,

--- a/src/hooks/useFetchData.tsx
+++ b/src/hooks/useFetchData.tsx
@@ -5,6 +5,7 @@ import {
 } from '../components/store/features/preset/preset-slice';
 import { useAppDispatch, useAppSelector } from '../components/store/hooks';
 import { api } from '../api/api';
+import { loadNotifications } from '../components/store/features/notifications/notification-slice';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
 
@@ -24,6 +25,7 @@ export function useFetchData(onReady?: () => void) {
   useEffect(() => {
     dispatch(getPresets({}));
     dispatch(loadDefaultProfiles());
+    dispatch(loadNotifications());
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What was done?
This allows for the fetching of startup-time backend notifications before the dial app was fully started
![image](https://github.com/user-attachments/assets/82e6b730-6b69-42cd-a8fd-063a7ceb6bec)
