### PR TITLE
Modify scale screen behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,7 @@ const App = (): JSX.Element => {
       // TODO: Ideally we'd get tare up/down events so we can zoom in full the scale gradually
       singleTare() {
         setScaleState(({ visible }) => ({
-          visible: true,
+          visible: screen.value !== 'calibrateScale',
           size: visible ? 'full' : 'small'
         }));
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,9 +76,8 @@ const App = (): JSX.Element => {
     size: 'small' | 'full';
   }>({ visible: false, size: 'small' });
 
-  const isQuickScaleVisible = scaleState.visible && scaleState.size === 'small';
   useEffect(() => {
-    const hide_timer = isQuickScaleVisible ? 10000 : 2 * 60 * 1000;
+    const hide_timer = scaleState.size === 'small' ? 10000 : 2 * 60 * 10000;
     const scheduleHide = () =>
       setTimeout(() => {
         setScaleState((state) => ({ ...state, visible: false }));
@@ -99,7 +98,7 @@ const App = (): JSX.Element => {
       clearTimeout(timer);
       subscription();
     };
-  }, [isQuickScaleVisible]);
+  }, [scaleState]);
 
   useHandleGestures(
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,12 +78,11 @@ const App = (): JSX.Element => {
 
   const isQuickScaleVisible = scaleState.visible && scaleState.size === 'small';
   useEffect(() => {
-    if (!isQuickScaleVisible) return;
-
+    const hide_timer = isQuickScaleVisible ? 10000 : 2 * 60 * 1000;
     const scheduleHide = () =>
       setTimeout(() => {
         setScaleState((state) => ({ ...state, visible: false }));
-      }, 10000);
+      }, hide_timer);
     let timer = scheduleHide();
 
     let lastSignificantWeight = store.getState().stats.sensors.w;

--- a/src/components/Scale/scale.css
+++ b/src/components/Scale/scale.css
@@ -73,7 +73,7 @@
 
 .scale-weight .weight-unit {
   position: absolute;
+  top: 60px;
   left: 100%;
-  margin-left: 5px;
-  font-size: 64px;
+  font-size: 50px;
 }


### PR DESCRIPTION
## What was done?
- fix the letter `g` on the scale screen.
- Hide quickScale on the CalibrateScale screen.
- Hide fullScale after two minutes without weight variations.

Before & After

<img src="https://github.com/user-attachments/assets/969d5814-86c9-4c12-a1a0-f4c10e260116" width="300" />
<img src="https://github.com/user-attachments/assets/3f51275b-94e9-4241-b5de-8438a013435b" width="300" />
<hr>
<img src="https://github.com/user-attachments/assets/f9cd0b4f-1f9d-49f8-8e70-5bee971935b1" width="300" />
<img src="https://github.com/user-attachments/assets/79415eb7-e30e-4a9c-9e90-20690e66da86" width="300" />
<hr> 

## Why?
- The letter "g," which represents grams, went out of the visible area of the screen in certain cases.
- It was requested to hide the full-screen scale after a certain time, rather than just dimming the screen brightness or switching to the idle screen.
- When calibrating the scale, it is not necessary to display anything related to the Scale screen.

## Additional comments & remarks
- The full-size scale will be hidden after 2 minutes without weight variations, in the same way as quick-scale. After being hidden, it will display the screen that was active at that moment.
- Even though the `quick-scale` is not displayed on the CalibrateScale screen, it is possible to view the full-size scale using the longTare gesture and hide it using either the longTare or doubleTare gestures.