### PR TITLE
feat(home): allow for press-through logic to start the shot

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -82,6 +82,7 @@ export const ProfileHomeScreen = () => {
     'left' | 'right' | 'none'
   >('none');
   const [isPressingDown, setIsPressingDown] = useState(false);
+  const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
 
   const nodeRefs = useRef<Record<string, Ref<HTMLDivElement>>>({});
 
@@ -179,12 +180,19 @@ export const ProfileHomeScreen = () => {
           if (!localHoverState) {
             setLocalHoverState(true);
             setTransitionDirection('none');
+            pressThroughTimer.current = setTimeout(() => {
+              setIsPressingDown(true);
+            }, 300);
           } else {
             setIsPressingDown(true);
           }
         }
       },
       pressUp() {
+        if (pressThroughTimer.current) {
+          clearTimeout(pressThroughTimer.current);
+          pressThroughTimer.current = null;
+        }
         setIsPressingDown(false);
       }
     },
@@ -257,7 +265,7 @@ export const ProfileHomeScreen = () => {
         </Viewport>
       </Container>
       <CircleOverlay
-        shouldAnimate={localHoverState && isPressingDown}
+        shouldAnimate={isPressingDown}
         onAnimationFinished={animationFinished}
       />
     </>


### PR DESCRIPTION
## What was done?
The shot start can be triggered by holding the encoder for more than 300ms


https://github.com/user-attachments/assets/7ccf9420-6a5b-4175-96c0-c2117bada722

