### PR TITLE
Chore/load profile pictures

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -62,8 +62,6 @@ const InnerList = styled(TransitionGroup)<{
 `;
 type dialDirection = 'left' | 'right' | 'none';
 
-const MAX_PFP_LOADED = 20; // The mechanical encoder has 32 steps per revolution
-
 const PISTON_ON_PURGE_POSITION = 76.8;
 
 export const ProfileHomeScreen = () => {
@@ -89,6 +87,7 @@ export const ProfileHomeScreen = () => {
     useState<dialDirection>('none');
   const [isPressingDown, setIsPressingDown] = useState(false);
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
+  const [unsafeToUnmount, setUnsafeToUnmount] = useState<number[]>([]);
 
   const nodeRefs = useRef<Record<string, Ref<HTMLDivElement>>>({});
   const requiresPurge = useRef<boolean>(false);
@@ -107,30 +106,6 @@ export const ProfileHomeScreen = () => {
       dispatch(setScreen('heating'));
     } else {
       dispatch(setScreen('manual-purge'));
-    }
-  };
-
-  const inDynamicWindow = (
-    index: number,
-    direction: dialDirection
-  ): boolean => {
-    switch (direction) {
-      case 'none':
-        return false;
-      case 'left':
-        return (
-          index >= Math.max(activeOption - 2, 0) &&
-          index <
-            Math.min(
-              activeOption + MAX_PFP_LOADED - 2,
-              mergedProfiles.length - 1
-            )
-        );
-      case 'right':
-        return (
-          index >= Math.max(activeOption - MAX_PFP_LOADED + 2, 0) &&
-          index < Math.min(activeOption + 2, mergedProfiles.length - 1)
-        );
     }
   };
 
@@ -273,10 +248,28 @@ export const ProfileHomeScreen = () => {
                     distanceToActive={index - activeOption}
                     zoomedIn={localHoverState}
                   >
-                    {/* Only render images in those that are close to the active option */}
+                    {/* Only render images in those that are close to the active option 
+                        or are unsafe to remove*/}
+
                     {(Math.abs(index - activeOption) < 4 ||
-                      inDynamicWindow(index, transitionDirection)) && (
-                      <ProfileImage profile={profile} />
+                      unsafeToUnmount.includes(index)) && (
+                      <ProfileImage
+                        profile={profile}
+                        onEnteringViewport={() => {
+                          setUnsafeToUnmount((prev) => {
+                            if (prev.includes(index)) return prev;
+                            return [...prev, index];
+                          });
+                        }}
+                        onExitingViewport={() => {
+                          setUnsafeToUnmount((prev) =>
+                            prev.filter(
+                              (unsafe_index) =>
+                                Math.abs(unsafe_index - activeOption) < 4
+                            )
+                          );
+                        }}
+                      />
                     )}
                     {profile.isLast && (
                       <LastLabel isTemporary={profile.temporary} />

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -60,6 +60,9 @@ const InnerList = styled(TransitionGroup)<{
   transform: ${({ $translateX }) => `translateX(${$translateX}px)`};
   transition: transform ${translationAnimationDuration}ms ease;
 `;
+type dialDirection = 'left' | 'right' | 'none';
+
+const MAX_PFP_LOADED = 20; // The mechanical encoder has 32 steps per revolution
 
 const PISTON_ON_PURGE_POSITION = 76.8;
 
@@ -82,9 +85,8 @@ export const ProfileHomeScreen = () => {
     mergedProfiles
   } = profileState;
 
-  const [transitionDirection, setTransitionDirection] = useState<
-    'left' | 'right' | 'none'
-  >('none');
+  const [transitionDirection, setTransitionDirection] =
+    useState<dialDirection>('none');
   const [isPressingDown, setIsPressingDown] = useState(false);
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
 
@@ -105,6 +107,30 @@ export const ProfileHomeScreen = () => {
       dispatch(setScreen('heating'));
     } else {
       dispatch(setScreen('manual-purge'));
+    }
+  };
+
+  const inDynamicWindow = (
+    index: number,
+    direction: dialDirection
+  ): boolean => {
+    switch (direction) {
+      case 'none':
+        return false;
+      case 'left':
+        return (
+          index >= Math.max(activeOption - 2, 0) &&
+          index <
+            Math.min(
+              activeOption + MAX_PFP_LOADED - 2,
+              mergedProfiles.length - 1
+            )
+        );
+      case 'right':
+        return (
+          index >= Math.max(activeOption - MAX_PFP_LOADED + 2, 0) &&
+          index < Math.min(activeOption + 2, mergedProfiles.length - 1)
+        );
     }
   };
 
