### PR TITLE
fix(heating): remove transform animation breaking css blend modes

### DIFF
--- a/src/components/Heating/LottieBubbleAnimation.tsx
+++ b/src/components/Heating/LottieBubbleAnimation.tsx
@@ -21,6 +21,10 @@ const BubbleContainer = styled.div`
 const Animation = styled.div`
   width: ${BUBBLES_WIDTH}px;
   height: ${BUBBLES_HEIGHT}px;
+
+  & svg {
+    transform: none !important;
+  }
 `;
 
 const gradientColors = [


### PR DESCRIPTION
## What was done?
The transform was removed from the Animation SVG to allow the blend modes to work again