### PR TITLE
feat(wifi): skip app explanation text for now

### DIFF
--- a/src/components/Wifi/SelectWifi.tsx
+++ b/src/components/Wifi/SelectWifi.tsx
@@ -44,7 +44,7 @@ export const SelectWifi = (): JSX.Element => {
     pressDown() {
       if (wifiList[activeIndex].key === 'back') {
         dispatch(
-          setBubbleDisplay({ visible: true, component: 'connectWifiMenu' })
+          setBubbleDisplay({ visible: true, component: 'wifiSettings' })
         );
       } else {
         dispatch(setBubbleDisplay({ visible: false, component: undefined }));

--- a/src/components/Wifi/WifiSettings.tsx
+++ b/src/components/Wifi/WifiSettings.tsx
@@ -149,7 +149,7 @@ export const WifiSettings = (): JSX.Element => {
           }
           case 'connect_new_network': {
             dispatch(
-              setBubbleDisplay({ visible: true, component: 'connectWifiMenu' })
+              setBubbleDisplay({ visible: true, component: 'selectWifi' })
             );
             break;
           }


### PR DESCRIPTION
## What was done?
The "connect via app" entry has been disabled by skipping over the menu for now
