### PR TITLE
Fix/show details default profiles

### DIFF
--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -1,9 +1,35 @@
-import { useEffect, useState, useRef, createElement } from 'react';
+import {
+  useEffect,
+  useState,
+  useRef,
+  createElement,
+  createContext,
+  useContext,
+  RefObject
+} from 'react';
 import { useHandleGestures } from '../../../src/hooks/useHandleGestures';
 import { memoizedRoutes } from '../../../src/utils';
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import './bubble.less';
+
+type BubbleContextType = {
+  bubbleContainerRef: RefObject<HTMLDivElement> | null;
+};
+
+export const BubbleContext = createContext<BubbleContextType | undefined>(
+  undefined
+);
+
+//We use a context to give the children of the Bubble component access to certain properties—in this particular case, to give them access to a DOM element so they can modify its styles.
+export const useBubbleContext = () => {
+  const context = useContext(BubbleContext);
+  if (!context)
+    throw new Error(
+      'useBubbleContext must be used within <BubbleContext.Provider>'
+    );
+  return context;
+};
 
 export default function Bubble() {
   const dispatch = useAppDispatch();
@@ -14,6 +40,7 @@ export default function Bubble() {
   });
 
   const prevComponentRef = useRef<string | null>(null);
+  const bubbleContainerRef = useRef<HTMLDivElement>(null);
 
   if (bubbleDisplay.component) {
     prevComponentRef.current = bubbleDisplay.component;
@@ -67,17 +94,19 @@ export default function Bubble() {
   };
 
   return (
-    <div
-      className={`main-bubble main-layout ${
-        !animationState.isAnimating
-          ? 'bubble-enter-animation'
-          : 'bubble-leave-animation'
-      } large`}
-      onAnimationEnd={handleAnimationEnd}
-    >
-      <div className="bubble-container">
-        {ActiveComponent && createElement(ActiveComponent)}
+    <BubbleContext.Provider value={{ bubbleContainerRef }}>
+      <div
+        className={`main-bubble main-layout ${
+          !animationState.isAnimating
+            ? 'bubble-enter-animation'
+            : 'bubble-leave-animation'
+        } large`}
+        onAnimationEnd={handleAnimationEnd}
+      >
+        <div className="bubble-container" ref={bubbleContainerRef}>
+          {ActiveComponent && createElement(ActiveComponent)}
+        </div>
       </div>
-    </div>
+    </BubbleContext.Provider>
   );
 }

--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -1,35 +1,9 @@
-import {
-  useEffect,
-  useState,
-  useRef,
-  createElement,
-  createContext,
-  useContext,
-  RefObject
-} from 'react';
+import { useEffect, useState, useRef, createElement } from 'react';
 import { useHandleGestures } from '../../../src/hooks/useHandleGestures';
 import { memoizedRoutes } from '../../../src/utils';
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import './bubble.less';
-
-type BubbleContextType = {
-  bubbleContainerRef: RefObject<HTMLDivElement> | null;
-};
-
-export const BubbleContext = createContext<BubbleContextType | undefined>(
-  undefined
-);
-
-//We use a context to give the children of the Bubble component access to certain properties—in this particular case, to give them access to a DOM element so they can modify its styles.
-export const useBubbleContext = () => {
-  const context = useContext(BubbleContext);
-  if (!context)
-    throw new Error(
-      'useBubbleContext must be used within <BubbleContext.Provider>'
-    );
-  return context;
-};
 
 export default function Bubble() {
   const dispatch = useAppDispatch();
@@ -40,7 +14,6 @@ export default function Bubble() {
   });
 
   const prevComponentRef = useRef<string | null>(null);
-  const bubbleContainerRef = useRef<HTMLDivElement>(null);
 
   if (bubbleDisplay.component) {
     prevComponentRef.current = bubbleDisplay.component;
@@ -94,19 +67,17 @@ export default function Bubble() {
   };
 
   return (
-    <BubbleContext.Provider value={{ bubbleContainerRef }}>
-      <div
-        className={`main-bubble main-layout ${
-          !animationState.isAnimating
-            ? 'bubble-enter-animation'
-            : 'bubble-leave-animation'
-        } large`}
-        onAnimationEnd={handleAnimationEnd}
-      >
-        <div className="bubble-container" ref={bubbleContainerRef}>
-          {ActiveComponent && createElement(ActiveComponent)}
-        </div>
+    <div
+      className={`main-bubble main-layout ${
+        !animationState.isAnimating
+          ? 'bubble-enter-animation'
+          : 'bubble-leave-animation'
+      } large`}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      <div className="bubble-container">
+        {ActiveComponent && createElement(ActiveComponent)}
       </div>
-    </BubbleContext.Provider>
+    </div>
   );
 }

