### PR TITLE
feat(advanced): remove the nightly channel option

### DIFF
--- a/src/components/Settings/Advanced/UpdateChannel.tsx
+++ b/src/components/Settings/Advanced/UpdateChannel.tsx
@@ -11,7 +11,7 @@ import Styled, {
 } from '../../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../../styles/utils/calculateOptionPosition';
 
-const UPDATE_CHANNELS = ['stable', 'beta', 'nightly'];
+const UPDATE_CHANNELS = ['stable', 'beta'];
 
 export const UpdateChannel = () => {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
## What was done?
The option to go to nightly was removed from the advanced software menu
