### PR TITLE
feat(quicksettings): show image version

### DIFF
--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -14,7 +14,6 @@ import { routes } from '../../navigation/routes';
 import Styled, {
   VIEWPORT_HEIGHT,
   MARQUEE_MIN_TEXT_LENGTH,
-  SWVersionMenuAnnotation,
   MenuAnnotation,
   ITEM_HEIGHT,
   ITEM_MARGIN
@@ -445,34 +444,20 @@ export function QuickSettings(): JSX.Element {
           $bringToFront={holdAnimation === 'running'}
           $osStatus={osStatusVisible ? osStatusData.status.toLowerCase() : null}
           $osInfo={osStatusVisible ? osStatusInfo : null}
+          $SWVersion={`${!isPending ? deviceInfo.software_version : 'loading ...'}`}
         >
-          {settings.map((option) => {
-            switch (option.key) {
-              case 'sw_version':
-                return (
-                  <Styled.SWVersionOption>
-                    <SWVersionMenuAnnotation>
-                      {`${!isPending ? deviceInfo.software_version : 'loading ...'}`}
-                    </SWVersionMenuAnnotation>
-                  </Styled.SWVersionOption>
-                );
-              default:
-                return (
-                  <Styled.Option
-                    key={option.key}
-                    $hasSeparator={option.hasSeparator}
-                    $isAnimating={
-                      holdAnimation === 'running' && option.longpress
-                    }
-                    onAnimationEnd={handleAnimationEnd}
-                  >
-                    <span>
-                      {option.key === 'preheat' ? preheatTimer : option.label}
-                    </span>
-                  </Styled.Option>
-                );
-            }
-          })}
+          {settings.map((option) => (
+            <Styled.Option
+              key={option.key}
+              $hasSeparator={option.hasSeparator}
+              $isAnimating={holdAnimation === 'running' && option.longpress}
+              onAnimationEnd={handleAnimationEnd}
+            >
+              <span>
+                {option.key === 'preheat' ? preheatTimer : option.label}
+              </span>
+            </Styled.Option>
+          ))}
         </Styled.OptionsContainer>
 
         <Styled.ActiveIndicator $holdAnimation={holdAnimation}>
@@ -484,31 +469,22 @@ export function QuickSettings(): JSX.Element {
             }
             $osInfo={osStatusVisible ? osStatusInfo : null}
           >
-            {settings.map((option, index) => {
-              switch (option.key) {
-                case 'sw_version':
-                  return <></>;
-                default:
-                  return (
-                    <Styled.Option
-                      key={option.key}
-                      $hasSeparator={option.hasSeparator}
-                      $isMarquee={
-                        activeOption === index &&
-                        option.label.length > MARQUEE_MIN_TEXT_LENGTH
-                      }
-                      $isMultiItem={option.longpress}
-                    >
-                      <span>
-                        {option.key === 'preheat' ? preheatTimer : option.label}
-                      </span>
-                      {option.longpress && (
-                        <MenuAnnotation>HOLD</MenuAnnotation>
-                      )}
-                    </Styled.Option>
-                  );
-              }
-            })}
+            {settings.map((option, index) => (
+              <Styled.Option
+                key={option.key}
+                $hasSeparator={option.hasSeparator}
+                $isMarquee={
+                  activeOption === index &&
+                  option.label.length > MARQUEE_MIN_TEXT_LENGTH
+                }
+                $isMultiItem={option.longpress}
+              >
+                <span>
+                  {option.key === 'preheat' ? preheatTimer : option.label}
+                </span>
+                {option.longpress && <MenuAnnotation>HOLD</MenuAnnotation>}
+              </Styled.Option>
+            ))}
           </Styled.OptionsContainer>
         </Styled.ActiveIndicator>
       </Styled.Viewport>

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -15,7 +15,9 @@ import Styled, {
   VIEWPORT_HEIGHT,
   MARQUEE_MIN_TEXT_LENGTH,
   SWVersionMenuAnnotation,
-  MenuAnnotation
+  MenuAnnotation,
+  ITEM_HEIGHT,
+  ITEM_MARGIN
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
 import { formatTime } from '../../utils';
@@ -168,10 +170,6 @@ export function QuickSettings(): JSX.Element {
     !HIDDEN_OS_STATUS_SCREENS.includes(currentScreen);
   const [activeOption, setActiveOption] = useState(0);
 
-  useEffect(() => {
-    setActiveOption(osStatusVisible ? 1 : 0);
-  }, [osStatusVisible]);
-
   const osStatusInfo = useMemo(() => {
     if (osStatusError) {
       return '';
@@ -228,8 +226,7 @@ export function QuickSettings(): JSX.Element {
         );
       },
       left() {
-        const minIndex = osStatusVisible ? 1 : 0;
-        setActiveOption((prev) => Math.max(prev - 1, minIndex));
+        setActiveOption((prev) => Math.max(prev - 1, 0));
         setCounterESGG(0);
       },
       right() {
@@ -387,19 +384,9 @@ export function QuickSettings(): JSX.Element {
 
     const backAvailable = !!routes[currentScreen].parent;
 
-    const osStatusSettingOption: QuickSettingOption | null = osStatusVisible
-      ? {
-          key: 'os_update',
-          label: osStatusInfo,
-          isStatusInfo: true,
-          status: osStatusData.status.toLowerCase()
-        }
-      : null;
-
     switch (currentScreen) {
       case 'defaultProfiles':
         setSettings([
-          ...(osStatusSettingOption ? [osStatusSettingOption] : []),
           ...(defaultProfileSelectedForDetails
             ? [{ key: 'details', label: 'Show details' }]
             : []),
@@ -424,7 +411,6 @@ export function QuickSettings(): JSX.Element {
             ? context.filter((c) => c.key !== 'delete')
             : context;
           setSettings([
-            ...(osStatusSettingOption ? [osStatusSettingOption] : []),
             ...(requiresProfileContext ? newContext : []),
             ...(backAvailable ? [prevScreenSetting] : []),
             ...defaultSettings
@@ -445,6 +431,8 @@ export function QuickSettings(): JSX.Element {
     () =>
       calculateOptionPosition({
         activeOptionIdx: activeOption,
+        adjustmentFn: (position) =>
+          osStatusVisible ? position - (ITEM_HEIGHT + ITEM_MARGIN) : position,
         settings
       }),
     [activeOption, settings]
@@ -454,7 +442,10 @@ export function QuickSettings(): JSX.Element {
     () =>
       calculateOptionPosition({
         activeOptionIdx: activeOption,
-        adjustmentFn: (position) => position - VIEWPORT_HEIGHT / 2,
+        adjustmentFn: (position) =>
+          osStatusVisible
+            ? position - (ITEM_HEIGHT + ITEM_MARGIN + VIEWPORT_HEIGHT / 2)
+            : position - VIEWPORT_HEIGHT / 2,
         settings
       }),
     [activeOption, settings]
@@ -469,23 +460,15 @@ export function QuickSettings(): JSX.Element {
   );
   return (
     <Styled.SettingsContainer>
-      <Styled.Viewport>
+      <Styled.Viewport className="Viewport">
         <Styled.OptionsContainer
           $translateY={optionPositionOutter}
           $bringToFront={holdAnimation === 'running'}
+          $osStatus={osStatusVisible ? osStatusData.status.toLowerCase() : null}
+          $osInfo={osStatusVisible ? osStatusInfo : null}
         >
           {settings.map((option) => {
             switch (option.key) {
-              case 'os_update':
-                return (
-                  <Styled.OsStatusOption
-                    key={option.key}
-                    $status={option.status}
-                    $hasSeparator={option.hasSeparator}
-                  >
-                    <span>{option.label}</span>
-                  </Styled.OsStatusOption>
-                );
               case 'sw_version':
                 return (
                   <Styled.SWVersionOption>
@@ -517,19 +500,13 @@ export function QuickSettings(): JSX.Element {
           <Styled.OptionsContainer
             $translateY={optionPositionInner}
             $isInner={true}
+            $osStatus={
+              osStatusVisible ? osStatusData.status.toLowerCase() : null
+            }
+            $osInfo={osStatusVisible ? osStatusInfo : null}
           >
             {settings.map((option, index) => {
               switch (option.key) {
-                case 'os_update':
-                  return (
-                    <Styled.OsStatusOption
-                      key={option.key}
-                      $status={option.status}
-                      $hasSeparator={option.hasSeparator}
-                    >
-                      <span>{option.label}</span>
-                    </Styled.OsStatusOption>
-                  );
                 case 'sw_version':
                   return <></>;
                 default:

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -92,10 +92,6 @@ const defaultSettings: QuickSettingOption[] = [
   {
     key: 'exit',
     label: 'exit'
-  },
-  {
-    key: 'sw_version',
-    label: 'Version: '
   }
 ];
 
@@ -117,10 +113,6 @@ const inBrewSettings: QuickSettingOption[] = [
   {
     key: 'exit',
     label: 'exit'
-  },
-  {
-    key: 'sw_version',
-    label: 'Version: '
   }
 ];
 
@@ -205,16 +197,6 @@ export function QuickSettings(): JSX.Element {
     }
   };
 
-  const versionVisibleInCurrentMenu: boolean = useMemo(() => {
-    const isVersionPresent = settings.find(
-      (value) => value.key === 'sw_version'
-    );
-    if (isVersionPresent) {
-      return true;
-    }
-    return false;
-  }, [settings]);
-
   useHandleGestures(
     {
       context() {
@@ -230,10 +212,7 @@ export function QuickSettings(): JSX.Element {
         setCounterESGG(0);
       },
       right() {
-        const maxIndexOffset = versionVisibleInCurrentMenu ? 2 : 1;
-        setActiveOption((prev) =>
-          Math.min(prev + 1, settings.length - maxIndexOffset)
-        );
+        setActiveOption((prev) => Math.min(prev + 1, settings.length - 1));
         if (settings[activeOption].key === 'exit') {
           setCounterESGG(counterESGG + 1);
         }

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -9,11 +9,12 @@ import {
 } from '../store/features/screens/screens-slice';
 import { useContinueBrewAction, useSocket } from '../store/SocketManager';
 
-import { useOSStatus } from '../../hooks/useDeviceOSStatus';
+import { useOSStatus, useDeviceInfo } from '../../hooks/useDeviceOSStatus';
 import { routes } from '../../navigation/routes';
 import Styled, {
   VIEWPORT_HEIGHT,
   MARQUEE_MIN_TEXT_LENGTH,
+  SWVersionMenuAnnotation,
   MenuAnnotation
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
@@ -89,6 +90,10 @@ const defaultSettings: QuickSettingOption[] = [
   {
     key: 'exit',
     label: 'exit'
+  },
+  {
+    key: 'sw_version',
+    label: 'Version: '
   }
 ];
 
@@ -110,6 +115,10 @@ const inBrewSettings: QuickSettingOption[] = [
   {
     key: 'exit',
     label: 'exit'
+  },
+  {
+    key: 'sw_version',
+    label: 'Version: '
   }
 ];
 
@@ -145,6 +154,7 @@ export function QuickSettings(): JSX.Element {
 
   const { forceIdle } = useIdleTimer();
 
+  const { data: deviceInfo, isPending } = useDeviceInfo();
   const { data: osStatusData, error: osStatusError } = useOSStatus();
 
   const HIDDEN_OS_STATUS_SCREENS: ScreenType[] = [
@@ -197,6 +207,16 @@ export function QuickSettings(): JSX.Element {
     }
   };
 
+  const versionVisibleInCurrentMenu: boolean = useMemo(() => {
+    const isVersionPresent = settings.find(
+      (value) => value.key === 'sw_version'
+    );
+    if (isVersionPresent) {
+      return true;
+    }
+    return false;
+  }, [settings]);
+
   useHandleGestures(
     {
       context() {
@@ -213,7 +233,10 @@ export function QuickSettings(): JSX.Element {
         setCounterESGG(0);
       },
       right() {
-        setActiveOption((prev) => Math.min(prev + 1, settings.length - 1));
+        const maxIndexOffset = versionVisibleInCurrentMenu ? 2 : 1;
+        setActiveOption((prev) =>
+          Math.min(prev + 1, settings.length - maxIndexOffset)
+        );
         if (settings[activeOption].key === 'exit') {
           setCounterESGG(counterESGG + 1);
         }
@@ -451,28 +474,43 @@ export function QuickSettings(): JSX.Element {
           $translateY={optionPositionOutter}
           $bringToFront={holdAnimation === 'running'}
         >
-          {settings.map((option) =>
-            option.key === 'os_update' ? (
-              <Styled.OsStatusOption
-                key={option.key}
-                $status={option.status}
-                $hasSeparator={option.hasSeparator}
-              >
-                <span>{option.label}</span>
-              </Styled.OsStatusOption>
-            ) : (
-              <Styled.Option
-                key={option.key}
-                $hasSeparator={option.hasSeparator}
-                $isAnimating={holdAnimation === 'running' && option.longpress}
-                onAnimationEnd={handleAnimationEnd}
-              >
-                <span>
-                  {option.key === 'preheat' ? preheatTimer : option.label}
-                </span>
-              </Styled.Option>
-            )
-          )}
+          {settings.map((option) => {
+            switch (option.key) {
+              case 'os_update':
+                return (
+                  <Styled.OsStatusOption
+                    key={option.key}
+                    $status={option.status}
+                    $hasSeparator={option.hasSeparator}
+                  >
+                    <span>{option.label}</span>
+                  </Styled.OsStatusOption>
+                );
+              case 'sw_version':
+                return (
+                  <Styled.SWVersionOption>
+                    <SWVersionMenuAnnotation>
+                      {`${!isPending ? deviceInfo.software_version : 'loading ...'}`}
+                    </SWVersionMenuAnnotation>
+                  </Styled.SWVersionOption>
+                );
+              default:
+                return (
+                  <Styled.Option
+                    key={option.key}
+                    $hasSeparator={option.hasSeparator}
+                    $isAnimating={
+                      holdAnimation === 'running' && option.longpress
+                    }
+                    onAnimationEnd={handleAnimationEnd}
+                  >
+                    <span>
+                      {option.key === 'preheat' ? preheatTimer : option.label}
+                    </span>
+                  </Styled.Option>
+                );
+            }
+          })}
         </Styled.OptionsContainer>
 
         <Styled.ActiveIndicator $holdAnimation={holdAnimation}>
@@ -480,32 +518,41 @@ export function QuickSettings(): JSX.Element {
             $translateY={optionPositionInner}
             $isInner={true}
           >
-            {settings.map((option, index) =>
-              option.key === 'os_update' ? (
-                <Styled.OsStatusOption
-                  key={option.key}
-                  $status={option.status}
-                  $hasSeparator={option.hasSeparator}
-                >
-                  <span>{option.label}</span>
-                </Styled.OsStatusOption>
-              ) : (
-                <Styled.Option
-                  key={option.key}
-                  $hasSeparator={option.hasSeparator}
-                  $isMarquee={
-                    activeOption === index &&
-                    option.label.length > MARQUEE_MIN_TEXT_LENGTH
-                  }
-                  $isMultiItem={option.longpress}
-                >
-                  <span>
-                    {option.key === 'preheat' ? preheatTimer : option.label}
-                  </span>
-                  {option.longpress && <MenuAnnotation>HOLD</MenuAnnotation>}
-                </Styled.Option>
-              )
-            )}
+            {settings.map((option, index) => {
+              switch (option.key) {
+                case 'os_update':
+                  return (
+                    <Styled.OsStatusOption
+                      key={option.key}
+                      $status={option.status}
+                      $hasSeparator={option.hasSeparator}
+                    >
+                      <span>{option.label}</span>
+                    </Styled.OsStatusOption>
+                  );
+                case 'sw_version':
+                  return <></>;
+                default:
+                  return (
+                    <Styled.Option
+                      key={option.key}
+                      $hasSeparator={option.hasSeparator}
+                      $isMarquee={
+                        activeOption === index &&
+                        option.label.length > MARQUEE_MIN_TEXT_LENGTH
+                      }
+                      $isMultiItem={option.longpress}
+                    >
+                      <span>
+                        {option.key === 'preheat' ? preheatTimer : option.label}
+                      </span>
+                      {option.longpress && (
+                        <MenuAnnotation>HOLD</MenuAnnotation>
+                      )}
+                    </Styled.Option>
+                  );
+              }
+            })}
           </Styled.OptionsContainer>
         </Styled.ActiveIndicator>
       </Styled.Viewport>

--- a/src/styles/utils/mixins.ts
+++ b/src/styles/utils/mixins.ts
@@ -33,7 +33,7 @@ export const EXTRA_MARGIN_AFTER_BORDER = 10;
  */
 export const MARQUEE_MIN_TEXT_LENGTH = 22;
 
-const TOP_MARGIN_FOR_LIST_SEPARATION = 130;
+const TOP_MARGIN_FOR_LIST_SEPARATION = 100;
 
 const SettingsContainer = styled.div`
   display: flex;
@@ -146,15 +146,14 @@ const OptionsContainer = styled.div<{
   ${({ $isInner }) => $isInner && 'top: 50%; left: 50%;'}
   ${({ $bringToFront }) => ($bringToFront ? 'z-index: 20;' : 'z-index: 10;')}
  
-  ${({ $SWVersion }) => {
-    return (
-      $SWVersion &&
-      `
+  ${({ $SWVersion }) =>
+    $SWVersion &&
+    `
         &::after{
           position: relative;
           content: "${$SWVersion}";
           text-transform: none;
-          font-size: 22px;
+          font-size: 20px;
           letter-spacing: 2.2px;
           text-align: left;
           padding: 3px 5px 0px 5px;
@@ -166,19 +165,13 @@ const OptionsContainer = styled.div<{
           font-family: 'ABC Diatype Mono';
           border: 1px solid currentColor;
           border-radius: 4px;
-          right: 35px;
+          right: 58px;
         }
-      `
-    );
-  }}
+      `}
 
-  ${({ $osStatus, $osInfo }) => {
-    console.log('$osStatus: ', $osStatus);
-    console.log('$osInfo: ', $osInfo);
-
-    return (
-      $osStatus &&
-      `
+  ${({ $osStatus, $osInfo }) =>
+    $osStatus &&
+    `
        &::before {
          width: 90%;
          content: "${$osInfo ? `${$osInfo}` : ''}";
@@ -192,9 +185,7 @@ const OptionsContainer = styled.div<{
          justify-content: start;
          color: ${getOsStatusColor($osStatus)}};
        }
-     `
-    );
-  }}
+     `}
 `;
 
 const Option = styled.div<{

--- a/src/styles/utils/mixins.ts
+++ b/src/styles/utils/mixins.ts
@@ -262,10 +262,6 @@ const Option = styled.div<{
   }
 `;
 
-const SWVersionOption = styled(Option)`
-  margin-top: ${TOP_MARGIN_FOR_LIST_SEPARATION}px;
-`;
-
 const OsStatusOption = styled(Option)<{ $status?: string }>`
   text-transform: none;
   ${({ $status }) => $status === 'complete' && `color: #ffc107`}
@@ -298,22 +294,6 @@ export const MenuAnnotation = styled.span<{ $marginRigth?: string }>`
   margin-right: ${({ $marginRigth }) => $marginRigth || '0'};
 `;
 
-export const SWVersionMenuAnnotation = styled.span<{ $marginRigth?: string }>`
-  display: flex;
-  align-items: center;
-  height: ${ITEM_HEIGHT}px;
-  font-size: 22px;
-  text-align: left;
-  font-family: 'ABC Diatype Mono';
-  border: 1px solid currentColor;
-  border-radius: 4px;
-  padding: 5px 5px 2px 5px;
-  text-transform: none;
-  line-height: normal;
-  margin-top: -5px;
-  margin-right: ${({ $marginRigth }) => $marginRigth || '0'};
-`;
-
 const SelectedOption = styled(Option)<{ $gapValue?: string }>`
   justify-content: space-between;
 `;
@@ -326,6 +306,5 @@ export default {
   Option,
   OsStatusOption,
   NetworkOption,
-  SWVersionOption,
   SelectedOption
 };

--- a/src/styles/utils/mixins.ts
+++ b/src/styles/utils/mixins.ts
@@ -111,10 +111,24 @@ const ActiveIndicator = styled.div<{ $holdAnimation?: holdAnimationState }>`
       : 'none'};
 `;
 
+const getOsStatusColor = (status: string): string => {
+  switch (status) {
+    case 'complete':
+    case 'downloading':
+    case 'installing':
+      return '#ffc107';
+    case 'failed':
+      return '#f44336';
+    default:
+      return '';
+  }
+};
 const OptionsContainer = styled.div<{
   $translateY: number;
   $isInner?: boolean;
   $bringToFront?: boolean;
+  $osStatus?: string | null;
+  $osInfo?: string | null;
 }>`
   position: absolute;
   width: 100%;
@@ -130,6 +144,62 @@ const OptionsContainer = styled.div<{
   ${({ $isInner }) => ($isInner ? 'color: #000;' : 'color: #565656;')}
   ${({ $isInner }) => $isInner && 'top: 50%; left: 50%;'}
   ${({ $bringToFront }) => ($bringToFront ? 'z-index: 20;' : 'z-index: 10;')}
+
+    ${({ $osStatus, $osInfo }) => {
+    console.log('$osStatus: ', $osStatus);
+    console.log('$osInfo: ', $osInfo);
+
+    return (
+      $osStatus !== null &&
+      `
+       &::before {
+         width: 90%;
+         content: "${$osInfo ? `${$osInfo}` : ''}";
+         text-transform: none;
+         letter-spacing: 2.2px;
+         font-size: 22px;
+         text-align: left;
+         padding: 0 16px;
+         margin-bottom: 16px;
+         height: ${ITEM_HEIGHT}px;
+         justify-content: start;
+         color: ${getOsStatusColor($osStatus)}};
+       }
+     `
+    );
+  }}
+
+  &::after {
+  }
+`;
+
+const QSContainer = styled.div<{
+  $osStatus: string | null;
+  $osInfo: string | null;
+}>`
+  width: 100%;
+
+  ${({ $osStatus, $osInfo }) => {
+    console.log('$osStatus: ', $osStatus);
+    console.log('$osInfo: ', $osInfo);
+
+    return (
+      $osStatus !== null &&
+      `
+       &::before {
+         content: "${$osInfo ? `${$osInfo}` : ''}";
+         text-transform: none;
+       ${({ $osStatus }) => $osStatus === 'complete' && `color: #ffc107`}
+       ${({ $osStatus }) => $osStatus === 'failed' && `color: #f44336`}
+       ${({ $osStatus }) => $osStatus === 'downloading' && `color: #ffc107`}
+       ${({ $osStatus }) => $osStatus === 'installing' && `color: #ffc107`}
+       }
+     `
+    );
+  }}
+
+  &::after {
+  }
 `;
 
 const Option = styled.div<{
@@ -262,5 +332,6 @@ export default {
   OsStatusOption,
   NetworkOption,
   SWVersionOption,
+  QSContainer,
   SelectedOption
 };

--- a/src/styles/utils/mixins.ts
+++ b/src/styles/utils/mixins.ts
@@ -129,6 +129,7 @@ const OptionsContainer = styled.div<{
   $bringToFront?: boolean;
   $osStatus?: string | null;
   $osInfo?: string | null;
+  $SWVersion?: string;
 }>`
   position: absolute;
   width: 100%;
@@ -144,13 +145,39 @@ const OptionsContainer = styled.div<{
   ${({ $isInner }) => ($isInner ? 'color: #000;' : 'color: #565656;')}
   ${({ $isInner }) => $isInner && 'top: 50%; left: 50%;'}
   ${({ $bringToFront }) => ($bringToFront ? 'z-index: 20;' : 'z-index: 10;')}
+ 
+  ${({ $SWVersion }) => {
+    return (
+      $SWVersion &&
+      `
+        &::after{
+          position: relative;
+          content: "${$SWVersion}";
+          text-transform: none;
+          font-size: 22px;
+          letter-spacing: 2.2px;
+          text-align: left;
+          padding: 3px 5px 0px 5px;
+          margin-top: ${TOP_MARGIN_FOR_LIST_SEPARATION}px;
+          height: ${ITEM_HEIGHT}px;
+          justify-content: start;
+          display: flex;
+          align-items: center;
+          font-family: 'ABC Diatype Mono';
+          border: 1px solid currentColor;
+          border-radius: 4px;
+          right: 35px;
+        }
+      `
+    );
+  }}
 
-    ${({ $osStatus, $osInfo }) => {
+  ${({ $osStatus, $osInfo }) => {
     console.log('$osStatus: ', $osStatus);
     console.log('$osInfo: ', $osInfo);
 
     return (
-      $osStatus !== null &&
+      $osStatus &&
       `
        &::before {
          width: 90%;
@@ -168,38 +195,6 @@ const OptionsContainer = styled.div<{
      `
     );
   }}
-
-  &::after {
-  }
-`;
-
-const QSContainer = styled.div<{
-  $osStatus: string | null;
-  $osInfo: string | null;
-}>`
-  width: 100%;
-
-  ${({ $osStatus, $osInfo }) => {
-    console.log('$osStatus: ', $osStatus);
-    console.log('$osInfo: ', $osInfo);
-
-    return (
-      $osStatus !== null &&
-      `
-       &::before {
-         content: "${$osInfo ? `${$osInfo}` : ''}";
-         text-transform: none;
-       ${({ $osStatus }) => $osStatus === 'complete' && `color: #ffc107`}
-       ${({ $osStatus }) => $osStatus === 'failed' && `color: #f44336`}
-       ${({ $osStatus }) => $osStatus === 'downloading' && `color: #ffc107`}
-       ${({ $osStatus }) => $osStatus === 'installing' && `color: #ffc107`}
-       }
-     `
-    );
-  }}
-
-  &::after {
-  }
 `;
 
 const Option = styled.div<{
@@ -332,6 +327,5 @@ export default {
   OsStatusOption,
   NetworkOption,
   SWVersionOption,
-  QSContainer,
   SelectedOption
 };

--- a/src/styles/utils/mixins.ts
+++ b/src/styles/utils/mixins.ts
@@ -33,6 +33,8 @@ export const EXTRA_MARGIN_AFTER_BORDER = 10;
  */
 export const MARQUEE_MIN_TEXT_LENGTH = 22;
 
+const TOP_MARGIN_FOR_LIST_SEPARATION = 130;
+
 const SettingsContainer = styled.div`
   display: flex;
   align-items: center;
@@ -195,6 +197,10 @@ const Option = styled.div<{
   }
 `;
 
+const SWVersionOption = styled(Option)`
+  margin-top: ${TOP_MARGIN_FOR_LIST_SEPARATION}px;
+`;
+
 const OsStatusOption = styled(Option)<{ $status?: string }>`
   text-transform: none;
   ${({ $status }) => $status === 'complete' && `color: #ffc107`}
@@ -227,6 +233,22 @@ export const MenuAnnotation = styled.span<{ $marginRigth?: string }>`
   margin-right: ${({ $marginRigth }) => $marginRigth || '0'};
 `;
 
+export const SWVersionMenuAnnotation = styled.span<{ $marginRigth?: string }>`
+  display: flex;
+  align-items: center;
+  height: ${ITEM_HEIGHT}px;
+  font-size: 22px;
+  text-align: left;
+  font-family: 'ABC Diatype Mono';
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  padding: 5px 5px 2px 5px;
+  text-transform: none;
+  line-height: normal;
+  margin-top: -5px;
+  margin-right: ${({ $marginRigth }) => $marginRigth || '0'};
+`;
+
 const SelectedOption = styled(Option)<{ $gapValue?: string }>`
   justify-content: space-between;
 `;
@@ -239,5 +261,6 @@ export default {
   Option,
   OsStatusOption,
   NetworkOption,
+  SWVersionOption,
   SelectedOption
 };


### PR DESCRIPTION
The image version reported by the backend is shown at the bottom of the quick settings item list

<img width="485" height="485" alt="image" src="https://github.com/user-attachments/assets/5544c30b-a971-4575-abc9-1916a7ed7038" />

