### PR TITLE
chore(profilestart): start the profile on profilehomescreen again

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -20,7 +20,6 @@ import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { OptionsMenu } from './OptionsMenu';
 import { useContinueBrewAction } from '../store/SocketManager';
 import { useProfileContext } from '../../context/ProfileContext';
-import { loadProfileData, startProfile } from '../../api/profile';
 
 const PushToStartLabel = styled.div`
   font-size: 20px;
@@ -68,16 +67,10 @@ const transitionDuration = 600;
 
 export const HeatingScreen = () => {
   const dispatch = useAppDispatch();
-  const {
-    lastProfile,
-    mergedProfiles,
-    localProfileIndex: activeProfile,
-    profileStarting
-  } = useProfileContext();
+  const { lastProfile, profileStarting } = useProfileContext();
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const continueBrew = useContinueBrewAction();
   const waterStatus = useAppSelector((state) => state.stats.waterStatus);
-  const prevScreen = useAppSelector((state) => state.screen.prev);
   const temperature =
     useAppSelector((state) => Math.round(state.stats.sensors.t)) || 0;
   const hasNotifications = useAppSelector(
@@ -94,27 +87,6 @@ export const HeatingScreen = () => {
   const [temperatureTarget, setTemperatureTarget] = useState(
     temperatureTargetStatus || 0
   );
-
-  // send the profile and start it only when coming from profileHome and
-  // the profileStarting flag is set
-
-  useEffect(() => {
-    const loadAndStartProfile = async () => {
-      const profile = mergedProfiles?.[activeProfile];
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { isLast, temporary, ...cleanProfile } = profile;
-      const data = await loadProfileData(cleanProfile);
-
-      if (data) {
-        await startProfile();
-      }
-    };
-
-    if (prevScreen === 'profileHome' && profileStarting) {
-      loadAndStartProfile();
-    }
-  }, []);
 
   useEffect(() => {
     if (lastProfile && lastProfile.profile && temperatureTarget == 0) {

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -20,6 +20,7 @@ import { PlusIcon } from './PlusIcon';
 import { LastLabel } from './LastLabel';
 import { useIsOnline } from '../../hooks/useIsOnline';
 import { useSocket } from '../store/SocketManager';
+import { loadProfileData, startProfile } from '../../api/profile';
 
 const CARD_GAP = 79;
 const CARD_SIZE = PROFILE_ENTRY_SIZE + CARD_GAP;
@@ -100,7 +101,20 @@ export const ProfileHomeScreen = () => {
   };
 
   const animationFinished = async () => {
+    const loadAndStartProfile = async () => {
+      const profile = mergedProfiles?.[activeOption];
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { isLast, temporary, ...cleanProfile } = profile;
+      const data = await loadProfileData(cleanProfile);
+
+      if (data) {
+        await startProfile();
+      }
+    };
+
     setProfileStarting(true);
+    loadAndStartProfile();
     if (!requiresPurge.current) {
       dispatch(setScreen('heating'));
     } else {

--- a/src/components/PurgePiston/PurgeScreen.tsx
+++ b/src/components/PurgePiston/PurgeScreen.tsx
@@ -6,54 +6,24 @@ import { notificationSelector } from '../store/features/notifications/notificati
 
 import './piston.css';
 import { setScreen } from '../store/features/screens/screens-slice';
-import { loadProfileData, startProfile } from '../../api/profile';
 import { useProfileContext } from '../../context/ProfileContext';
 
 export function PurgeScreen(): JSX.Element {
   const dispatch = useAppDispatch();
 
-  const {
-    mergedProfiles,
-    localProfileIndex: activeProfile,
-    profileStarting
-  } = useProfileContext();
+  const { profileStarting } = useProfileContext();
 
   const statsName = useAppSelector((state) => state.stats.name);
   const sensors = useAppSelector((state) => state.stats.sensors);
   const hasNotifications = useAppSelector(
     notificationSelector.selectHasNotifications
   );
-  const prevScreen = useAppSelector((state) => state.screen.prev);
 
   useEffect(() => {
     if (statsName === 'idle' && !hasNotifications && !profileStarting) {
       dispatch(setScreen('profileHome'));
     }
   }, [statsName]);
-
-  // send the profile and start it only when coming from profileHome and
-  // the profileStarting flag is set
-
-  useEffect(() => {
-    const loadAndStartProfile = async () => {
-      const profile = mergedProfiles?.[activeProfile];
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { isLast, temporary, ...cleanProfile } = profile;
-      const data = await loadProfileData(cleanProfile);
-
-      if (data) {
-        await startProfile();
-        console.log('starting profile');
-      } else {
-        console.log('loadProfileData returned nothing, not starting profile');
-      }
-    };
-
-    if (prevScreen === 'profileHome' && profileStarting) {
-      loadAndStartProfile();
-    }
-  }, []);
 
   return (
     <div className="piston-container">


### PR DESCRIPTION
## What was done?

To avoid duplicate logic in the HeatingScreen and the PurgeScreen to start the shot, the logic goes back to profileHomeScreen.