### PR TITLE
fix(profilehomescreen): lock profile displacement while pressing down the knob

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -122,6 +122,8 @@ export const ProfileHomeScreen = () => {
     }
   };
 
+  const lockMovement = useRef<boolean>(false);
+
   useEffect(() => {
     socket.on('sensors', (data: { m_pos: number }) => {
       if (data.m_pos < PISTON_ON_PURGE_POSITION) {
@@ -184,6 +186,7 @@ export const ProfileHomeScreen = () => {
   useHandleGestures(
     {
       left() {
+        if (lockMovement.current) return;
         if (globalSettings?.reverse_scrolling.home) {
           rotateRight();
         } else {
@@ -191,6 +194,7 @@ export const ProfileHomeScreen = () => {
         }
       },
       right() {
+        if (lockMovement.current) return;
         if (globalSettings?.reverse_scrolling.home) {
           rotateLeft();
         } else {
@@ -199,6 +203,7 @@ export const ProfileHomeScreen = () => {
       },
       pressDown() {
         // New profile button
+        lockMovement.current = true;
         if (activeOption == mergedProfiles?.length) {
           if (!isOnline) return;
           dispatch(setScreen('defaultProfiles'));
@@ -217,6 +222,7 @@ export const ProfileHomeScreen = () => {
         }
       },
       pressUp() {
+        lockMovement.current = false;
         if (pressThroughTimer.current) {
           clearTimeout(pressThroughTimer.current);
           pressThroughTimer.current = null;

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -122,8 +122,6 @@ export const ProfileHomeScreen = () => {
     }
   };
 
-  const lockMovement = useRef<boolean>(false);
-
   useEffect(() => {
     socket.on('sensors', (data: { m_pos: number }) => {
       if (data.m_pos < PISTON_ON_PURGE_POSITION) {
@@ -186,7 +184,7 @@ export const ProfileHomeScreen = () => {
   useHandleGestures(
     {
       left() {
-        if (lockMovement.current) return;
+        if (pressThroughTimer.current) return; //This locks the movement if we are pressing the button
         if (globalSettings?.reverse_scrolling.home) {
           rotateRight();
         } else {
@@ -194,7 +192,7 @@ export const ProfileHomeScreen = () => {
         }
       },
       right() {
-        if (lockMovement.current) return;
+        if (pressThroughTimer.current) return;
         if (globalSettings?.reverse_scrolling.home) {
           rotateLeft();
         } else {
@@ -203,7 +201,6 @@ export const ProfileHomeScreen = () => {
       },
       pressDown() {
         // New profile button
-        lockMovement.current = true;
         if (activeOption == mergedProfiles?.length) {
           if (!isOnline) return;
           dispatch(setScreen('defaultProfiles'));
@@ -222,7 +219,6 @@ export const ProfileHomeScreen = () => {
         }
       },
       pressUp() {
-        lockMovement.current = false;
         if (pressThroughTimer.current) {
           clearTimeout(pressThroughTimer.current);
           pressThroughTimer.current = null;


### PR DESCRIPTION
## What was done?
This commit locks the movement of the profile list while the knob is pressed down

## Why?
When the knob is pressed down to start the profile brew we can still move through the profile list. This can cause either to brew a non intended profile, or if ends up in the "new profile" option, crash the dial app.

### Before

https://github.com/user-attachments/assets/bda5c527-3238-4e5b-84ef-e5f0105a1980


### After

https://github.com/user-attachments/assets/4bdb49a6-5dc3-48a6-b02f-4dbdaa849f61

