### PR TITLE
fix(heatingscreen): optionsmenu was not ignoring gestures

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -206,7 +206,7 @@ export const HeatingScreen = () => {
           classNames="fade-options"
         >
           <OptionsMenu
-            ignoreGestures={heatingFinished}
+            ignoreGestures={heatingFinished || bubbleDisplay.interceptsGesture}
             onOptionChange={onOptionChange}
             onOptionHold={onOptionHold}
           />


### PR DESCRIPTION
While the bubble display was open, the heating display's `OptionsMenu` was not ignoring the gestures.