### PR TITLE
Remove trailing semicolons from motor hot and cold keys

### DIFF
--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -10,8 +10,8 @@ import { APIError } from '@meticulous-home/espresso-api/dist';
 
 type ResponseOption = 'Update' | 'Auto Update' | 'Skip';
 
-export const MOTOR_HOT_KEY = 'motor_hot;';
-export const MOTOR_COLD_KEY = 'motor_cold;';
+export const MOTOR_HOT_KEY = 'motor_hot';
+export const MOTOR_COLD_KEY = 'motor_cold';
 
 export interface NotificationItem {
   id: string;


### PR DESCRIPTION
## What was done?
I modified the keys to identify if a notification is about the motor temperature and display an informative message.

## Why?
By removing the `;` in the message, the notifications were not processed correctly, and the informative message was not displayed.