### PR TITLE
fix(scale): auto-hide the scale overlay on brewing start

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,12 @@ const App = (): JSX.Element => {
     isExtracting || bubbleDisplay.visible
   );
 
+  useEffect(() => {
+    if (isExtracting) {
+      setScaleState({ visible: false, size: 'small' });
+    }
+  }, [isExtracting]);
+
   const dev = !!window.env?.SHOW_CIRCLE_OVERLAY;
 
   return (


### PR DESCRIPTION
This was tested against the emulated backend with different retraction interactions as well as on a physical machine with one real shot.

## What was done?
An Effect was added to hide the scale one extraction starts as we ignore button presses from that point onwards.

## Why?
So users would not be stuck with an unseasonable overlay