### PR TITLE
feat(preset-settings): allow running without saving

### DIFF
--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -5,6 +5,7 @@ import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { getPresetSettings } from '../../utils/preset';
 import {
   discardSettings,
+  runPresetOnce,
   savePreset,
   setNextSettingOption,
   setPrevSettingOption
@@ -139,6 +140,9 @@ export function PressetSettings(): JSX.Element {
           dispatch(setScreen('profileHome'));
         } else if (activeSetting.key == 'discard') {
           dispatch(discardSettings());
+          dispatch(setScreen('profileHome'));
+        } else if (activeSetting.key === 'brew_once') {
+          dispatch(runPresetOnce());
           dispatch(setScreen('profileHome'));
         } else if (activeSetting.key === 'name') {
           dispatch(setScreen('name'));

--- a/src/components/store/features/preset/preset-slice.ts
+++ b/src/components/store/features/preset/preset-slice.ts
@@ -18,7 +18,8 @@ import {
   saveProfile,
   deleteProfile,
   getDefaultProfiles,
-  getProfileDefaultImages
+  getProfileDefaultImages,
+  loadProfileData
 } from '../../../../api/profile';
 
 export interface PresetSettingInterface {
@@ -294,64 +295,70 @@ export const resetActiveSetting = createAsyncThunk(
   }
 );
 
+const getEditPreset = (presetState: PresetsState) => {
+  const updateSetting = presetState.updatingSettings;
+  const nameSetting = updateSetting.settings.find(
+    (setting) => setting.key === 'name' && setting.isInternal
+  );
+  const temperatureSetting = updateSetting.settings.find(
+    (setting) => setting.key === 'temperature' && setting.isInternal
+  );
+  const weight = updateSetting.settings.find(
+    (setting) => setting.key === 'output' && setting.isInternal
+  );
+
+  const display = updateSetting.settings.find(
+    (setting) => setting.key === 'image' && setting.isInternal
+  );
+
+  const profileSettings =
+    updateSetting.settings.filter((setting) => !setting.isInternal) || [];
+
+  const activePreset = {
+    ...presetState.activePreset,
+    settings: [...updateSetting.settings],
+    name: nameSetting.value as string
+  };
+
+  presetState.activePreset = { ...activePreset };
+
+  const activeIndex = presetState.activeIndexSwiper;
+  const copyListPresets = [...presetState.value];
+  copyListPresets[activeIndex] = {
+    ...copyListPresets[activeIndex],
+    name: updateSetting.settings[0]?.value.toString(),
+    settings: [...updateSetting.settings]
+  };
+  presetState.value = [...copyListPresets];
+
+  const body = cleanupInternalProfile({
+    ...presetState.activePreset,
+    display: {
+      ...presetState.activePreset.display,
+      image: display
+        ? `${display.value}`
+        : presetState.activePreset.display.image
+    },
+    temperature: temperatureSetting.value as number,
+    stages: presetState.activePreset.stages ?? simpleJson.stages,
+    final_weight: weight.value as number,
+    variables: profileSettings.map((p) => ({
+      name: p.label,
+      key: p.key,
+      type: p.externalType,
+      value: p.value as number
+    }))
+  });
+
+  return body;
+};
+
 export const savePreset = createAsyncThunk(
   'presetData/savePreset',
   async (_, { getState, dispatch }) => {
     const state = getState() as RootState;
     const presetState = { ...state.presets };
-    const updateSetting = presetState.updatingSettings;
-    const nameSetting = updateSetting.settings.find(
-      (setting) => setting.key === 'name' && setting.isInternal
-    );
-    const temperatureSetting = updateSetting.settings.find(
-      (setting) => setting.key === 'temperature' && setting.isInternal
-    );
-    const weight = updateSetting.settings.find(
-      (setting) => setting.key === 'output' && setting.isInternal
-    );
-
-    const display = updateSetting.settings.find(
-      (setting) => setting.key === 'image' && setting.isInternal
-    );
-
-    const profileSettings =
-      updateSetting.settings.filter((setting) => !setting.isInternal) || [];
-
-    const activePreset = {
-      ...presetState.activePreset,
-      settings: [...updateSetting.settings],
-      name: nameSetting.value as string
-    };
-
-    presetState.activePreset = { ...activePreset };
-
-    const activeIndex = presetState.activeIndexSwiper;
-    const copyListPresets = [...presetState.value];
-    copyListPresets[activeIndex] = {
-      ...copyListPresets[activeIndex],
-      name: updateSetting.settings[0]?.value.toString(),
-      settings: [...updateSetting.settings]
-    };
-    presetState.value = [...copyListPresets];
-
-    const body = cleanupInternalProfile({
-      ...presetState.activePreset,
-      display: {
-        ...presetState.activePreset.display,
-        image: display
-          ? `${display.value}`
-          : presetState.activePreset.display.image
-      },
-      temperature: temperatureSetting.value as number,
-      stages: presetState.activePreset.stages ?? simpleJson.stages,
-      final_weight: weight.value as number,
-      variables: profileSettings.map((p) => ({
-        name: p.label,
-        key: p.key,
-        type: p.externalType,
-        value: p.value as number
-      }))
-    });
+    const body = getEditPreset(presetState);
 
     await saveProfile(body);
 
@@ -360,6 +367,17 @@ export const savePreset = createAsyncThunk(
         ...presetState
       })
     );
+  }
+);
+
+export const runPresetOnce = createAsyncThunk(
+  'presetData/runPresetOnce',
+  async (_, { getState }) => {
+    const state = getState() as RootState;
+    const presetState = { ...state.presets };
+    const body = getEditPreset(presetState);
+
+    await loadProfileData(body);
   }
 );
 

--- a/src/constants/setting.ts
+++ b/src/constants/setting.ts
@@ -14,6 +14,11 @@ export const DEFAULT_SETTING: StaticAction[] = [
   },
   {
     type: 'action',
+    key: 'brew_once',
+    label: 'Brew without saving'
+  },
+  {
+    type: 'action',
     key: 'discard',
     label: 'discard'
   }
@@ -24,6 +29,11 @@ export const TEMPORARY_SETTINGS: StaticAction[] = [
     type: 'action',
     key: 'save',
     label: 'save permanently'
+  },
+  {
+    type: 'action',
+    key: 'brew_once',
+    label: 'Brew without saving'
   },
   {
     type: 'action',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,7 +55,7 @@ export type DoseKey = 'dose';
 
 export type OutputKey = 'output';
 
-export type ActionKey = 'save' | 'discard' | 'delete';
+export type ActionKey = 'save' | 'discard' | 'brew_once' | 'delete';
 
 export type IPresetText = {
   type: 'text';


### PR DESCRIPTION
## What was done?
The ability to brew a profile without saving was added.
The nice loading cycle is missing for now but as we are working on removing it anyways we hopefully have a better solution very soon :)

![image](https://github.com/user-attachments/assets/1a51614a-170a-4ceb-b9e0-24bd34f7224b)

## Why?
Customer request
