### PR TITLE
feat(profile-home): allow up to 3 items from the active item to render

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -242,7 +242,7 @@ export const ProfileHomeScreen = () => {
                     zoomedIn={localHoverState}
                   >
                     {/* Only render images in those that are close to the active option */}
-                    {Math.abs(index - activeOption) < 2 && (
+                    {Math.abs(index - activeOption) < 4 && (
                       <ProfileImage profile={profile} />
                     )}
                     {profile.isLast && (


### PR DESCRIPTION
This way we avoid no-image containers scrolling by
