### PR TITLE
fix(heatingscreen): brew now issue

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -175,7 +175,10 @@ export const HeatingScreen = () => {
   useHandleGestures(
     {
       pressDown() {
-        if (heatingFinished && optionSeletected == 'push_to_brew') {
+        if (
+          heatingFinished &&
+          ['push_to_brew', 'brew_now'].includes(optionSeletected)
+        ) {
           continueBrew();
           console.log('action,continue');
         }


### PR DESCRIPTION
## What was done?

This commit adds the brew_now option to the push_to_brew check, so if the heating ends before the brew_now time ends, the button press will still be registered on the click to start screen

## Why?

When the heating was finished, it checks if the option selected is auto_start to send the continue command, else passes to the click to start screen, if the user sets the brew_now option and while it loads the heating finishes, it will not be in auto_start passing to click to start screen, which asks if the option selected is push_to_brew (which isn't). so it wont register the button press.

## Additional comments & remarks

## Full detail of changes made to each function
