### PR TITLE
feat(display-alignment): add test screen to advanced menu

### DIFF
--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -9,7 +9,10 @@ import {
   useRootPassword
 } from '../../../hooks/useSettings';
 import { useManufacturingSchema } from '../../../hooks/useManufacturing';
-import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
 import Styled, {
@@ -35,6 +38,11 @@ const initialSettings: SettingsItem[] = [
   {
     key: 'master_calibration',
     label: 'ACAIA master calibration',
+    visible: true
+  },
+  {
+    key: 'displayAlignment',
+    label: 'Display Alignment Screen',
     visible: true
   },
   {
@@ -198,6 +206,15 @@ export const AdvancedSettings = () => {
                 component: 'manufacturingSettings'
               })
             );
+            break;
+          case 'displayAlignment':
+            dispatch(
+              setBubbleDisplay({
+                visible: false,
+                component: null
+              })
+            );
+            dispatch(setScreen('displayAlignment'));
             break;
           case 'back':
             dispatch(

--- a/src/components/Settings/Advanced/DisplayAlignment.tsx
+++ b/src/components/Settings/Advanced/DisplayAlignment.tsx
@@ -1,0 +1,38 @@
+import { useHandleGestures } from '../../../hooks/useHandleGestures';
+import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import Styled from '../../../styles/utils/mixins';
+import { styled } from 'styled-components';
+
+const NUMLINES = 10;
+
+const VerticalLine = styled.div`
+  margin-left: 4.5%;
+  margin-right: 4.5%;
+  width: 1%;
+  background-color: white;
+  height: 100%;
+`;
+
+export const DisplayAlignment = () => {
+  const dispatch = useAppDispatch();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  useHandleGestures(
+    {
+      pressDown() {
+        dispatch(
+          setBubbleDisplay({ visible: true, component: 'advancedSettings' })
+        );
+      }
+    },
+    !bubbleDisplay.interceptsGesture
+  );
+
+  return (
+    <Styled.SettingsContainer>
+      {Array.from({ length: NUMLINES }).map((_, i) => (
+        <VerticalLine key={i} />
+      ))}
+    </Styled.SettingsContainer>
+  );
+};

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -58,7 +58,8 @@ export type ScreenType =
   | 'factoryReset'
   | 'usbSettings'
   | 'retraction_volume'
-  | 'manufacturingSettings';
+  | 'manufacturingSettings'
+  | 'displayAlignment';
 
 interface ScreenState {
   value: ScreenType;

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -55,6 +55,7 @@ import { FactoryReset } from '../components/Settings/Advanced/FactoryReset';
 import { Manufacturing } from '../components/Settings/Advanced/Manufacturing';
 import { RetractionSettingGauge } from '../components/Settings/Advanced/RetractionVolume';
 import { useProfileContext } from '../context/ProfileContext';
+import { DisplayAlignment } from '../components/Settings/Advanced/DisplayAlignment';
 interface Route {
   component: ComponentType;
   parentTitle?: string | ((state: RootState) => string) | (() => JSX.Element);
@@ -414,6 +415,10 @@ export const routes: Record<ScreenType, Route> = {
   },
   factoryReset: {
     component: FactoryReset,
+    bottomStatusHidden: true
+  },
+  displayAlignment: {
+    component: DisplayAlignment,
     bottomStatusHidden: true
   }
 };


### PR DESCRIPTION
## What was done?
A display alignment helper screen was added
<img width="526" height="526" alt="image" src="https://github.com/user-attachments/assets/98a8a66a-adf3-42c4-8a16-0e2a4677f11b" />
