### PR TITLE
feat(quicksettings.tsx): add fail osstatus rendering

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -169,6 +169,8 @@ export function QuickSettings(): JSX.Element {
         return `Downloading Update: ${Math.round(osStatusData.progress)}%`;
       case 'INSTALLING':
         return `Installing Update: ${Math.round(osStatusData.progress)}%`;
+      case 'FAILED':
+        return `Update Failed: ${osStatusData.info}%`;
     }
     return '';
   }, [osStatusData, osStatusError]);


### PR DESCRIPTION
## What was done?

Added the possiblility to show OS Update failures in the context menu

![image](https://github.com/user-attachments/assets/2e3c53f5-1b90-40c1-a3d3-4e185335f523)

## Why?

So the user get the information on when the update fails, this may lay ground for future manual 'Update retries' notifications

## Full detail of changes made to each function

Add to the `osStatusInfo` memoization the `'FAILED'` case 