### PR TITLE
Feat/profile start improvement

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -20,6 +20,7 @@ import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { OptionsMenu } from './OptionsMenu';
 import { useContinueBrewAction } from '../store/SocketManager';
 import { useProfileContext } from '../../context/ProfileContext';
+import { loadProfileData, startProfile } from '../../api/profile';
 
 const PushToStartLabel = styled.div`
   font-size: 20px;
@@ -67,10 +68,16 @@ const transitionDuration = 600;
 
 export const HeatingScreen = () => {
   const dispatch = useAppDispatch();
-  const { lastProfile } = useProfileContext();
+  const {
+    lastProfile,
+    mergedProfiles,
+    localProfileIndex: activeProfile,
+    profileStarting
+  } = useProfileContext();
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const continueBrew = useContinueBrewAction();
   const waterStatus = useAppSelector((state) => state.stats.waterStatus);
+  const prevScreen = useAppSelector((state) => state.screen.prev);
   const temperature =
     useAppSelector((state) => Math.round(state.stats.sensors.t)) || 0;
   const hasNotifications = useAppSelector(
@@ -87,6 +94,27 @@ export const HeatingScreen = () => {
   const [temperatureTarget, setTemperatureTarget] = useState(
     temperatureTargetStatus || 0
   );
+
+  // send the profile and start it only when coming from profileHome and
+  // the profileStarting flag is set
+
+  useEffect(() => {
+    const loadAndStartProfile = async () => {
+      const profile = mergedProfiles?.[activeProfile];
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { isLast, temporary, ...cleanProfile } = profile;
+      const data = await loadProfileData(cleanProfile);
+
+      if (data) {
+        await startProfile();
+      }
+    };
+
+    if (prevScreen === 'profileHome' && profileStarting) {
+      loadAndStartProfile();
+    }
+  }, []);
 
   useEffect(() => {
     if (lastProfile && lastProfile.profile && temperatureTarget == 0) {
@@ -131,7 +159,7 @@ export const HeatingScreen = () => {
   const heatingFinished = statsName === 'click to start';
 
   useEffect(() => {
-    if (statsName === 'idle' && !hasNotifications) {
+    if (statsName === 'idle' && !hasNotifications && !profileStarting) {
       dispatch(setScreen('profileHome'));
     }
   }, [statsName]);

--- a/src/components/ProfileHomeScreen/CircleOverlay.tsx
+++ b/src/components/ProfileHomeScreen/CircleOverlay.tsx
@@ -93,11 +93,9 @@ export function CircleOverlay({
           r={radius}
           fill="transparent"
           className={
-            isDrawn
-              ? 'animateCircleColor'
-              : shouldAnimate
-                ? 'animateCirlceOpacityUp'
-                : 'animateCirlceOpacityDown'
+            shouldAnimate
+              ? 'animateCirlceOpacityUp'
+              : 'animateCirlceOpacityDown'
           }
           strokeWidth={stroke}
           style={{

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -10,7 +10,6 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { PROFILE_ENTRY_SIZE, ProfileEntry } from './ProfileEntry';
 import { ProfileImage } from './ProfileImage';
 
-import { loadProfileData, startProfile } from '../../api/profile';
 import { CircleOverlay } from './CircleOverlay';
 import './transitions.less';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -97,14 +96,7 @@ export const ProfileHomeScreen = () => {
 
   const animationFinished = async () => {
     setProfileStarting(true);
-    const profile = mergedProfiles?.[activeOption];
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { isLast, temporary, ...cleanProfile } = profile;
-    const data = await loadProfileData(cleanProfile);
-    if (data) {
-      await startProfile();
-    }
+    dispatch(setScreen('heating'));
   };
 
   useEffect(() => {

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -19,6 +19,7 @@ import { useIdleTimer } from '../../hooks/useIdleTimer';
 import { PlusIcon } from './PlusIcon';
 import { LastLabel } from './LastLabel';
 import { useIsOnline } from '../../hooks/useIsOnline';
+import { useSocket } from '../store/SocketManager';
 
 const CARD_GAP = 79;
 const CARD_SIZE = PROFILE_ENTRY_SIZE + CARD_GAP;
@@ -60,6 +61,8 @@ const InnerList = styled(TransitionGroup)<{
   transition: transform ${translationAnimationDuration}ms ease;
 `;
 
