### PR TITLE
fix(heatingscreen): go to retraction when cancelling

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -174,7 +174,7 @@ export const HeatingScreen = () => {
 
   useHandleGestures(
     {
-      pressDown() {
+      click() {
         if (
           heatingFinished &&
           ['push_to_brew', 'brew_now'].includes(optionSeletected)

--- a/src/components/Settings/Advanced/RetractionVolume.tsx
+++ b/src/components/Settings/Advanced/RetractionVolume.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useSettings, useUpdateSettings } from '../../../hooks/useSettings';
 import { Gauge } from '../../SettingNumerical/Gauge';
 import { useHandleGestures } from '../../../hooks/useHandleGestures';


### PR DESCRIPTION

## What was done?

Change the gesture to trigger the continue action while on the heating screen

## Why?

When on the heating screen, we used the pressDown gesture to trigger the 'continue' action, which was triggered when also double clicking to cancel, so we ended up cancelling in the retraction stage and sending the piston to home

## Additional comments & remarks

## Full detail of changes made to each function