--- a/src/components/DefaultProfiles/DefaultProfileDetails.tsx
+++ b/src/components/DefaultProfiles/DefaultProfileDetails.tsx
@@ -112,30 +112,19 @@ const BouncingArrow = styled.svg`
 
 export const DefaultProfileDetails = () => {
   const dispatch = useAppDispatch();
-  console.log('DefaultProfileDetails component rendered');
 
   const { defaultProfileSelected: defaultProfile } = useProfileContext();
 
   const descriptionDivRef = useRef<HTMLDivElement | null>(null);
 
   const prevScreen = useAppSelector((state) => state.screen.prev);
-  const currentScreen = useAppSelector((state) => state.screen.value);
   const [isScrollable, setIsScrollable] = useState(false);
   const [isAtBottom, setIsAtBottom] = useState(false);
-
-  console.log('prevScreen :: => ', prevScreen);
-  console.log('currentScreen :: => ', currentScreen);
-  console.log('defaultProfile :: => ', defaultProfile);
-
-  useEffect(() => {
-    console.log('defaultProfile triggers effect 😪 :: => ', defaultProfile);
-  }, [defaultProfile]);
 
   useEffect(() => {
     dispatch(setBubbleDisplay({ visible: false, component: 'quick-settings' }));
   }, []);
 
-  // Scroll control
   const mainContainerScroll = (up: boolean) => {
     if (!descriptionDivRef.current) return;
     descriptionDivRef.current.scrollTop += up ? -SCROLL_VALUE : SCROLL_VALUE;
@@ -184,8 +173,6 @@ export const DefaultProfileDetails = () => {
   const profileDescription =
     defaultProfile?.display?.description ||
     'Shared by a member of the community, this profile is ready for you to discover in the cup. Perfect for those who enjoy exploring new extractions and finding their own balance.';
-
-  console.log('profile_url :: => ', profileUrl);
 
   return (
     <Container>

--- a/src/components/DefaultProfiles/DefaultProfileDetails.tsx
+++ b/src/components/DefaultProfiles/DefaultProfileDetails.tsx
@@ -1,20 +1,102 @@
-import { useRef } from 'react';
-import { useAppDispatch } from '../store/hooks';
+import { useEffect, useRef } from 'react';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { api } from '../../api/api';
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { useProfileContext } from '../../context/ProfileContext';
+import { useBubbleContext } from '../Bubble/Bubble';
+import { styled } from 'styled-components';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
 
 const SCROLL_VALUE = 50;
+export const MainQuickSettings = styled.div`
+  height: 480px;
+  align-items: center;
+`;
+
+export const Wrapper = styled.div`
+  width: 100%;
+  padding: 24px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const ImageWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 32px;
+`;
+
+export const ProfileImage = styled.img<{ borderColor: string }>`
+  border: 8px solid ${(props) => props.borderColor};
+  display: block;
+  position: relative;
+  width: 66px;
+  height: 66px;
+`;
+
+export const Name = styled.p`
+  text-align: center;
+  font-size: 24px;
+  font-weight: bold;
+`;
+
+export const Description = styled.p`
+  white-space: pre-wrap;
+  overflow: hidden;
+  scroll-behavior: smooth;
+  max-height: 283px;
+  max-width: 85%;
+  margin: 0;
+`;
+
+export const BackButtonContainer = styled.div`
+  margin-top: 80px;
+  margin-bottom: 80px;
+  max-width: 40%;
+  border-radius: 9999px;
+  margin-inline: auto;
+  padding: 0;
+`;
+
+export const BackButtonInner = styled.div`
+  padding: 8px 32px;
+  width: auto;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+`;
 
 export const DefaultProfileDetails = () => {
+  const { bubbleContainerRef } = useBubbleContext();
+
   const dispatch = useAppDispatch();
 
   const { defaultProfileSelected: defaultProfile } = useProfileContext();
 
   const mainContainerRef = useRef<HTMLDivElement | null>(null);
+
+  //When our component is mounted, we modify the styles of its container — the Bubble component in this case.
+  //Once it is unmounted, we restore it to its original state.
+  useEffect(() => {
+    const $bubbleContainer = bubbleContainerRef?.current;
+    if (!$bubbleContainer) return;
+    const originalWidth = $bubbleContainer.style.width;
+    const originalPadding = $bubbleContainer.style.padding;
+
+    $bubbleContainer.style.width = '100%';
+    $bubbleContainer.style.padding = '0px';
+
+    return () => {
+      $bubbleContainer.style.width = originalWidth;
+      $bubbleContainer.style.padding = originalPadding;
+    };
+  }, []);
 
   useHandleGestures({
     left: () => {
@@ -41,72 +123,43 @@ export const DefaultProfileDetails = () => {
   };
 
   return (
-    <div
-      className="main-quick-settings"
-      style={{
-        height: 480,
-        alignItems: 'normal',
-        paddingTop: 100
-      }}
-    >
-      <div
-        style={{
-          width: '100%',
-          paddingLeft: '5px'
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center'
-          }}
-        >
-          <img
+    <MainQuickSettings className="main-quick-settings">
+      <Wrapper>
+        <ImageWrapper>
+          <ProfileImage
             src={`${API_URL}${api.getProfileImageUrl(profile_url)}`}
             alt="No image"
             width="50"
             height="50"
             className="profile-image image-prev"
-            style={{
-              border: `8px solid ${
-                defaultProfile.display?.accentColor ?? '#e0dcd0'
-              }`,
-              display: 'block',
-              position: 'relative'
-            }}
+            borderColor={defaultProfile?.display?.accentColor ?? '#e0dcd0'}
           />
-        </div>
-        <p>{defaultProfile.name}</p>
-        <p
-          style={{
-            padding: '0px 10px',
-            whiteSpace: 'pre-wrap',
-            overflow: 'hidden',
-            scrollBehavior: 'smooth',
-            maxHeight: 283
-          }}
-          ref={mainContainerRef}
-        >
-          {defaultProfile.display?.description}
-          <div
-            className={`settings-item active-setting`}
-            style={{
-              marginTop: 80,
-              marginBottom: 80
-            }}
-          >
-            <div
-              className="settings-entry"
-              style={{
-                padding: '6px'
-              }}
-            >
+        </ImageWrapper>
+        <Name>{defaultProfile?.name}</Name>
+        <Description ref={mainContainerRef}>
+          {defaultProfile?.display?.description ||
+            'Shared by a member of the community, this profile is ready for you to discover in the cup. Perfect for those who enjoy exploring new extractions and finding their own balance.'}
+          <BackButtonContainer className="settings-item active-setting">
+            <BackButtonInner className="settings-entry">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m12 19-7-7 7-7" />
+                <path d="M19 12H5" />
+              </svg>
               <span>Back</span>
-            </div>
-          </div>
-        </p>
-      </div>
-    </div>
+            </BackButtonInner>
+          </BackButtonContainer>
+        </Description>
+      </Wrapper>
+    </MainQuickSettings>
   );
 };

--- a/src/components/DefaultProfiles/DefaultProfileDetails.tsx
+++ b/src/components/DefaultProfiles/DefaultProfileDetails.tsx
@@ -1,102 +1,145 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { api } from '../../api/api';
-import { setBubbleDisplay } from '../store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../store/features/screens/screens-slice';
 import { useProfileContext } from '../../context/ProfileContext';
-import { useBubbleContext } from '../Bubble/Bubble';
-import { styled } from 'styled-components';
+import { styled, keyframes } from 'styled-components';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
 
 const SCROLL_VALUE = 50;
-export const MainQuickSettings = styled.div`
-  height: 480px;
-  align-items: center;
-`;
 
-export const Wrapper = styled.div`
+const Container = styled.div`
+  position: relative;
   width: 100%;
-  padding: 24px;
+  height: 100%;
   display: flex;
-  justify-content: center;
   flex-direction: column;
   align-items: center;
+  padding: 24px;
+  box-sizing: border-box;
 `;
 
