### PR TITLE
feat(quick-settings): use image version instead of build timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.93.2",
       "license": "MIT",
       "dependencies": {
-        "@meticulous-home/espresso-api": "^0.10.6",
+        "@meticulous-home/espresso-api": "^0.10.7",
         "@meticulous-home/espresso-profile": "^0.4.2",
         "@reduxjs/toolkit": "^2.2.7",
         "@tanstack/react-query": "^5.56.2",
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@meticulous-home/espresso-api": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.10.6.tgz",
-      "integrity": "sha512-ePYRxiU+TMHRsSzG9DyQn7qXFWmenvuigfNPctQ34bfNB1wU58DDBpVtojmqetld7CaKuOogBic4BBu14OrfyA==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.10.7.tgz",
+      "integrity": "sha512-fxwQuLnzvr702ET8ojKanz+bqZu2eOu4k50fE/ksXi/4aP3GUyDvkaOzqCFes1v1KBR4h62l//00GOaQXbxX5g==",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vite": "^6.0.3"
   },
   "dependencies": {
-    "@meticulous-home/espresso-api": "^0.10.6",
+    "@meticulous-home/espresso-api": "^0.10.7",
     "@meticulous-home/espresso-profile": "^0.4.2",
     "@reduxjs/toolkit": "^2.2.7",
     "@tanstack/react-query": "^5.56.2",

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -459,7 +459,7 @@ export function QuickSettings(): JSX.Element {
           $bringToFront={holdAnimation === 'running'}
           $osStatus={osStatusVisible ? osStatusData.status.toLowerCase() : null}
           $osInfo={osStatusVisible ? osStatusInfo : null}
-          $SWVersion={`${!isPending ? deviceInfo.software_version : 'loading ...'}`}
+          $SWVersion={`${!isPending ? deviceInfo.image_version : 'loading ...'}`}
         >
           {settings.map((option) => (
             <Styled.Option


### PR DESCRIPTION
## What was done?
The newly added image version is shown in the quick settings instead