### PR TITLE
Fix listeners usehandlegestures & Bubble display animation

### DIFF
--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -3,16 +3,14 @@ import { useHandleGestures } from '../../../src/hooks/useHandleGestures';
 import { memoizedRoutes } from '../../../src/utils';
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { CSSTransition } from 'react-transition-group';
 import './bubble.less';
 
 export default function Bubble() {
   const dispatch = useAppDispatch();
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
-  const [animationState, setAnimationState] = useState({
-    isVisible: false,
-    isAnimating: false
-  });
 
+  const [showBubble, setShowBubble] = useState(false);
   const prevComponentRef = useRef<string | null>(null);
 
   if (bubbleDisplay.component) {
@@ -20,14 +18,7 @@ export default function Bubble() {
   }
 
   useEffect(() => {
-    if (bubbleDisplay.visible)
-      setAnimationState({
-        isVisible: true,
-        isAnimating: false
-      });
-
-    if (!bubbleDisplay.visible && animationState.isVisible)
-      setAnimationState((prev) => ({ ...prev, isAnimating: true }));
+    setShowBubble(bubbleDisplay.visible);
   }, [bubbleDisplay.visible]);
 
   const ActiveComponent =
@@ -47,37 +38,28 @@ export default function Bubble() {
     }
   });
 
-  if (!animationState.isVisible && !animationState.isAnimating) return null;
-
-  const handleAnimationEnd = () => {
-    if (!animationState.isAnimating) return;
-
-    setAnimationState({
-      isVisible: false,
-      isAnimating: false
-    });
-
-    if (bubbleDisplay.component)
-      dispatch(
-        setBubbleDisplay({
-          visible: false,
-          component: null
-        })
-      );
+  const handleExited = () => {
+    dispatch(
+      setBubbleDisplay({
+        visible: false,
+        component: null
+      })
+    );
   };
 
   return (
-    <div
-      className={`main-bubble main-layout ${
-        !animationState.isAnimating
-          ? 'bubble-enter-animation'
-          : 'bubble-leave-animation'
-      } large`}
-      onAnimationEnd={handleAnimationEnd}
+    <CSSTransition
+      in={showBubble}
+      timeout={450}
+      classNames="bubble"
+      unmountOnExit
+      onExited={handleExited}
     >
-      <div className="bubble-container">
-        {ActiveComponent && createElement(ActiveComponent)}
+      <div className="main-bubble main-layout large">
+        <div className="bubble-container">
+          {ActiveComponent && createElement(ActiveComponent)}
+        </div>
       </div>
-    </div>
+    </CSSTransition>
   );
 }

--- a/src/components/Bubble/bubble.less
+++ b/src/components/Bubble/bubble.less
@@ -39,7 +39,7 @@
   .spring-interpolate-keyframes(100%, 1% )
 }
 
-.bubble-enter-animation {
+.bubble-enter {
   animation: bubbleEnter 450ms forwards;
 }
 
@@ -47,6 +47,6 @@
   .spring-interpolate-keyframes(1%, 100% )
 }
 
-.bubble-leave-animation {
+.bubble-exit {
   animation: bubbleLeave 450ms forwards;
 }

--- a/src/hooks/useHandleGestures.ts
+++ b/src/hooks/useHandleGestures.ts
@@ -13,13 +13,16 @@ export function useHandleGestures(
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  useEffect(
-    () =>
-      handleEvents.on('gesture', (gesture, time_since_last_event) => {
-        if (stateRef.current.isVisible && !shouldIgnoreGesture) {
-          stateRef.current.gestureHandlers[gesture]?.(time_since_last_event);
-        }
-      }),
-    [stateRef, shouldIgnoreGesture]
-  );
+  useEffect(() => {
+    const handler = (gesture: GestureType, time_since_last_event: number) => {
+      if (stateRef.current.isVisible && !shouldIgnoreGesture)
+        stateRef.current.gestureHandlers[gesture]?.(time_since_last_event);
+    };
+
+    const unsubscribe = handleEvents.on('gesture', handler);
+
+    return () => {
+      unsubscribe();
+    };
+  }, [shouldIgnoreGesture]);
 }


### PR DESCRIPTION
## What was done?
* Proper cleanup of nano events listeners in useHandleGestures. 
* Improved way of handling enter and exit animations in bubble display using CSSTransitions.

## Why?
* Too many listeners were being created and accumulated without being properly cleaned up, potentially causing a performance issue. 
* The way the enter and exit animations of the Bubble component were handled wasn’t entirely clear.