+const PISTON_ON_PURGE_POSITION = 76.8;
+
 export const ProfileHomeScreen = () => {
   const dispatch = useAppDispatch();
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
@@ -86,6 +89,8 @@ export const ProfileHomeScreen = () => {
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
 
   const nodeRefs = useRef<Record<string, Ref<HTMLDivElement>>>({});
+  const requiresPurge = useRef<boolean>(false);
+  const socket = useSocket();
 
   const getOrCreateRef = (id: string) => {
     if (!nodeRefs.current[id]) {
@@ -96,8 +101,20 @@ export const ProfileHomeScreen = () => {
 
   const animationFinished = async () => {
     setProfileStarting(true);
-    dispatch(setScreen('heating'));
+    if (!requiresPurge.current) {
+      dispatch(setScreen('heating'));
+    } else {
+      dispatch(setScreen('manual-purge'));
+    }
   };
+
+  useEffect(() => {
+    socket.on('sensors', (data: { m_pos: number }) => {
+      if (data.m_pos < PISTON_ON_PURGE_POSITION) {
+        requiresPurge.current = true;
+      }
+    });
+  }, []);
 
   useEffect(() => {
     if (!shouldGoToIdle) return;

--- a/src/components/PurgePiston/PurgeScreen.tsx
+++ b/src/components/PurgePiston/PurgeScreen.tsx
@@ -6,21 +6,54 @@ import { notificationSelector } from '../store/features/notifications/notificati
 
 import './piston.css';
 import { setScreen } from '../store/features/screens/screens-slice';
+import { loadProfileData, startProfile } from '../../api/profile';
+import { useProfileContext } from '../../context/ProfileContext';
 
 export function PurgeScreen(): JSX.Element {
   const dispatch = useAppDispatch();
+
+  const {
+    mergedProfiles,
+    localProfileIndex: activeProfile,
+    profileStarting
+  } = useProfileContext();
 
   const statsName = useAppSelector((state) => state.stats.name);
   const sensors = useAppSelector((state) => state.stats.sensors);
   const hasNotifications = useAppSelector(
     notificationSelector.selectHasNotifications
   );
+  const prevScreen = useAppSelector((state) => state.screen.prev);
 
   useEffect(() => {
-    if (statsName === 'idle' && !hasNotifications) {
+    if (statsName === 'idle' && !hasNotifications && !profileStarting) {
       dispatch(setScreen('profileHome'));
     }
   }, [statsName]);
+
+  // send the profile and start it only when coming from profileHome and
+  // the profileStarting flag is set
+
+  useEffect(() => {
+    const loadAndStartProfile = async () => {
+      const profile = mergedProfiles?.[activeProfile];
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { isLast, temporary, ...cleanProfile } = profile;
+      const data = await loadProfileData(cleanProfile);
+
+      if (data) {
+        await startProfile();
+        console.log('starting profile');
+      } else {
+        console.log('loadProfileData returned nothing, not starting profile');
+      }
+    };
+
+    if (prevScreen === 'profileHome' && profileStarting) {
+      loadAndStartProfile();
+    }
+  }, []);
 
   return (
     <div className="piston-container">

--- a/src/components/store/SocketProviderValue.tsx
+++ b/src/components/store/SocketProviderValue.tsx
@@ -25,6 +25,7 @@ import { OSStatusResponse, ProfileUpdate } from '@meticulous-home/espresso-api';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
 import { LASTS_PROFILE_QUERY_KEY } from '../../hooks/useProfiles';
 import { useProfileContext } from '../../context/ProfileContext';
+import { HIDDEN_STAGES } from '../../constants/setting';
 
 const socket: Socket | null = io(API_URL);
 
@@ -113,12 +114,8 @@ export const SocketProviderValue = () => {
           return;
         }
 
-        // When the machine is not in idle, lock the screen at Barometer
-        if (
-          data?.name !== 'idle' &&
-          data?.name !== 'boot' &&
-          data?.name !== 'END_STAGE'
-        ) {
+        // When the machine is not in a hidden stage, lock the screen at Barometer
+        if (!HIDDEN_STAGES.includes(data?.name)) {
           dispatch(setScreen('barometer'));
         }
       }

--- a/src/constants/setting.ts
+++ b/src/constants/setting.ts
@@ -41,3 +41,12 @@ export const TEMPORARY_SETTINGS: StaticAction[] = [
     label: 'discard'
   }
 ];
+
+// When the stage changes, if it is one of the followings
+// do not show the barometer
+export const HIDDEN_STAGES: string[] = [
+  'idle',
+  'boot',
+  'END_STAGE',
+  'starting...'
+];

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -54,6 +54,7 @@ import {
 import { FactoryReset } from '../components/Settings/Advanced/FactoryReset';
 import { Manufacturing } from '../components/Settings/Advanced/Manufacturing';
 import { RetractionSettingGauge } from '../components/Settings/Advanced/RetractionVolume';
+import { useProfileContext } from '../context/ProfileContext';
 interface Route {
   component: ComponentType;
   parentTitle?: string | ((state: RootState) => string) | (() => JSX.Element);
@@ -72,8 +73,18 @@ interface Route {
 
 const selectPurgeTitle = (state: RootState) => {
   const machine_state = state.stats.state;
-  if (machine_state == 'brewing') {
+  if (machine_state == 'brewing' && state.stats.profile !== 'Init Profile') {
     return state.stats.profile;
+  }
+
+  const {
+    mergedProfiles,
+    localProfileIndex: activeProfile,
+    profileStarting
+  } = useProfileContext();
+
+  if (mergedProfiles && profileStarting) {
+    return mergedProfiles[activeProfile].name;
   }
 
   if (state.stats.name === 'home') {


### PR DESCRIPTION
## What was done?

The screen transitions at the start of the profile changed to be more straightforward

The yellow ring that indicates profile loading gets skipped, and the wait happens on the heating screen or (if needed) in the purging screen

The barometer flashed with the stage `starting...` after loading the profile and before the heating screen, that got removed

## Why?

This cleans the "profile start" visual workflow up

## Summary

- feat(profilestart): skip yellow breathing ring - load the profile while on the heating screen

- fix(profilestart): purge prior profile start - wait and load the profile on the purge screen (if necessary)

>NOTE:
There is duplicated logic in heating and purge screens, might use
improvement

- fix(routes): purge screen title - use the profile name if we are loading it