### PR TITLE
fix(quicksettings): exit option was transparent to click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const App = (): JSX.Element => {
         );
       }
     },
-    isExtracting || bubbleDisplay.visible
+    isExtracting || bubbleDisplay.interceptsGesture
   );
 
   const [isScaleVisible, setIsScaleVisible] = useState<boolean>(false);

--- a/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
+++ b/src/components/BrewCompleteScreen/BrewCompleteScreen.tsx
@@ -109,7 +109,7 @@ export const BrewCompleteScreen = () => {
         setKeepGraph(true);
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   const stateLabel =

--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -301,7 +301,7 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   const toUpperOrLowerCase = (

--- a/src/components/DefaultProfiles/DefaultProfiles.tsx
+++ b/src/components/DefaultProfiles/DefaultProfiles.tsx
@@ -110,7 +110,7 @@ export const DefaultProfiles = ({ transitioning }: RouteProps): JSX.Element => {
         setActiveIndex(next);
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   useEffect(() => {

--- a/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
+++ b/src/components/HeatTimeoutAfterShot/HeatTimeoutAfterShot.tsx
@@ -43,7 +43,7 @@ export const HeatTimeoutAfterShot: React.FC = () => {
         );
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -212,7 +212,7 @@ export const HeatingScreen = () => {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -66,7 +66,7 @@ export function Notification(): JSX.Element {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   if (!currentNotification) {

--- a/src/components/OnOff/OnOff.tsx
+++ b/src/components/OnOff/OnOff.tsx
@@ -49,7 +49,7 @@ export function OnOff({ type }: Props): JSX.Element {
         dispatch(setScreen('pressetSettings'));
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/PressetSettings/PressetProfileImage.tsx
+++ b/src/components/PressetSettings/PressetProfileImage.tsx
@@ -81,7 +81,7 @@ export const PressetProfileImage = ({ transitioning }: RouteProps) => {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   useEffect(() => {

--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -184,7 +184,7 @@ export function PressetSettings(): JSX.Element {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -210,7 +210,7 @@ export const ProfileHomeScreen = () => {
         setIsPressingDown(false);
       }
     },
-    bubbleDisplay.visible || profileStarting
+    bubbleDisplay.interceptsGesture || profileStarting
   );
 
   if (!mergedProfiles) {

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -333,8 +333,20 @@ export function QuickSettings(): JSX.Element {
           }
 
           case 'exit': {
+            setTimeout(() => {
+              setBubbleDisplay({
+                visible: false,
+                component: undefined,
+                interceptsGesture: false
+              });
+            }, 100);
+
             dispatch(
-              setBubbleDisplay({ visible: false, component: undefined })
+              setBubbleDisplay({
+                visible: false,
+                component: undefined,
+                interceptsGesture: true
+              })
             );
             break;
           }
@@ -343,7 +355,10 @@ export function QuickSettings(): JSX.Element {
           case 'skip_step': {
             skipStep();
             dispatch(
-              setBubbleDisplay({ visible: false, component: undefined })
+              setBubbleDisplay({
+                visible: false,
+                component: undefined
+              })
             );
             break;
           }
@@ -351,7 +366,7 @@ export function QuickSettings(): JSX.Element {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const requiresProfileContext: boolean =

--- a/src/components/Scale/Scale.tsx
+++ b/src/components/Scale/Scale.tsx
@@ -207,7 +207,7 @@ export const Scale = memo(
           closeScale();
         }
       },
-      isExtracting || bubbleDisplay.visible
+      isExtracting || bubbleDisplay.interceptsGesture
     );
 
     useEffect(() => {

--- a/src/components/SettingNumerical/SettingNumerical.tsx
+++ b/src/components/SettingNumerical/SettingNumerical.tsx
@@ -134,7 +134,7 @@ export function SettingNumerical({ type }: Props): JSX.Element {
         dispatch(setScreen('pressetSettings'));
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -221,7 +221,7 @@ export const AdvancedSettings = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Advanced/DeviceInfoScreen.tsx
+++ b/src/components/Settings/Advanced/DeviceInfoScreen.tsx
@@ -93,7 +93,7 @@ export const DeviceInfoScreen = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
   const optionPositionOutter = useMemo(
     () =>

--- a/src/components/Settings/Advanced/FactoryReset.tsx
+++ b/src/components/Settings/Advanced/FactoryReset.tsx
@@ -70,7 +70,7 @@ export const FactoryReset = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Advanced/IdleScreenSetting.tsx
+++ b/src/components/Settings/Advanced/IdleScreenSetting.tsx
@@ -84,7 +84,7 @@ export const IdleScreenSetting = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Advanced/Manufacturing.tsx
+++ b/src/components/Settings/Advanced/Manufacturing.tsx
@@ -121,7 +121,7 @@ export const Manufacturing = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Advanced/TimeDate/DateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/DateConfig.tsx
@@ -123,7 +123,7 @@ export function DateConfig(): JSX.Element {
         dispatch(setBubbleDisplay({ visible: true, component: 'timeDate' }));
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/Settings/Advanced/TimeDate/TimeConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeConfig.tsx
@@ -108,7 +108,7 @@ export function TimeConfig(): JSX.Element {
         dispatch(setBubbleDisplay({ visible: true, component: 'timeDate' }));
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
@@ -108,7 +108,7 @@ export function TimeDate(): JSX.Element {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/CountrySettings.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/CountrySettings.tsx
@@ -63,7 +63,7 @@ export default function CountrySettings() {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return (

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneConfig.tsx
@@ -103,7 +103,7 @@ export const TimeZoneConfig = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings.tsx
@@ -76,7 +76,7 @@ export default function TimeZoneSettings() {
         }
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
   return (
     <Container>

--- a/src/components/Settings/Advanced/UpdateChannel.tsx
+++ b/src/components/Settings/Advanced/UpdateChannel.tsx
@@ -57,7 +57,7 @@ export const UpdateChannel = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/BrewSettings.tsx
+++ b/src/components/Settings/BrewSettings.tsx
@@ -124,7 +124,7 @@ export function BrewSettings(): JSX.Element {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/ScrollDirection.tsx
+++ b/src/components/Settings/ScrollDirection.tsx
@@ -90,7 +90,7 @@ export function ScrollDirectionSettings(): JSX.Element {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -134,7 +134,7 @@ export function Settings(): JSX.Element {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   const optionPositionOutter = useMemo(

--- a/src/components/Settings/USBSettings.tsx
+++ b/src/components/Settings/USBSettings.tsx
@@ -103,7 +103,7 @@ export const USBSettings = () => {
         }
       }
     },
-    !bubbleDisplay.visible
+    !bubbleDisplay.interceptsGesture
   );
 
   if (!globalSettings) {

--- a/src/components/ShotGraph/ShotGraphScreen.tsx
+++ b/src/components/ShotGraph/ShotGraphScreen.tsx
@@ -144,7 +144,7 @@ export const ShotGraph = ({
         );
       }
     },
-    bubbleDisplay.visible || isStatic
+    bubbleDisplay.interceptsGesture || isStatic
   );
 
   useEffect(() => {
@@ -290,7 +290,7 @@ export const ShotGraphScreen = () => {
         dispatch(setScreen('profileHome'));
       }
     },
-    bubbleDisplay.visible
+    bubbleDisplay.interceptsGesture
   );
 
   return <ShotGraph profile={activeProfile} />;

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -64,6 +64,7 @@ interface ScreenState {
   value: ScreenType;
   prev?: ScreenType;
   bubbleDisplay: {
+    interceptsGesture: boolean;
     visible: boolean;
     component?: ScreenType;
     previousComponent?: ScreenType;
@@ -73,6 +74,7 @@ interface ScreenState {
 const initialState: ScreenState = {
   prev: undefined,
   bubbleDisplay: {
+    interceptsGesture: false,
     visible: false,
     component: undefined,
     previousComponent: undefined
@@ -94,11 +96,17 @@ const screenSlice = createSlice({
     },
     setBubbleDisplay: (
       state: ScreenState,
-      action: PayloadAction<{ visible: boolean; component?: ScreenType }>
+      action: PayloadAction<{
+        visible: boolean;
+        component?: ScreenType;
+        interceptsGesture?: boolean;
+      }>
     ) => {
       state.bubbleDisplay.visible = action.payload.visible;
       state.bubbleDisplay.previousComponent = state.bubbleDisplay.component;
       state.bubbleDisplay.component = action.payload.component;
+      state.bubbleDisplay.interceptsGesture =
+        action.payload.interceptsGesture || action.payload.visible;
     }
   }
 });


### PR DESCRIPTION
When clicking the 'exit' option in the quick settings menu, the gesture was also registered on the underlying screen.

## What was done?

We now implement a 'interceptsGesture' attribute to the screen state under bubbledisplay. This way the 'visible' attribute only handles the visibility of the component, while 'interceptGesture' is used in 'useHandleGestures' to not consume the gesture in the underlying screens

With that new implementation, when clicking on the 'exit' option first the visibility is toggled off, and then after 100ms timeout, the 'intercerptGesture' is turned off.

## Why?

This was probably because when handling the 'gesture' event, it was handled first by the quick settings menu, updating the 'visible' attribute of the bubbleDisplay to false before the underlying screen handle its gesture, so by the time it does, the gesture is also handled there.

## Additional comments & remarks

### Before

https://github.com/user-attachments/assets/11af47c0-dffa-49a1-8d37-a5afc59a0834

### After

https://github.com/user-attachments/assets/7a0ea6c9-27c7-43e1-8142-f46a6e45d7a7


