### PR TITLE
Add support to edit `piston_position` and `motor_power` profile variables in the dial app

### DIFF
--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -173,6 +173,10 @@ export function PressetSettings(): JSX.Element {
           dispatch(setScreen('time'));
         } else if (activeSetting.key.includes('weight')) {
           dispatch(setScreen('weight'));
+        } else if (activeSetting.key.includes('piston_position')) {
+          dispatch(setScreen('piston_position'));
+        } else if (activeSetting.key.includes('power')) {
+          dispatch(setScreen('motor_power'));
         } else if (activeSetting.key.includes('flow')) {
           dispatch(setScreen('flow'));
         } else if (activeSetting.key === 'temperature') {

--- a/src/components/SettingNumerical/Gauge.tsx
+++ b/src/components/SettingNumerical/Gauge.tsx
@@ -7,7 +7,14 @@ export const circumference = radius * 2 * Math.PI;
 const transform = `rotate(90, ${radius}, ${radius})`;
 const minDigits = 3;
 
-export type Unit = 'bar' | 'celcius' | 'gram' | 'sec' | 'ml' | 'min';
+export type Unit =
+  | 'bar'
+  | 'celcius'
+  | 'gram'
+  | 'sec'
+  | 'ml'
+  | 'min'
+  | 'percentage';
 
 const unitNameMap: Record<Unit, string> = {
   bar: 'bar',
@@ -15,6 +22,7 @@ const unitNameMap: Record<Unit, string> = {
   gram: 'g',
   sec: 's',
   ml: 'ml/s',
+  percentage: '%',
   min: 'min'
 };
 
@@ -24,6 +32,7 @@ const unitClassNameMap: Record<Unit, string> = {
   gram: 'scale-weight-limit',
   sec: 'scale-time',
   ml: 'scale-flow',
+  percentage: 'scale-percentile',
   min: 'scale-time'
 };
 
@@ -36,18 +45,30 @@ const formatValue = (value: number, precision: number) => {
   return { valueOnly, padded };
 };
 
-export const getDashArray = (value: number, maxValue: number) => {
-  if (maxValue === 0) {
-    return `0 ${circumference}`;
+export const getDashArray = (
+  value: number,
+  maxValue: number,
+  minValue?: number
+) => {
+  if (value >= 0) {
+    if (maxValue === 0) {
+      return `0 ${circumference}`;
+    }
+    const percentage = Math.min(value, maxValue) / maxValue;
+    const marc = circumference * percentage;
+    return `${marc} ${circumference}`;
+  } else {
+    const percentage =
+      Math.abs(Math.max(value, minValue | 0)) / Math.abs(minValue);
+    const marc = percentage * circumference;
+    const space = circumference - marc;
+    return `0 ${space} ${marc}`;
   }
-  const percentage = Math.min(value, maxValue) / maxValue;
-  const marc = circumference * percentage;
-
-  return `${marc} ${circumference}`;
 };
 
 interface GaugeProps {
   value: number;
+  minValue?: number;
   maxValue: number;
   precision: number;
   unit: Unit;
@@ -55,6 +76,7 @@ interface GaugeProps {
 
 export function Gauge({
   value,
+  minValue,
   maxValue,
   precision,
   unit
@@ -93,7 +115,7 @@ export function Gauge({
           r={radius}
           stroke="#F5C444"
           strokeWidth={strokeWidth}
-          strokeDasharray={getDashArray(value, maxValue)}
+          strokeDasharray={getDashArray(value, maxValue, minValue)}
           transform={transform}
         />
       </svg>

--- a/src/components/SettingNumerical/Gauge.tsx
+++ b/src/components/SettingNumerical/Gauge.tsx
@@ -37,9 +37,11 @@ const formatValue = (value: number, precision: number) => {
 };
 
 export const getDashArray = (value: number, maxValue: number) => {
-  const mI = (360 / maxValue) * (Math.min(value, maxValue) / 100);
-  const fA = mI * 100;
-  const marc = circumference * (fA / 360);
+  if (maxValue === 0) {
+    return `0 ${circumference}`;
+  }
+  const percentage = Math.min(value, maxValue) / maxValue;
+  const marc = circumference * percentage;
 
   return `${marc} ${circumference}`;
 };

--- a/src/components/SettingNumerical/SettingNumerical.tsx
+++ b/src/components/SettingNumerical/SettingNumerical.tsx
@@ -17,6 +17,7 @@ import { useProfileContext } from '../../context/ProfileContext';
 interface ISettingConfig {
   interval: number;
   unit: Unit;
+  minValue?: number;
   maxValue: number;
 }
 type NumericalSettingType =
@@ -25,12 +26,25 @@ type NumericalSettingType =
   | 'output'
   | 'flow'
   | 'time'
+  | 'piston_position'
+  | 'motor_power'
   | 'weight';
 const unitSettingConfigMap: Record<NumericalSettingType, ISettingConfig> = {
   pressure: {
     interval: 0.1,
     unit: 'bar',
     maxValue: 13
+  },
+  piston_position: {
+    interval: 1,
+    unit: 'percentage',
+    maxValue: 100
+  },
+  motor_power: {
+    interval: 1,
+    unit: 'percentage',
+    minValue: -99,
+    maxValue: 100
   },
   temperature: {
     interval: 0.5,
@@ -70,7 +84,7 @@ export function SettingNumerical({ type }: Props): JSX.Element {
 
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const total = Number(setting?.value || 0);
-  const { interval, maxValue, unit } = unitSettingConfigMap[
+  const { interval, maxValue, unit, minValue } = unitSettingConfigMap[
     type as NumericalSettingType
   ] ?? {
     interval: 0,
@@ -85,7 +99,7 @@ export function SettingNumerical({ type }: Props): JSX.Element {
   const updateValue = (gesture: 'left' | 'right') => {
     if (
       (total === maxValue && gesture === 'right') ||
-      (total === 0 && gesture === 'left')
+      (total === (minValue || 0) && gesture === 'left')
     ) {
       return;
     }
@@ -126,6 +140,7 @@ export function SettingNumerical({ type }: Props): JSX.Element {
   return (
     <Gauge
       unit={unit}
+      minValue={minValue}
       maxValue={maxValue}
       precision={interval < 1 ? 1 : 0}
       value={total}

--- a/src/components/SettingNumerical/gauge.css
+++ b/src/components/SettingNumerical/gauge.css
@@ -69,6 +69,10 @@
   margin-left: 88px;
 }
 
+.scale-percentile .scale-level {
+  margin-left: 88px;
+}
+
 .scale-time .scale-level {
   margin-left: 100px;
 }

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -12,6 +12,8 @@ export type ScreenType =
   | 'weight'
   | 'flow'
   | 'temperature'
+  | 'piston_position'
+  | 'motor_power'
   | 'dose'
   | 'output'
   | 'settings'

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -20,3 +20,4 @@ export const colorDataRed = '#FF5844';
 export const colorDataGreenLight = '#7BEEBF';
 export const colorDataYellow = '#FDC352';
 export const colorDataWhite = '#FFFFFF';
+export const colorDataYellowBright = '#F0F000';

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -154,6 +154,26 @@ export const routes: Record<ScreenType, Route> = {
     bottomStatusHidden: true,
     parent: 'pressetSettings'
   },
+  piston_position: {
+    component: SettingNumerical,
+    title: getActiveProfilesTitle,
+    bottomTitle: 'piston position',
+    props: {
+      type: 'piston_position'
+    },
+    bottomStatusHidden: true,
+    parent: 'pressetSettings'
+  },
+  motor_power: {
+    component: SettingNumerical,
+    title: getActiveProfilesTitle,
+    bottomTitle: 'motor power',
+    props: {
+      type: 'motor_power'
+    },
+    bottomStatusHidden: true,
+    parent: 'pressetSettings'
+  },
   time: {
     component: SettingNumerical,
     title: getActiveProfilesTitle,

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -2,10 +2,16 @@ import {
   colorDataBlueLight,
   colorDataGreenLight,
   colorDataRed,
-  colorDataYellow
+  colorDataYellow,
+  colorDataWhite,
+  colorDataYellowBright
 } from '../constants/colors';
 
 export type DataTypeKey = 'weight' | 'pressure' | 'flow';
+export type ExtraSettingType =
+  | 'piston_position'
+  | 'motor_power'
+  | 'temperature';
 
 export interface DataType {
   minValue: number;
@@ -17,7 +23,25 @@ export interface DataType {
   precision: 0 | 1;
 }
 
-export const dataTypes: Record<DataTypeKey | 'temperature', DataType> = {
+export const dataTypes: Record<DataTypeKey | ExtraSettingType, DataType> = {
+  piston_position: {
+    name: 'piston position',
+    minValue: 0,
+    maxValue: 100,
+    axisLabelStep: 25,
+    unit: '%',
+    color: colorDataWhite,
+    precision: 1
+  },
+  motor_power: {
+    name: 'motor power',
+    minValue: 0,
+    maxValue: 100,
+    axisLabelStep: 25,
+    unit: '%',
+    color: colorDataYellowBright,
+    precision: 1
+  },
   weight: {
     name: 'Weight',
     minValue: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,10 @@ export type DoseKey = 'dose';
 
 export type OutputKey = 'output';
 
+export type PistonPosKey = 'pistor_position';
+
+export type MotorPowerKey = 'motor_power';
+
 export type ActionKey = 'brew_once' | 'save' | 'discard' | 'delete';
 
 export type IPresetText = {


### PR DESCRIPTION
## What was done?
 1.  Simplify `getDashArray` fcn math
 2.  Added support to edit `piston_position` and `motor_power` profile variables on the dial app
 3.  Added support to set negative values on the profile variables on the dial app

## Why?
1. Remove the complexity of the function and make it easier to be read for the next implementations
2. There was no screen to be shown when trying to edit a `piston_position` or `motor_power` variables, so they could not be edited in the dial app
3. As the `motor_power` variable app can also be set to negative values, the support is required to be implemented in the dial app

![Screencast from 2025-05-28 15-59-04 (trimmed)](https://github.com/user-attachments/assets/c25133b4-ed9d-408a-935a-1915377a8dcc)