### PR TITLE
Chore/improve idle exit

### DIFF
--- a/src/components/IdleScreen/IdleScreen.tsx
+++ b/src/components/IdleScreen/IdleScreen.tsx
@@ -87,20 +87,18 @@ export function IdleScreen(): JSX.Element {
       // Screen is dark, dim up for 5 seconds
       if (prev) {
         screenDimTimeoutRef.current = setTimeout(() => {
+          updateBrightness({ brightness: 0.03 });
           cycleScreenDim();
         }, 5 * 1000);
       } else {
         screenDimTimeoutRef.current = setTimeout(() => {
+          updateBrightness({ brightness: 0.33 });
           cycleScreenDim();
         }, 55 * 1000);
       }
       return !prev;
     });
   };
-
-  useEffect(() => {
-    updateBrightness({ brightness: isScreenDim ? 0.03 : 0.33 });
-  }, [isScreenDim]);
 
   useEffect(() => {
     updateBrightness({ brightness: 0.33 });

--- a/src/components/IdleScreen/IdleScreen.tsx
+++ b/src/components/IdleScreen/IdleScreen.tsx
@@ -111,8 +111,6 @@ export function IdleScreen(): JSX.Element {
     }, SCREEN_TIMEOUT);
 
     return () => {
-      updateBrightness({ brightness: 1 });
-
       if (screenDimTimeoutRef.current) {
         clearTimeout(screenDimTimeoutRef.current);
       }
@@ -131,6 +129,7 @@ export function IdleScreen(): JSX.Element {
 
   useEffect(() => {
     if (shouldGoToIdle || prevScreen === 'idle') return;
+    updateBrightness({ brightness: 1 });
     if (!prevScreen || routes[prevScreen].ignoreAsPrevious) {
       dispatch(setScreen('profileHome'));
     }


### PR DESCRIPTION
## What was done?
1. The method `updateBrightness` was being called on the component unmount, this commit calls it before unmounting but once we are sure we will exit the idle screen.

2. Remove `isScreenDim` useEffect

## Why?
1. To reduce lag perception in machine awakening.

2. The `useEffect` dependent on `isScreenDim` made the `updateBrightness` execute twice on `IdleScreen` mount, now we set the corresponding brightness on the `cycleScreenDim` instead.
Executing `updateBrightness` twice in a row causes the backend to cancel the dimming animation, skipping immediately to the target brightness