-export const ImageWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
+const ImageWrapper = styled.div`
   margin-top: 32px;
+  margin-bottom: 24px;
 `;
 
-export const ProfileImage = styled.img<{ borderColor: string }>`
-  border: 8px solid ${(props) => props.borderColor};
-  display: block;
-  position: relative;
-  width: 66px;
-  height: 66px;
+const ImageContainer = styled.div<{ accentColor: string }>`
+  width: 80px;
+  height: 80px;
+  border: 8px solid ${({ accentColor }) => accentColor};
+  border-radius: 4px;
 `;
 
-export const Name = styled.p`
+const ProfileImage = styled.img<{ src: string; alt: string }>`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const Name = styled.h2`
   text-align: center;
   font-size: 24px;
   font-weight: bold;
+  margin: 0 0 16px 0;
 `;
 
-export const Description = styled.p`
+const Description = styled.p`
+  position: relative;
   white-space: pre-wrap;
   overflow: hidden;
   scroll-behavior: smooth;
-  max-height: 283px;
+  height: 180px;
+  width: 100%;
   max-width: 85%;
-  margin: 0;
+  margin: 0 0 64px 0;
+  padding: 0 16px;
+  color: #e6e6e6;
 `;
 
-export const BackButtonContainer = styled.div`
-  margin-top: 80px;
-  margin-bottom: 80px;
-  max-width: 40%;
-  border-radius: 9999px;
-  margin-inline: auto;
-  padding: 0;
-`;
-
-export const BackButtonInner = styled.div`
-  padding: 8px 32px;
-  width: auto;
+const BackButtonContainer = styled.div`
+  position: absolute;
+  bottom: 32px;
+  left: 0;
+  right: 0;
+  display: flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+`;
+
+const BackButtonInner = styled.button`
+  background-color: #f5c444;
+  color: #000000;
+  font-weight: bold;
+  padding: 8px 32px;
+  border-radius: 9999px;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 16px;
+  border: none;
+`;
+
+const bounce = keyframes`
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+`;
+
+const ScrollIndicatorWrapper = styled.div<{ visible: boolean }>`
+  position: absolute;
+  bottom: 90px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  display: ${(props) => (props.visible ? 'flex' : 'none')};
+  justify-content: center;
+  color: #f5c444;
+`;
+
+const BouncingArrow = styled.svg`
+  animation: ${bounce} 2s infinite;
 `;
 
 export const DefaultProfileDetails = () => {
-  const { bubbleContainerRef } = useBubbleContext();
-
   const dispatch = useAppDispatch();
+  console.log('DefaultProfileDetails component rendered');
 
   const { defaultProfileSelected: defaultProfile } = useProfileContext();
 
-  const mainContainerRef = useRef<HTMLDivElement | null>(null);
+  const descriptionDivRef = useRef<HTMLDivElement | null>(null);
 
-  //When our component is mounted, we modify the styles of its container — the Bubble component in this case.
-  //Once it is unmounted, we restore it to its original state.
+  const prevScreen = useAppSelector((state) => state.screen.prev);
+  const currentScreen = useAppSelector((state) => state.screen.value);
+  const [isScrollable, setIsScrollable] = useState(false);
+  const [isAtBottom, setIsAtBottom] = useState(false);
+
+  console.log('prevScreen :: => ', prevScreen);
+  console.log('currentScreen :: => ', currentScreen);
+  console.log('defaultProfile :: => ', defaultProfile);
+
   useEffect(() => {
-    const $bubbleContainer = bubbleContainerRef?.current;
-    if (!$bubbleContainer) return;
-    const originalWidth = $bubbleContainer.style.width;
-    const originalPadding = $bubbleContainer.style.padding;
+    console.log('defaultProfile triggers effect 😪 :: => ', defaultProfile);
+  }, [defaultProfile]);
 
-    $bubbleContainer.style.width = '100%';
-    $bubbleContainer.style.padding = '0px';
-
-    return () => {
-      $bubbleContainer.style.width = originalWidth;
-      $bubbleContainer.style.padding = originalPadding;
-    };
+  useEffect(() => {
+    dispatch(setBubbleDisplay({ visible: false, component: 'quick-settings' }));
   }, []);
+
+  // Scroll control
+  const mainContainerScroll = (up: boolean) => {
+    if (!descriptionDivRef.current) return;
+    descriptionDivRef.current.scrollTop += up ? -SCROLL_VALUE : SCROLL_VALUE;
+  };
 
   useHandleGestures({
     left: () => {
@@ -106,60 +149,94 @@ export const DefaultProfileDetails = () => {
       mainContainerScroll(false);
     },
     pressDown: async () => {
+      dispatch(setScreen(prevScreen));
       dispatch(
-        setBubbleDisplay({ visible: true, component: 'quick-settings' })
+        setBubbleDisplay({ visible: false, component: 'quick-settings' })
       );
     }
   });
 
-  const profile_url = defaultProfile.display?.image || '';
+  // Check scrollability and scroll position
+  useEffect(() => {
+    const $descriptionDiv = descriptionDivRef.current;
+    if (!$descriptionDiv) return;
 
-  const mainContainerScroll = (up: boolean) => {
-    if (!mainContainerRef.current) {
-      return;
-    }
+    const SCROLL_BOTTOM_THRESHOLD = 5;
 
-    mainContainerRef.current.scrollTop += up ? -SCROLL_VALUE : SCROLL_VALUE;
-  };
+    const checkScrollState = () => {
+      setIsScrollable(
+        $descriptionDiv.scrollHeight > $descriptionDiv.clientHeight
+      );
+      const atBottom =
+        $descriptionDiv.scrollHeight - $descriptionDiv.scrollTop <=
+        $descriptionDiv.clientHeight + SCROLL_BOTTOM_THRESHOLD;
+      setIsAtBottom(atBottom);
+    };
+
+    checkScrollState();
+    $descriptionDiv.addEventListener('scroll', checkScrollState);
+
+    return () =>
+      $descriptionDiv.removeEventListener('scroll', checkScrollState);
+  }, []);
+
+  const profileUrl = defaultProfile?.display?.image || '';
+  const profileDescription =
+    defaultProfile?.display?.description ||
+    'Shared by a member of the community, this profile is ready for you to discover in the cup. Perfect for those who enjoy exploring new extractions and finding their own balance.';
+
+  console.log('profile_url :: => ', profileUrl);
 
   return (
-    <MainQuickSettings className="main-quick-settings">
-      <Wrapper>
-        <ImageWrapper>
+    <Container>
+      <ImageWrapper>
+        <ImageContainer
+          accentColor={defaultProfile?.display?.accentColor ?? '#e0dcd0'}
+        >
           <ProfileImage
-            src={`${API_URL}${api.getProfileImageUrl(profile_url)}`}
+            src={`${API_URL}${api.getProfileImageUrl(profileUrl)}`}
             alt="No image"
-            width="50"
-            height="50"
-            className="profile-image image-prev"
-            borderColor={defaultProfile?.display?.accentColor ?? '#e0dcd0'}
           />
-        </ImageWrapper>
-        <Name>{defaultProfile?.name}</Name>
-        <Description ref={mainContainerRef}>
-          {defaultProfile?.display?.description ||
-            'Shared by a member of the community, this profile is ready for you to discover in the cup. Perfect for those who enjoy exploring new extractions and finding their own balance.'}
-          <BackButtonContainer className="settings-item active-setting">
-            <BackButtonInner className="settings-entry">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="m12 19-7-7 7-7" />
-                <path d="M19 12H5" />
-              </svg>
-              <span>Back</span>
-            </BackButtonInner>
-          </BackButtonContainer>
-        </Description>
-      </Wrapper>
-    </MainQuickSettings>
+        </ImageContainer>
+      </ImageWrapper>
+      <Name>{defaultProfile?.name}</Name>
+      <Description ref={descriptionDivRef}>{profileDescription}</Description>
+
+      <ScrollIndicatorWrapper visible={isScrollable && !isAtBottom}>
+        <BouncingArrow
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </BouncingArrow>
+      </ScrollIndicatorWrapper>
+
+      <BackButtonContainer>
+        <BackButtonInner>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m12 19-7-7 7-7" />
+            <path d="M19 12H5" />
+          </svg>
+          <span>Back</span>
+        </BackButtonInner>
+      </BackButtonContainer>
+    </Container>
   );
 };

--- a/src/components/DefaultProfiles/DefaultProfiles.tsx
+++ b/src/components/DefaultProfiles/DefaultProfiles.tsx
@@ -64,6 +64,7 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
   const createProfile = useSavePreset();
   const [activeIndex, setActiveIndex] = useState(0);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const currentScreen = useAppSelector((state) => state.screen.value);
 
   const { data: allDefaultProfiles, isLoading } = useDefaultProfiles();
   const defaultProfiles = allDefaultProfiles
@@ -138,7 +139,8 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
       // This is important to avoid keeping the last selected profile when navigating back
       // to the default profiles screen
       setActiveIndex(0);
-      setDefaultProfileSelected(null);
+      //Since DefaultProfileDetails is now treated as a screen and not as an element within the bubble display, we need to retain the selected profile so that the information is preserved when viewing its details.
+      if (currentScreen === 'profileHome') setDefaultProfileSelected(null); //
     };
   }, []);
 

--- a/src/components/DefaultProfiles/DefaultProfiles.tsx
+++ b/src/components/DefaultProfiles/DefaultProfiles.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 
 import { RouteProps } from '../../navigation';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
@@ -67,9 +67,13 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
   const currentScreen = useAppSelector((state) => state.screen.value);
 
   const { data: allDefaultProfiles, isLoading } = useDefaultProfiles();
-  const defaultProfiles = allDefaultProfiles
-    ? [...allDefaultProfiles.default, ...allDefaultProfiles.community]
-    : [];
+  const defaultProfiles = useMemo(
+    () =>
+      allDefaultProfiles
+        ? [...allDefaultProfiles.default, ...allDefaultProfiles.community]
+        : [],
+    [allDefaultProfiles]
+  );
 
   const dispatch = useAppDispatch();
   const { data: defaultImages, isLoading: defaultImagesLoading } =
@@ -123,7 +127,7 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
     } else {
       setDefaultProfileSelected(null);
     }
-  }, [activeIndex, defaultProfiles.length]);
+  }, [activeIndex, defaultProfiles.length, defaultImages.length]);
 
   useEffect(() => {
     if (!isLoading && defaultProfiles.length === 0) {

--- a/src/components/PressetSettings/PressetProfileImage.tsx
+++ b/src/components/PressetSettings/PressetProfileImage.tsx
@@ -15,8 +15,24 @@ import { useDimScreen } from '../../hooks/useDimScreen';
 import { api } from '../../api/api';
 import { useProfileDefaultImages } from '../../hooks/useProfiles';
 import { useProfileContext } from '../../context/ProfileContext';
+import { styled } from 'styled-components';
 
 const API_URL = window.env?.SERVER_URL || 'http://localhost:8080';
+
+const SwiperWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+
+  .swiper-pagination {
+    top: 352px;
+    line-height: 0;
+  }
+
+  .swiper {
+    width: 100%;
+    height: 100%;
+  }
+`;
 
 export const PressetProfileImage = ({ transitioning }: RouteProps) => {
   const dispatch = useDispatch();
@@ -85,7 +101,7 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
   }
 
   return (
-    <div className="image-swiper">
+    <SwiperWrapper>
       <Swiper
         effect={'coverflow'}
         coverflowEffect={{
@@ -113,7 +129,15 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
       >
         {images.length &&
           images.map((image) => (
-            <SwiperSlide key={image}>
+            <SwiperSlide
+              key={image}
+              style={{
+                textAlign: 'center',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center'
+              }}
+            >
               {() => (
                 <div>
                   <img
@@ -131,6 +155,6 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
             </SwiperSlide>
           ))}
       </Swiper>
-    </div>
+    </SwiperWrapper>
   );
 };

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -207,12 +207,7 @@ export function QuickSettings(): JSX.Element {
             break;
           }
           case 'details': {
-            dispatch(
-              setBubbleDisplay({
-                visible: true,
-                component: 'defaultProfileDetails'
-              })
-            );
+            dispatch(setScreen('defaultProfileDetails'));
             break;
           }
           case 'disable_ui_features': {

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -5,7 +5,6 @@ export type ScreenType =
   | 'ready'
   | 'barometer'
   | 'profileHome'
-  | 'profileHome'
   | 'pressetSettings'
   | 'name'
   | 'pressure'


### PR DESCRIPTION
## What was done?

I fixed a bug that was caused by the display property not existing in community profiles. I updated the screen that shows the default profile details, and added a "generic" description for profiles that don't have their own description.  Fixes image display when editing profile; they no longer overflow the viewport. 

| Before | After |
|:----------|:--------:|
| ![image](https://github.com/user-attachments/assets/52c54fd2-e7b2-4b67-b33d-3d4e1c85b21c) | <img alt="image" src="https://github.com/user-attachments/assets/fe718c8b-7323-4ffc-b3f5-dce633464a65" /> | 
![image](https://github.com/user-attachments/assets/05fa52ce-5254-4c99-8702-f9f407718846) | <img alt="image" src="https://github.com/user-attachments/assets/59e38229-7781-45c7-851b-ee62bc6e6ed7" /> |
<img width="361" alt="image" src="https://github.com/user-attachments/assets/2d6be943-a9ce-477b-8c1b-b2289dad1ad5" /> | <img width="362" alt="image" src="https://github.com/user-attachments/assets/9ca4a61e-e3b0-4472-935e-1a1e1b6450d2" /> | 


## Why?
The app was crashing when trying to access the default profile details, and the layout seemed a bit scattered.
