### PR TITLE
Better notification management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,22 @@
 import { useEffect, useState } from 'react';
 import * as ReactDOM from 'react-dom/client';
-import { Provider, useSelector, useStore } from 'react-redux';
+import { Provider, useStore } from 'react-redux';
 
 import { useAppDispatch, useAppSelector } from './components/store/hooks';
 import { SocketManager } from './components/store/SocketManager';
 import { RootState, store } from './components/store/store';
 import { useHandleGestures } from './hooks/useHandleGestures';
-import {
-  setBubbleDisplay,
-  setScreen
-} from './components/store/features/screens/screens-slice';
+import { setBubbleDisplay } from './components/store/features/screens/screens-slice';
 import { Router } from './navigation/Router';
-import { notificationSelector } from './components/store/features/notifications/notification-slice';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IdleTimerProvider } from './hooks/useIdleTimer';
 import { setBrightness } from './api/api';
 import { Scale } from './components/Scale/Scale';
 import { VisibilityProvider } from './navigation/VisibilityContext';
-import { routes } from './navigation/routes';
+import {
+  useNotification,
+  useNotificationHandler
+} from './hooks/useNotification';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -53,9 +52,11 @@ const App = (): JSX.Element => {
 
   const isExtracting = useAppSelector((state) => state.stats?.extracting);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
-  const notifications = useSelector(notificationSelector.selectAll);
-
-  useEffect(() => {
+  // Inicializar notificaciones
+  useNotification();
+  // Manejar cambios de pantalla basados en notificaciones
+  useNotificationHandler();
+  /*  useEffect(() => {
     if (notifications.length > 0 && screen.value !== 'notifications') {
       dispatch(setScreen('notifications'));
       dispatch(setBubbleDisplay({ visible: false, component: null }));
@@ -69,7 +70,7 @@ const App = (): JSX.Element => {
         dispatch(setScreen(screen.prev));
       }
     }
-  }, [notifications]);
+  }, [notifications]); */
 
   const [scaleState, setScaleState] = useState<{
     visible: boolean;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,25 +52,9 @@ const App = (): JSX.Element => {
 
   const isExtracting = useAppSelector((state) => state.stats?.extracting);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
-  // Inicializar notificaciones
-  useNotification();
-  // Manejar cambios de pantalla basados en notificaciones
-  useNotificationHandler();
-  /*  useEffect(() => {
-    if (notifications.length > 0 && screen.value !== 'notifications') {
-      dispatch(setScreen('notifications'));
-      dispatch(setBubbleDisplay({ visible: false, component: null }));
-    }
 
-    if (notifications.length === 0 && screen.value === 'notifications') {
-      // Dont return to the idle screen
-      if (!screen.prev || routes[screen.prev].ignoreAsPrevious) {
-        dispatch(setScreen('pressets'));
-      } else {
-        dispatch(setScreen(screen.prev));
-      }
-    }
-  }, [notifications]); */
+  useNotification();
+  useNotificationHandler();
 
   const [scaleState, setScaleState] = useState<{
     visible: boolean;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -60,7 +60,7 @@ export function Notification(): JSX.Element {
           const { id, responses } = currentNotification;
           await acknowledgeNotification({
             id,
-            response: responses[selectedOption]
+            response: responses && responses[selectedOption]
           });
           dispatch(removeOneNotification(id));
         }
@@ -97,7 +97,7 @@ export function Notification(): JSX.Element {
   };
 
   const renderOptions = () => {
-    if (responses.length === 1) {
+    if (responses?.length === 1) {
       return (
         <button className="notification-button selected">
           {responses[0] || 'OK'}
@@ -116,9 +116,9 @@ export function Notification(): JSX.Element {
           </button>
         )}
         <button className="notification-button center selected">
-          {responses[selectedOption]}
+          {responses && responses[selectedOption]}
         </button>
-        {selectedOption < responses.length - 1 && (
+        {selectedOption < responses?.length - 1 && (
           <button
             className="notification-button right"
             disabled={!canSelectOption}

--- a/src/components/PurgePiston/PurgePiston.tsx
+++ b/src/components/PurgePiston/PurgePiston.tsx
@@ -139,8 +139,8 @@ export function PurgePiston(): JSX.Element {
 
   useEffect(() => {
     return () => {
-      pistonContainer.current.destroy();
-      blinkContainer.current.destroy();
+      pistonContainer.current?.destroy();
+      blinkContainer.current?.destroy();
     };
   }, []);
 

--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -113,7 +113,7 @@ export const SocketProviderValue = () => {
         }
 
         // When the machine is not in idle, lock the screen at Barometer
-        if (data?.name !== 'idle') {
+        if (data?.name !== 'idle' && data?.name !== 'boot') {
           dispatch(setScreen('barometer'));
         }
       }

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -86,7 +86,15 @@ const notificationSlice = createSlice({
   name: 'notifications',
   initialState,
   reducers: {
-    addOneNotification: notificationAdapter.upsertOne,
+    /*When the firmware is updated, two notifications are sent. 
+      It is literally impossible to click "Accept" on the first one because the mechanism responsible for gestures is not active.
+      When the second notification is displayed, the first one disappears but is not removed, leaving it lagging behind and keeping it in the notifications array.
+      To avoid that, before adding a new notification, we will clear any previous ones that may have been left behind.
+    */
+    addOneNotification: (state, action) => {
+      notificationAdapter.removeAll(state);
+      notificationAdapter.upsertOne(state, action.payload);
+    },
     removeOneNotification: notificationAdapter.removeOne,
     removeAllNotications: notificationAdapter.removeAll,
     setMotorHot: (state, action: PayloadAction<boolean>) => {

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -86,15 +86,7 @@ const notificationSlice = createSlice({
   name: 'notifications',
   initialState,
   reducers: {
-    /*When the firmware is updated, two notifications are sent. 
-      It is literally impossible to click "Accept" on the first one because the mechanism responsible for gestures is not active.
-      When the second notification is displayed, the first one disappears but is not removed, leaving it lagging behind and keeping it in the notifications array.
-      To avoid that, before adding a new notification, we will clear any previous ones that may have been left behind.
-    */
-    addOneNotification: (state, action) => {
-      notificationAdapter.removeAll(state);
-      notificationAdapter.upsertOne(state, action.payload);
-    },
+    addOneNotification: notificationAdapter.upsertOne,
     removeOneNotification: notificationAdapter.removeOne,
     removeAllNotications: notificationAdapter.removeAll,
     setMotorHot: (state, action: PayloadAction<boolean>) => {

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '../components/store/hooks';
+import {
+  loadNotifications,
+  notificationSelector
+} from '../components/store/features/notifications/notification-slice';
+import {
+  setScreen,
+  setBubbleDisplay
+} from '../components/store/features/screens/screens-slice';
+import { routes } from '../navigation/routes';
+export const useNotification = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(loadNotifications());
+  }, [dispatch]);
+};
+
+export const useNotificationHandler = () => {
+  const dispatch = useAppDispatch();
+  const notifications = useAppSelector(notificationSelector.selectAll);
+  const screen = useAppSelector((state) => state.screen);
+
+  useEffect(() => {
+    const handleScreenChange = () => {
+      if (notifications.length > 0 && screen.value !== 'notifications') {
+        dispatch(setScreen('notifications'));
+        dispatch(setBubbleDisplay({ visible: false, component: null }));
+      }
+
+      if (notifications.length === 0 && screen.value === 'notifications') {
+        const targetScreen =
+          !screen.prev || routes[screen.prev]?.ignoreAsPrevious
+            ? 'pressets'
+            : screen.prev;
+
+        dispatch(setScreen(targetScreen));
+      }
+    };
+
+    handleScreenChange();
+  }, [notifications, screen.value, dispatch, screen.prev]);
+};


### PR DESCRIPTION
## What was done?
Fixed the behavior of notifications that were not addressed and got 'stuck'.

## Why?
When a new notification arrived and with notifications being stuck, it caused issues with certain screens, making the machine remain on specific screens, such as Purge or Barometer.

## Additional comments & remarks
To handle stuck notifications, a fetch is performed to /notifications?acknowledged=false, then they are displayed and removed from both the frontend and the backend.