@@ -144,7 +170,6 @@ export const ProfileHomeScreen = () => {
       return;
     }
     if (activeOption !== mergedProfiles?.length) {
-      setTransitionDirection('none');
       requestAnimationFrame(() => {
         setTransitionDirection('right');
       });
@@ -158,8 +183,6 @@ export const ProfileHomeScreen = () => {
       return;
     }
     if (activeOption !== 0) {
-      setTransitionDirection('none');
-
       requestAnimationFrame(() => {
         setTransitionDirection('left');
       });
@@ -251,7 +274,8 @@ export const ProfileHomeScreen = () => {
                     zoomedIn={localHoverState}
                   >
                     {/* Only render images in those that are close to the active option */}
-                    {Math.abs(index - activeOption) < 4 && (
+                    {(Math.abs(index - activeOption) < 4 ||
+                      inDynamicWindow(index, transitionDirection)) && (
                       <ProfileImage profile={profile} />
                     )}
                     {profile.isLast && (

--- a/src/components/ProfileHomeScreen/ProfileImage.tsx
+++ b/src/components/ProfileHomeScreen/ProfileImage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Profile } from '@meticulous-home/espresso-profile';
 import { api, API_URL } from '../../api/api';
 
@@ -13,11 +13,23 @@ const Image = styled.img`
   background-repeat: no-repeat;
 `;
 
-export const ProfileImage = ({ profile: preset }: { profile: Profile }) => {
+export const ProfileImage = ({
+  profile: preset,
+  onEnteringViewport,
+  onExitingViewport
+}: {
+  profile: Profile;
+  onEnteringViewport: () => void;
+  onExitingViewport: () => void;
+}) => {
   const [image, setImage] = useState(
     preset.display?.image &&
       `${API_URL}${api.getProfileImageUrl(preset.display.image)}`
   );
+  const [isVisible, setIsVisible] = useState(false);
+  const oldIsVisible = useRef<boolean>(false);
+
+  const imgRef = useRef(null);
 
   useEffect(() => {
     if (!preset.display?.image) {
@@ -29,8 +41,43 @@ export const ProfileImage = ({ profile: preset }: { profile: Profile }) => {
     );
   }, [preset.display?.image]);
 
+  useEffect(() => {
+    onEnteringViewport();
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsVisible((prev) => {
+          oldIsVisible.current = prev;
+          return entry.isIntersecting;
+        });
+      },
+      {
+        root: null, // viewport
+        rootMargin: '0px', // no margin
+        threshold: 0 // 50% of target visible
+      }
+    );
+
+    if (imgRef.current) {
+      observer.observe(imgRef.current);
+    }
+
+    // Clean up the observer
+    return () => {
+      if (imgRef.current) {
+        observer.unobserve(imgRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible && oldIsVisible.current) {
+      onExitingViewport();
+    }
+  }, [isVisible]);
+
   return (
     <Image
+      ref={imgRef}
       src={image}
       alt="No image"
       width={PROFILE_IMAGE_SIZE}


### PR DESCRIPTION
## What was done?

Besides checking if the profile is close to the active profile, we keep it mounted as long as it is still visible

## Why?

There is an issue of syncronization between the "scroll" animation and
the loading of the profile images, this causes that the image
containers get unmounted while the animation is still on going and in
the space of the now unmounted image, thats why it only renders the
profile container with the colo(u)r backgound.

Now when mounting the image container we mark it as unsafe to remove,
observe if it intersects the viewport (is visible) and when it is no
longer  visible we remove the mark allowing it to be unmounted.
