### PR TITLE
fix(timezone): use the settings design language for the timezones as well

### DIFF
--- a/src/components/Settings/Advanced/TimeDate/TimeZone/CountrySettings.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/CountrySettings.tsx
@@ -1,17 +1,20 @@
-import { Swiper, SwiperSlide } from 'swiper/react';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useHandleGestures } from '../../../../../hooks/useHandleGestures';
-import { Option, TextContainer, Title } from './Timezone.styled';
 import { setScreen } from '../../../../store/features/screens/screens-slice';
 import { setCountry } from '../../../../store/features/settings/settings-slice';
 import { getTimezoneRegion } from '../../../../../api/api';
 import { Regions } from '@meticulous-home/espresso-api';
 import { useDimScreen } from '../../../../../hooks/useDimScreen';
+import {
+  Container,
+  SettingsEntry,
+  SettingsLabel,
+  Title,
+  Viewport
+} from './Timezone.styled';
 
 export default function CountrySettings() {
-  const [swiper, setSwiper] = useState(null);
-  const [animationStyle, setAnimationStyle] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
 
   const [availableCountries, setAvailableCountries] = useState<Regions>({
@@ -26,11 +29,6 @@ export default function CountrySettings() {
   useDimScreen();
 
   useEffect(() => {
-    if (swiper) swiper.slideTo(activeIndex);
-  }, [activeIndex, swiper]);
-
-  useEffect(() => {
-    console.log('requesting countries');
     try {
       getTimezoneRegion('countries', countryLetter.toLowerCase()).then(
         (result) => {
@@ -43,57 +41,18 @@ export default function CountrySettings() {
     }
   }, []);
 
-  const slides = useMemo(() => {
-    if (availableCountries['countries'].length == 0) {
-      return [
-        <SwiperSlide className="presset-option-item" key={`option-back`}>
-          <div className={`${animationStyle}`}>
-            <Option isactive={activeIndex === 0}>Back</Option>
-          </div>
-        </SwiperSlide>
-      ];
-    } else {
-      return [
-        <SwiperSlide className="presset-option-item" key={`option-back`}>
-          <div className={`${animationStyle}`}>
-            <Option isactive={activeIndex === 0}>Back</Option>
-          </div>
-        </SwiperSlide>,
-        ...availableCountries['countries'].map((country, index) => {
-          const isactive = index + 1 === activeIndex;
-          return (
-            <SwiperSlide
-              className="presset-option-item"
-              key={`option-${index + 1}`}
-            >
-              <div className={`${animationStyle}`}>
-                <TextContainer
-                  neednoWrap={country.length > 11}
-                  isactive={isactive}
-                >
-                  <Option isactive={isactive}>{country}</Option>
-                </TextContainer>
-              </div>
-            </SwiperSlide>
-          );
-        })
-      ];
-    }
-  }, [activeIndex, animationStyle, availableCountries]);
-
   useHandleGestures(
     {
       left() {
         const nextActiveIndex = activeIndex - 1;
         if (nextActiveIndex < 0) return;
-        console.log('left, nextActiveIndex', nextActiveIndex);
         setActiveIndex(nextActiveIndex);
       },
       right() {
         const nextActiveIndex = activeIndex + 1;
-        if (nextActiveIndex >= slides.length) return;
+        if (nextActiveIndex >= availableCountries['countries'].length + 1)
+          return;
         setActiveIndex(nextActiveIndex);
-        console.log('rigth, nextActiveIndex', nextActiveIndex);
       },
       pressDown() {
         if (activeIndex === 0) {
@@ -108,32 +67,44 @@ export default function CountrySettings() {
   );
 
   return (
-    <>
-      <Title>countries</Title>
-      <div className="presset-container">
-        <div className="presset-options">
-          <Swiper
-            onSwiper={setSwiper}
-            slidesPerView={9}
-            allowTouchMove={false}
-            direction="vertical"
-            autoHeight={false}
-            centeredSlides={true}
-            initialSlide={0}
-            onSlideNextTransitionStart={() => {
-              setAnimationStyle('animation-next');
-            }}
-            onSlidePrevTransitionStart={() =>
-              setAnimationStyle('animation-prev')
-            }
-            onSlideChangeTransitionEnd={() => setAnimationStyle('')}
+    <Container>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          background: 'linear-gradient(black 20%, transparent 50%, black 80%)',
+          pointerEvents: 'none',
+          zIndex: 1
+        }}
+      />
+      <Title>Country</Title>
+
+      <Viewport $activeIndex={activeIndex}>
+        <SettingsEntry $active={activeIndex == 0} key="back">
+          <SettingsLabel
+            $active={activeIndex == 0}
+            style={activeIndex == 0 ? { color: '#f5c444' } : {}}
           >
-            {slides}
-          </Swiper>
-        </div>
-        <div className="fade fade-top"></div>
-        <div className="fade fade-bottom"></div>
-      </div>
-    </>
+            Back
+          </SettingsLabel>
+        </SettingsEntry>
+        {availableCountries['countries'].map((country, index) => {
+          const isActive = activeIndex - 1 == index;
+
+          return (
+            <SettingsEntry
+              $marquee={isActive && country.length > 24}
+              $active={isActive}
+              key={index}
+            >
+              <SettingsLabel $active={isActive}>{country}</SettingsLabel>
+            </SettingsEntry>
+          );
+        })}
+      </Viewport>
+    </Container>
   );
 }

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import { useHandleGestures } from '../../../../../hooks/useHandleGestures';
 import {
   setBubbleDisplay,
   setScreen
 } from '../../../../store/features/screens/screens-slice';
-import { Option, TextContainer, Title } from './Timezone.styled';
+import {
+  Container,
+  SettingsEntry,
+  SettingsLabel,
+  Title,
+  Viewport
+} from './Timezone.styled';
 import { getTimezoneRegion, setTimezone } from '../../../../../api/api';
 import { styled } from 'styled-components';
 import { Regions } from '@meticulous-home/espresso-api';
@@ -19,8 +24,6 @@ const TimeZone = styled.span<{ isactive?: boolean }>`
 `;
 
 export default function TimeZoneSettings() {
-  const [swiper, setSwiper] = useState(null);
-  const [animationStyle, setAnimationStyle] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
 
   const country = useAppSelector((state) => state.settings.country);
@@ -33,10 +36,6 @@ export default function TimeZoneSettings() {
   useDimScreen();
 
   useEffect(() => {
-    if (swiper) swiper.slideTo(activeIndex);
-  }, [activeIndex, swiper]);
-
-  useEffect(() => {
     try {
       getTimezoneRegion('cities', country).then((result) => {
         setTimeZones(result);
@@ -46,37 +45,6 @@ export default function TimeZoneSettings() {
       setTimeZones({ cities: [] });
     }
   }, []);
-
-  const slides = useMemo(() => {
-    return [
-      <SwiperSlide className="presset-option-item" key={`option-back`}>
-        <div className={`${animationStyle}`}>
-          <Option isactive={activeIndex === 0}>Back</Option>
-        </div>
-      </SwiperSlide>,
-      ...timeZones['cities'].map((timezone, index) => {
-        const isactive = index + 1 === activeIndex;
-        const city = Object.keys(timezone)[0];
-        const tz_name = Object.values(timezone)[0];
-        const neednoWrap = city.length + tz_name.length > 11;
-        return (
-          <SwiperSlide
-            className="presset-option-item"
-            key={`option-${index + 1}`}
-          >
-            <div className={`${animationStyle}`}>
-              <TextContainer neednoWrap={neednoWrap} isactive={isactive}>
-                <Option isactive={isactive}>
-                  <span>{city}</span>{' '}
-                  <TimeZone isactive={isactive}>{tz_name}</TimeZone>
-                </Option>
-              </TextContainer>
-            </div>
-          </SwiperSlide>
-        );
-      })
-    ];
-  }, [activeIndex, animationStyle, timeZones]);
 
   useHandleGestures(
     {
@@ -88,7 +56,7 @@ export default function TimeZoneSettings() {
       },
       right() {
         const nextActiveIndex = activeIndex + 1;
-        if (nextActiveIndex >= slides.length) return;
+        if (nextActiveIndex >= timeZones['cities'].length + 1) return;
         setActiveIndex(nextActiveIndex);
         console.log('rigth, nextActiveIndex', nextActiveIndex);
       },
@@ -111,32 +79,47 @@ export default function TimeZoneSettings() {
     bubbleDisplay.visible
   );
   return (
-    <>
-      <Title>timezones</Title>
-      <div className="presset-container">
-        <div className="presset-options">
-          <Swiper
-            onSwiper={setSwiper}
-            slidesPerView={9}
-            allowTouchMove={false}
-            direction="vertical"
-            autoHeight={false}
-            centeredSlides={true}
-            initialSlide={0}
-            onSlideNextTransitionStart={() => {
-              setAnimationStyle('animation-next');
-            }}
-            onSlidePrevTransitionStart={() =>
-              setAnimationStyle('animation-prev')
-            }
-            onSlideChangeTransitionEnd={() => setAnimationStyle('')}
+    <Container>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          background: 'linear-gradient(black 20%, transparent 50%, black 80%)',
+          pointerEvents: 'none',
+          zIndex: 1
+        }}
+      />
+      <Title>Timezones</Title>
+
+      <Viewport $activeIndex={activeIndex}>
+        <SettingsEntry $active={activeIndex == 0} key="back">
+          <SettingsLabel
+            $active={activeIndex == 0}
+            style={activeIndex == 0 ? { color: '#f5c444' } : {}}
           >
-            {slides}
-          </Swiper>
-        </div>
-        <div className="fade fade-top"></div>
-        <div className="fade fade-bottom"></div>
-      </div>
-    </>
+            Back
+          </SettingsLabel>
+        </SettingsEntry>
+        {timeZones['cities'].map((timezone, index) => {
+          const isActive = activeIndex - 1 == index;
+          const city = Object.keys(timezone)[0];
+          const tz_name = Object.values(timezone)[0];
+
+          return (
+            <SettingsEntry
+              $marquee={isActive && city.length + tz_name.length > 24}
+              $active={isActive}
+              key={index}
+            >
+              <SettingsLabel $active={isActive}>{country}</SettingsLabel>
+              <TimeZone isactive={isActive}>{tz_name}</TimeZone>
+            </SettingsEntry>
+          );
+        })}
+      </Viewport>
+    </Container>
   );
 }

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/Timezone.styled.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/Timezone.styled.tsx
@@ -1,33 +1,78 @@
 import { styled, keyframes, css } from 'styled-components';
 
-const leftright = keyframes`
+export const OPTIONS_HEIGHT = 50;
+export const CARD_GAP = 2;
+const translationAnimationDuration = 150;
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Viewport = styled.div<{
+  $activeIndex: number;
+}>`
+  height: 100%;
+  width: 75%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  gap: ${CARD_GAP}px;
+  transform: ${({ $activeIndex }) => {
+    const translateY =
+      -$activeIndex * (OPTIONS_HEIGHT + CARD_GAP) + 240 - OPTIONS_HEIGHT / 2;
+    return `translateY(${translateY}px)`;
+  }};
+  transition: transform ${translationAnimationDuration}ms ease;
+`;
+
+const MarqueeAnimation = keyframes` 
   0% {
     transform: translateX(0%);
   }
+  50% {
+    transform: translateX(calc(120px - 100%));
+  }
   100% {
-    transform: translateX(calc(320px - 100%));
+    transform: translateX(0%);
   }
 `;
 
-export const TextContainer = styled.p<{
-  neednoWrap?: boolean;
-  isactive?: boolean;
+export const SettingsEntry = styled.div<{
+  $small?: boolean;
+  $active?: boolean;
+  $marquee?: boolean;
 }>`
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+  height: ${OPTIONS_HEIGHT}px;
+  width: 100%;
+
+  font-family: 'ABC Diatype';
+  font-size: 40px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  text-transform: capitalize;
   white-space: nowrap;
   ${(props) =>
-    props.neednoWrap &&
-    props.isactive &&
+    props.$marquee &&
     css`
-      position: relative;
-      display: inline-block;
-      animation: ${leftright} 6s infinite alternate ease-in-out;
-    `}
+      animation: ${MarqueeAnimation} 8s ease-in-out infinite;
+    `};
 `;
 
-export const Option = styled.span<{
-  isactive?: boolean;
-}>`
-  color: ${(props) => (props.isactive ? '#f5c444' : '')};
+export const SettingsLabel = styled.span<{ $active?: boolean }>`
+  padding-right: 8px;
+  color: ${(props) => (props.$active ? 'white' : '#e7e7e790')};
 `;
 
 export const Title = styled.span`


### PR DESCRIPTION
## What was done?
The timezone swipers were broken due to the removal of some older css which was loaded by accident.
The components were rebuild with the same Styled components used for the profile settings.
Later down the line we can probably export those styled components for universal usage

![Screenshot From 2025-04-10 16-02-35](https://github.com/user-attachments/assets/ee0b6d70-8082-4089-bdc0-3eada4b076d5)
![Screenshot From 2025-04-10 16-01-58](https://github.com/user-attachments/assets/9d35bdf9-e04c-45c1-b490-7ef791c1886c)