### PR TITLE
feat(brew): add virtual abort action

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -186,7 +186,7 @@ export function QuickSettings(): JSX.Element {
         break;
       }
       case 'abort_brew': {
-        socket.emit('action', 'home');
+        socket.emit('action', 'abort');
         dispatch(setBubbleDisplay({ visible: false, component: null }));
         break;
       }


### PR DESCRIPTION
## What was done?
The abort brew option in the dial app is now sending a new `abort` action to the backend which - together with https://github.com/MeticulousHome/meticulous-backend/pull/258 it allows for abortion during heating
