### PR TITLE
fix(brew-complete): dont show nan if no scale is connected

### DIFF
--- a/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
+++ b/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
@@ -76,7 +76,7 @@ export const BrewCompleteScreen = () => {
       ? lastBrewWeight.toFixed(1)
       : lastBrewWeight.toFixed(0)
     : lastBrewWeight;
-
+  const scaleConnected = !isNaN(lastBrewWeight);
   const isPurging = statsName === 'purge';
 
   useEffect(() => {
@@ -128,8 +128,14 @@ export const BrewCompleteScreen = () => {
       </ModularLeft>
       <ModularRight>
         <WeightContainer>
-          <WeightValue>{weight}</WeightValue>
-          <Unit>g</Unit>
+          {scaleConnected ? (
+            <>
+              <WeightValue>{weight}</WeightValue>
+              <Unit>g</Unit>
+            </>
+          ) : (
+            <Label style={{ color: '#f44336' }}>Scale not connected</Label>
+          )}
         </WeightContainer>
         <Label>{stateLabel}</Label>
       </ModularRight>


### PR DESCRIPTION
## What was done?
If no scale is connected the "NaN" is no longer shown. Instead we tell the user that no scale is connected

<img width="602" height="670" alt="image" src="https://github.com/user-attachments/assets/2d21d024-f0a4-4e92-a219-b18c1a1a8412" />

