### PR TITLE
fix(profilehomescreen): correct purge screen transition

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -61,7 +61,7 @@ const InnerList = styled(TransitionGroup)<{
   transition: transform ${translationAnimationDuration}ms ease;
 `;
 
-const PISTON_ON_PURGE_POSITION = 76.8;
+const PISTON_ON_PURGE_POSITION = 73; // value gotten from ComplexProfileConverter.head_template on 'prepare' stage
 
 export const ProfileHomeScreen = () => {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
## What was done?

Check if the piston is in the purge position with the same value it is checked by the head_template for the profile checks it with (73mm)

## Why?

This to avoid setting the purge screen when the profile will not purge the cylinder