### PR TITLE
Show time and date in Time & Date settings

### DIFF
--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -17,17 +17,19 @@ import Styled, {
 } from '../../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../../styles/utils/calculateOptionPosition';
 import { IdleScreens } from '../../../components/Settings/Advanced/IdleScreenSetting';
+import type { Settings } from '@meticulous-home/espresso-api';
 
 const initialSettings: SettingsItem[] = [
   {
     key: 'usb_mode',
     label: 'USB mode',
-    getLabel: (settings) => settings.usb_mode
+    getLabel: (settings: Settings) => settings.usb_mode
   },
   {
     key: 'ssh_enabled',
     label: 'SSH',
-    getLabel: (settings) => (settings.ssh_enabled ? 'ENABLED' : 'DISABLED')
+    getLabel: (settings: Settings) =>
+      settings.ssh_enabled ? 'ENABLED' : 'DISABLED'
   },
   {
     key: 'master_calibration',
@@ -37,27 +39,27 @@ const initialSettings: SettingsItem[] = [
   {
     key: 'save_debug_shot_data',
     label: 'Save debug shot data',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       settings.save_debug_shot_data ? 'ENABLED' : 'DISABLED',
     visible: true
   },
   {
     key: 'telemetry_opt_in',
     label: 'Share debug motor data',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       settings.allow_debug_sending ? 'ENABLED' : 'DISABLED',
     visible: true
   },
   {
     key: 'set_update_channel',
     label: 'Update channel',
-    getLabel: (settings) => settings.update_channel,
+    getLabel: (settings: Settings) => settings.update_channel,
     visible: true
   },
   {
     key: 'idle_screen',
     label: 'Select Idle Screen',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       IdleScreens.find((item) => item.key === settings.idle_screen)?.shortLabel,
     visible: true
   },

--- a/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
@@ -6,8 +6,10 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { setBubbleDisplay } from '../../../store/features/screens/screens-slice';
 import '../../../OSStatus/OSStatus.css';
 
-import { SettingsItem } from '../../../../types';
+import type { SettingsItem, TimeDateValues } from '../../../../types';
+import type { Settings } from '@meticulous-home/espresso-api';
 import { useSettings } from '../../../../hooks/useSettings';
+import { useCurrentTime } from '../../../../hooks/useCurrentTime';
 
 import Styled, {
   VIEWPORT_HEIGHT,
@@ -19,17 +21,20 @@ const initialSettings: SettingsItem[] = [
   {
     key: 'time_zone',
     label: 'Set time zone',
-    getLabel: (settings) => `${settings.time_zone || 'Not set'}`
+    getLabel: (settings: Settings) => `${settings.time_zone || 'Not set'}`
   },
   {
     key: 'set_time',
     label: 'Set Time',
     visible: true,
+    getLabel: ({ hours, minutes }: TimeDateValues) => `${hours}:${minutes}`,
     value: false
   },
   {
     key: 'set_date',
     label: 'Set Date',
+    getLabel: ({ day, month, year }: TimeDateValues) =>
+      `${day}/${month}/${year}`,
     visible: true,
     value: false
   },
@@ -45,19 +50,26 @@ export function TimeDate(): JSX.Element {
   const [activeIndex, setActiveIndex] = useState(0);
   const { data: globalSettings, isSuccess } = useSettings();
 
+  const { hours, minutes, day, month, year } = useCurrentTime();
+
   const settings = useMemo(() => {
     if (!isSuccess) {
       return initialSettings.map((item) => ({
         ...item
       }));
     }
+
     return initialSettings.map((item) => ({
       ...item,
       label: item.getLabel
-        ? `${item.label}: ${item.getLabel(globalSettings)}`
+        ? `${item.label}: ${item.getLabel(
+            item.key === 'set_time' || item.key === 'set_date'
+              ? { hours, minutes, day, month, year }
+              : globalSettings
+          )}`
         : item.label
     }));
-  }, [globalSettings, isSuccess]);
+  }, [globalSettings, isSuccess, hours, minutes, day, month, year]);
 
   useHandleGestures(
     {

--- a/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
@@ -34,7 +34,7 @@ const initialSettings: SettingsItem[] = [
     key: 'set_date',
     label: 'Set Date',
     getLabel: ({ day, month, year }: TimeDateValues) =>
-      `${day}/${month}/${year}`,
+      `${year}-${month}-${day}`,
     visible: true,
     value: false
   },

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneConfig.tsx
@@ -15,12 +15,13 @@ import Styled, {
   MARQUEE_MIN_TEXT_LENGTH
 } from '../../../../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../../../../styles/utils/calculateOptionPosition';
+import type { Settings } from '@meticulous-home/espresso-api';
 
 const initialSettings: SettingsItem[] = [
   {
     key: 'timezone_sync',
     label: 'Automatic',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       settings.timezone_sync === 'automatic' ? 'ENABLED' : 'DISABLED',
     visible: true
   },

--- a/src/components/Settings/BrewSettings.tsx
+++ b/src/components/Settings/BrewSettings.tsx
@@ -17,24 +17,25 @@ import Styled, {
   MARQUEE_MIN_TEXT_LENGTH
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
+import type { Settings } from '@meticulous-home/espresso-api';
 
 const initialSettings: SettingsItem[] = [
   {
     key: 'auto_start_shot',
     label: 'Start',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       `${settings.auto_start_shot ? 'Automatic' : 'On button press'}`
   },
   {
     key: 'auto_purge_after_shot',
     label: 'Purge',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       `${settings.auto_purge_after_shot ? 'Automatic' : 'On button press'}`
   },
   {
     key: 'heat_timeout_after_shot',
     label: 'Pre/Post-heat',
-    getLabel: (settings) => `${settings.heating_timeout} min`,
+    getLabel: (settings: Settings) => `${settings.heating_timeout} min`,
     visible: true
   },
   {

--- a/src/components/Settings/ScrollDirection.tsx
+++ b/src/components/Settings/ScrollDirection.tsx
@@ -14,18 +14,19 @@ import Styled, {
   MARQUEE_MIN_TEXT_LENGTH
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
+import type { Settings } from '@meticulous-home/espresso-api';
 
 const initialSettings: SettingsItem[] = [
   {
     key: 'home',
     label: 'Profiles',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       `${settings.reverse_scrolling.home ? 'Reversed' : 'Classic'}`
   },
   {
     key: 'keyboard',
     label: 'Keyboard',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       `${settings.reverse_scrolling.keyboard ? 'Reversed' : 'Classic'}`
   },
   {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -14,6 +14,7 @@ import type { SettingsItem } from '../../types';
 
 import Styled, { VIEWPORT_HEIGHT } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
+import type { Settings } from '@meticulous-home/espresso-api';
 
 const initialSettings: SettingsItem[] = [
   {
@@ -29,7 +30,7 @@ const initialSettings: SettingsItem[] = [
   {
     key: 'enable_sounds',
     label: 'sounds',
-    getLabel: (settings) =>
+    getLabel: (settings: Settings) =>
       `${settings.enable_sounds ? 'ENABLED' : 'DISABLED'}`,
     visible: true
   },

--- a/src/hooks/useCurrentTime.ts
+++ b/src/hooks/useCurrentTime.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export function useCurrentTime() {
+  const [time, setTime] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTime(new Date());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return {
+    hours: time.getHours().toString().padStart(2, '0'),
+    minutes: time.getMinutes().toString().padStart(2, '0'),
+    day: time.getDate().toString().padStart(2, '0'),
+    month: (time.getMonth() + 1).toString().padStart(2, '0'),
+    year: time.getFullYear().toString()
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -155,11 +155,19 @@ export interface PressetSettings {
   settings: Record<SettingsKeys, string | number>[];
 }
 
+export type TimeDateValues = {
+  hours: string;
+  minutes: string;
+  day: string;
+  month: string;
+  year: string;
+};
+
 export type SettingsItem = {
   value?: number | string | boolean;
   key: string;
   label?: string;
-  getLabel?: (settings: Settings) => string;
+  getLabel?: (values: Settings | TimeDateValues) => string;
   shortLabel?: string;
   visible?: boolean;
   hasSeparator?: boolean;


### PR DESCRIPTION
## What was done?
Show time and date in `Time & Date` settings on context menu

<img width="330" alt="image" src="https://github.com/user-attachments/assets/63146db0-6e6c-4e66-a183-6371b1e7d549" />


## Why?
A way is required to view the time or date without strictly accessing the settings or waiting for the idle screen.
