### PR TITLE
fix(circlekeyboard): rotation animation fixed

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -545,7 +545,7 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
       <svg height="390" width="390">
         <svg viewBox="0 0 100 100">
           <g
-            transform={`translate(50 50) rotate(${rotate})`}
+            style={{ transform: `translate(50px, 50px) rotate(${rotate}deg)` }}
             dominantBaseline="text-bottom"
             textAnchor="middle"
             textLength="120%"


### PR DESCRIPTION
## What was done?

SVG attribute `transform` seems to be unaffected by the CSS `transition` attribute, so `transform` is moved as a `CSS` attribute