### PR TITLE
feat(settings/advanced): custrom piston retraction

### DIFF
--- a/src/components/SettingNumerical/Gauge.tsx
+++ b/src/components/SettingNumerical/Gauge.tsx
@@ -14,6 +14,7 @@ export type Unit =
   | 'sec'
   | 'ml'
   | 'min'
+  | 'volume'
   | 'percentage';
 
 const unitNameMap: Record<Unit, string> = {
@@ -23,7 +24,8 @@ const unitNameMap: Record<Unit, string> = {
   sec: 's',
   ml: 'ml/s',
   percentage: '%',
-  min: 'min'
+  min: 'min',
+  volume: 'ml'
 };
 
 const unitClassNameMap: Record<Unit, string> = {
@@ -32,6 +34,7 @@ const unitClassNameMap: Record<Unit, string> = {
   gram: 'scale-weight-limit',
   sec: 'scale-time',
   ml: 'scale-flow',
+  volume: 'scale-flow',
   percentage: 'scale-percentile',
   min: 'scale-time'
 };

--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -9,7 +9,10 @@ import {
   useRootPassword
 } from '../../../hooks/useSettings';
 import { useManufacturingSchema } from '../../../hooks/useManufacturing';
-import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
 import Styled, {
@@ -19,6 +22,9 @@ import Styled, {
 import { calculateOptionPosition } from '../../../styles/utils/calculateOptionPosition';
 import { IdleScreens } from '../../../components/Settings/Advanced/IdleScreenSetting';
 import type { Settings } from '@meticulous-home/espresso-api';
+
+const cylinder_radius = 26.5; //ml
+const pi_r_squared = Math.PI * cylinder_radius * cylinder_radius;
 
 const initialSettings: SettingsItem[] = [
   {
@@ -68,6 +74,15 @@ const initialSettings: SettingsItem[] = [
     label: 'Factory reset',
     visible: true,
     caseSensitive: false
+  },
+  {
+    key: 'partial_retraction',
+    label: 'Shot volume',
+    getLabel: (settings: Settings) =>
+      ((settings.partial_retraction * pi_r_squared) / 1000.0)
+        .toFixed()
+        .toString() + ' ml',
+    visible: true
   }
 ];
 
@@ -212,6 +227,15 @@ export const AdvancedSettings = () => {
               .catch((err) => {
                 console.log(err);
               });
+            break;
+          case 'partial_retraction':
+            dispatch(setScreen('retraction_volume'));
+            dispatch(
+              setBubbleDisplay({
+                visible: false,
+                component: null
+              })
+            );
             break;
           default: {
             break;

--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -9,10 +9,7 @@ import {
   useRootPassword
 } from '../../../hooks/useSettings';
 import { useManufacturingSchema } from '../../../hooks/useManufacturing';
-import {
-  setBubbleDisplay,
-  setScreen
-} from '../../store/features/screens/screens-slice';
+import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
 import Styled, {
@@ -22,9 +19,6 @@ import Styled, {
 import { calculateOptionPosition } from '../../../styles/utils/calculateOptionPosition';
 import { IdleScreens } from '../../../components/Settings/Advanced/IdleScreenSetting';
 import type { Settings } from '@meticulous-home/espresso-api';
-
-const cylinder_radius = 26.5; //ml
-const pi_r_squared = Math.PI * cylinder_radius * cylinder_radius;
 
 const initialSettings: SettingsItem[] = [
   {
@@ -74,15 +68,6 @@ const initialSettings: SettingsItem[] = [
     label: 'Factory reset',
     visible: true,
     caseSensitive: false
-  },
-  {
-    key: 'partial_retraction',
-    label: 'Shot volume',
-    getLabel: (settings: Settings) =>
-      ((settings.partial_retraction * pi_r_squared) / 1000.0)
-        .toFixed()
-        .toString() + ' ml',
-    visible: true
   }
 ];
 
@@ -227,15 +212,6 @@ export const AdvancedSettings = () => {
               .catch((err) => {
                 console.log(err);
               });
-            break;
-          case 'partial_retraction':
-            dispatch(setScreen('retraction_volume'));
-            dispatch(
-              setBubbleDisplay({
-                visible: false,
-                component: null
-              })
-            );
             break;
           default: {
             break;

--- a/src/components/Settings/Advanced/RetractionVolume.tsx
+++ b/src/components/Settings/Advanced/RetractionVolume.tsx
@@ -45,9 +45,7 @@ export const RetractionSettingGauge: React.FC = () => {
           Math.round((localRetractionVolume * 1000 * 100) / pi_r_squared) / 100
       });
       dispatch(setScreen(prevScreen));
-      dispatch(
-        setBubbleDisplay({ visible: true, component: 'advancedSettings' })
-      );
+      dispatch(setBubbleDisplay({ visible: true, component: 'brewSettings' }));
     }
   });
 

--- a/src/components/Settings/Advanced/RetractionVolume.tsx
+++ b/src/components/Settings/Advanced/RetractionVolume.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { useSettings, useUpdateSettings } from '../../../hooks/useSettings';
+import { Gauge } from '../../SettingNumerical/Gauge';
+import { useHandleGestures } from '../../../hooks/useHandleGestures';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../../store/features/screens/screens-slice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+
+import { useDimScreen } from '../../../hooks/useDimScreen';
+
+const MIN_VOLUME = 100; // ml
+const MAX_VOLUME = 150; // ml
+const INTERVAL = 1; // 1 ml interval
+
+const cylinder_radius = 26.5; //mm
+
+const pi_r_squared = Math.PI * cylinder_radius * cylinder_radius;
+
+export const RetractionSettingGauge: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const prevScreen = useAppSelector((state) => state.screen.prev);
+  const { data: globalSettings } = useSettings();
+  const updateSettings = useUpdateSettings();
+
+  const [localRetractionVolume, setLocalRetractionVolume] = useState(
+    Math.round((pi_r_squared * globalSettings.partial_retraction) / 1000.0)
+  );
+
+  useDimScreen();
+
+  useHandleGestures({
+    left() {
+      const newValue = Math.max(localRetractionVolume - INTERVAL, MIN_VOLUME);
+      setLocalRetractionVolume(newValue);
+    },
+    right() {
+      const newValue = Math.min(localRetractionVolume + INTERVAL, MAX_VOLUME);
+      setLocalRetractionVolume(newValue);
+    },
+    pressDown() {
+      updateSettings.mutate({
+        partial_retraction:
+          Math.round((localRetractionVolume * 1000 * 100) / pi_r_squared) / 100
+      });
+      dispatch(setScreen(prevScreen));
+      dispatch(
+        setBubbleDisplay({ visible: true, component: 'advancedSettings' })
+      );
+    }
+  });
+
+  return (
+    <div className="gauge-container">
+      <Gauge
+        value={localRetractionVolume}
+        maxValue={MAX_VOLUME}
+        minValue={MIN_VOLUME}
+        precision={0}
+        unit="volume"
+      />
+    </div>
+  );
+};

--- a/src/components/Settings/BrewSettings.tsx
+++ b/src/components/Settings/BrewSettings.tsx
@@ -19,6 +19,9 @@ import Styled, {
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
 import type { Settings } from '@meticulous-home/espresso-api';
 
+const cylinder_radius = 26.5; //ml
+const pi_r_squared = Math.PI * cylinder_radius * cylinder_radius;
+
 const initialSettings: SettingsItem[] = [
   {
     key: 'auto_start_shot',
@@ -33,9 +36,13 @@ const initialSettings: SettingsItem[] = [
       `${settings.auto_purge_after_shot ? 'Automatic' : 'On button press'}`
   },
   {
-    key: 'partial_retraction',
-    label: 'Initial Retraction',
-    getLabel: (settings: Settings) => `${settings.partial_retraction}mm`
+    key: 'shot_volume',
+    label: 'Shot volume',
+    getLabel: (settings: Settings) =>
+      ((settings.partial_retraction * pi_r_squared) / 1000.0)
+        .toFixed()
+        .toString() + ' ml',
+    visible: true
   },
   {
     key: 'heat_timeout_after_shot',
@@ -87,11 +94,14 @@ export function BrewSettings(): JSX.Element {
             dispatch(setScreen('heat_timeout_after_shot'));
             dispatch(setBubbleDisplay({ visible: false, component: null }));
             break;
-          case 'partial_retraction':
-            updateSettings.mutate({
-              partial_retraction:
-                globalSettings['partial_retraction'] < 70 ? 70 : 45
-            });
+          case 'shot_volume':
+            dispatch(setScreen('retraction_volume'));
+            dispatch(
+              setBubbleDisplay({
+                visible: false,
+                component: null
+              })
+            );
             break;
           case 'back':
             dispatch(

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -57,6 +57,7 @@ export type ScreenType =
   | 'brewComplete'
   | 'factoryReset'
   | 'usbSettings'
+  | 'retraction_volume'
   | 'manufacturingSettings';
 
 interface ScreenState {

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -53,7 +53,7 @@ import {
 } from '../components/ProfileHomeScreen/ProfileTitle';
 import { FactoryReset } from '../components/Settings/Advanced/FactoryReset';
 import { Manufacturing } from '../components/Settings/Advanced/Manufacturing';
-
+import { RetractionSettingGauge } from '../components/Settings/Advanced/RetractionVolume';
 interface Route {
   component: ComponentType;
   parentTitle?: string | ((state: RootState) => string) | (() => JSX.Element);
@@ -163,6 +163,16 @@ export const routes: Record<ScreenType, Route> = {
     },
     bottomStatusHidden: true,
     parent: 'pressetSettings'
+  },
+  retraction_volume: {
+    component: RetractionSettingGauge,
+    title: 'retraction',
+    bottomTitle: 'retraction volume',
+    props: {
+      type: 'retraction_volume'
+    },
+    bottomStatusHidden: true,
+    parent: 'advancedSettings'
   },
   motor_power: {
     component: SettingNumerical,

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -172,7 +172,7 @@ export const routes: Record<ScreenType, Route> = {
       type: 'retraction_volume'
     },
     bottomStatusHidden: true,
-    parent: 'advancedSettings'
+    parent: 'brewSettings'
   },
   motor_power: {
     component: SettingNumerical,

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -167,7 +167,7 @@ export const routes: Record<ScreenType, Route> = {
   retraction_volume: {
     component: RetractionSettingGauge,
     title: 'retraction',
-    bottomTitle: 'retraction volume',
+    bottomTitle: 'shot volume',
     props: {
       type: 'retraction_volume'
     },


### PR DESCRIPTION
## What was done?

The option `initial retraction` from  the `brew settings` menu changed to `shot volume`, with it You can set amount of water for the shots to come

The volume range goes from 100ml to 150ml. That value is purely visual and used to calculate the retraction distance (mm) for the piston to be saved in the settings menu. Calculation is done using the cylinder diameter of 53 mm

![shot volume](https://github.com/user-attachments/assets/1bd87d76-c51e-4e52-9ed2-fee8e6ce9722)

> **Note: requieres approval of [this PR](https://github.com/MeticulousHome/meticulous-backend/pull/270) to succesfully save float values in the `partial_retraction` setting**