### PR TITLE
fix(displayalignment): we were unable to exit the screen

### DIFF
--- a/src/components/Settings/Advanced/DisplayAlignment.tsx
+++ b/src/components/Settings/Advanced/DisplayAlignment.tsx
@@ -1,5 +1,8 @@
 import { useHandleGestures } from '../../../hooks/useHandleGestures';
-import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import Styled from '../../../styles/utils/mixins';
 import { styled } from 'styled-components';
@@ -17,15 +20,22 @@ const VerticalLine = styled.div`
 export const DisplayAlignment = () => {
   const dispatch = useAppDispatch();
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+
+  const screen = useAppSelector(
+    (state) => state.screen,
+    (prev, next) => prev === next
+  );
+
   useHandleGestures(
     {
       pressDown() {
+        dispatch(setScreen(screen.prev || 'profileHome'));
         dispatch(
           setBubbleDisplay({ visible: true, component: 'advancedSettings' })
         );
       }
     },
-    !bubbleDisplay.interceptsGesture
+    bubbleDisplay.interceptsGesture
   );
 
   return (


### PR DESCRIPTION
useHandleGestures was being ignored when the bubble display was not intercepting the gestures, so the pressDown was being ignored.

Also, we were not setting any screen in the pressDown callback.

> If blocking the pressDown until the context menu is open was the intended behavior to exit only when hitting `exit`, let me know
