### PR TITLE
Handle NaN values for last brew weight

### DIFF
--- a/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
+++ b/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
@@ -68,10 +68,11 @@ export const BrewCompleteScreen = () => {
     notificationSelector.selectHasNotifications
   );
 
-  const weight =
-    Math.abs(lastBrewWeight) < 1000
+  const weight = !isNaN(lastBrewWeight)
+    ? Math.abs(lastBrewWeight) < 1000
       ? lastBrewWeight.toFixed(1)
-      : lastBrewWeight.toFixed(0);
+      : lastBrewWeight.toFixed(0)
+    : lastBrewWeight;
 
   const isPurging = statsName === 'purge';
 


### PR DESCRIPTION
## What was done?
When the scale is not connected, a runtime error is thrown, and it is now handled.

## Why?
A runtime error occurred, causing the application to crash.
