### PR TITLE
Feat/lock master calibration

### DIFF
--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -22,13 +22,6 @@ import { calculateOptionPosition } from '../../../styles/utils/calculateOptionPo
 import { IdleScreens } from '../../../components/Settings/Advanced/IdleScreenSetting';
 import type { Settings } from '@meticulous-home/espresso-api';
 
-import {
-  NotificationItem,
-  processNotification,
-  addOneNotification
-} from '../../store/features/notifications/notification-slice';
-import { v4 as uuidv4 } from 'uuid';
-
 const initialSettings: SettingsItem[] = [
   {
     key: 'usb_mode',
@@ -40,11 +33,6 @@ const initialSettings: SettingsItem[] = [
     label: 'SSH',
     getLabel: (settings: Settings) =>
       settings.ssh_enabled ? 'ENABLED' : 'DISABLED'
-  },
-  {
-    key: 'master_calibration',
-    label: 'ACAIA master calibration',
-    visible: true
   },
   {
     key: 'displayAlignment',
@@ -226,24 +214,6 @@ export const AdvancedSettings = () => {
             dispatch(
               setBubbleDisplay({ visible: true, component: 'settings' })
             );
-            break;
-          case 'master_calibration':
-            {
-              const _date: Date = new Date();
-              const MasterCalibrationAlert: NotificationItem =
-                processNotification({
-                  id: uuidv4(),
-                  message:
-                    'WARNING: Proceeding incorrectly can permanently damage your scale and may make it unusable. Only continue if you fully understand this procedure and accept the risk.',
-                  responses: ['OK'],
-                  timestamp: _date
-                }).updatedNotification;
-              dispatch(
-                setBubbleDisplay({ visible: false, component: undefined })
-              );
-              dispatch(setScreen('masterCalibrationLock'));
-              dispatch(addOneNotification(MasterCalibrationAlert));
-            }
             break;
           default: {
             break;

--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import { startMasterCalibration } from '../../../api/api';
 
 import { useHandleGestures } from '../../../hooks/useHandleGestures';
 import { SettingsItem } from '../../../types';
@@ -22,6 +21,13 @@ import Styled, {
 import { calculateOptionPosition } from '../../../styles/utils/calculateOptionPosition';
 import { IdleScreens } from '../../../components/Settings/Advanced/IdleScreenSetting';
 import type { Settings } from '@meticulous-home/espresso-api';
+
+import {
+  NotificationItem,
+  processNotification,
+  addOneNotification
+} from '../../store/features/notifications/notification-slice';
+import { v4 as uuidv4 } from 'uuid';
 
 const initialSettings: SettingsItem[] = [
   {
@@ -222,15 +228,22 @@ export const AdvancedSettings = () => {
             );
             break;
           case 'master_calibration':
-            startMasterCalibration()
-              .then(() => {
-                dispatch(
-                  setBubbleDisplay({ visible: false, component: undefined })
-                );
-              })
-              .catch((err) => {
-                console.log(err);
-              });
+            {
+              const _date: Date = new Date();
+              const MasterCalibrationAlert: NotificationItem =
+                processNotification({
+                  id: uuidv4(),
+                  message:
+                    'WARNING: Proceeding incorrectly can permanently damage your scale and may make it unusable. Only continue if you fully understand this procedure and accept the risk.',
+                  responses: ['OK'],
+                  timestamp: _date
+                }).updatedNotification;
+              dispatch(
+                setBubbleDisplay({ visible: false, component: undefined })
+              );
+              dispatch(setScreen('masterCalibrationLock'));
+              dispatch(addOneNotification(MasterCalibrationAlert));
+            }
             break;
           default: {
             break;

--- a/src/components/Settings/Advanced/Manufacturing.tsx
+++ b/src/components/Settings/Advanced/Manufacturing.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { SettingsItem } from '../../../types';
-import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../../store/features/screens/screens-slice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useHandleGestures } from '../../../hooks/useHandleGestures';
 import {
@@ -15,6 +18,12 @@ import Styled, {
   MARQUEE_MIN_TEXT_LENGTH
 } from '../../../styles/utils/mixins';
 import { LoadingScreen } from '../../LoadingScreen/LoadingScreen';
+import {
+  NotificationItem,
+  processNotification,
+  addOneNotification
+} from '../../store/features/notifications/notification-slice';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * "Technically, we won't reach this component if the option to access it from 'Advanced Settings' is not displayed,
@@ -79,6 +88,11 @@ export const Manufacturing = () => {
     return [
       ...manufacturingFormatted,
       {
+        key: 'master_calibration',
+        label: 'ACAIA master calibration',
+        visible: true
+      },
+      {
         key: 'back',
         label: 'Back',
         visible: true
@@ -115,6 +129,24 @@ export const Manufacturing = () => {
             dispatch(
               setBubbleDisplay({ visible: true, component: 'advancedSettings' })
             );
+            break;
+          case 'master_calibration':
+            {
+              const _date: Date = new Date();
+              const MasterCalibrationAlert: NotificationItem =
+                processNotification({
+                  id: uuidv4(),
+                  message:
+                    'WARNING: Proceeding incorrectly can permanently damage your scale and may make it unusable. Only continue if you fully understand this procedure and accept the risk.',
+                  responses: ['OK'],
+                  timestamp: _date
+                }).updatedNotification;
+              dispatch(
+                setBubbleDisplay({ visible: false, component: undefined })
+              );
+              dispatch(setScreen('masterCalibrationLock'));
+              dispatch(addOneNotification(MasterCalibrationAlert));
+            }
             break;
           default:
             break;

--- a/src/components/UnlockScreen/UnlockScreen.tsx
+++ b/src/components/UnlockScreen/UnlockScreen.tsx
@@ -2,8 +2,12 @@ import { useState } from 'react';
 import { useUpdateSettings } from '../../hooks/useSettings';
 import { useAppDispatch } from '../store/hooks';
 import { CircleKeyboard } from '../CircleKeyboard/CircleKeyboard';
-import { setScreen } from '../store/features/screens/screens-slice';
+import {
+  setScreen,
+  setBubbleDisplay
+} from '../store/features/screens/screens-slice';
 import { useDeviceInfo } from '../../hooks/useDeviceOSStatus';
+import { startMasterCalibration } from '../../api/api';
 
 export const UnlockScreen: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -32,6 +36,43 @@ export const UnlockScreen: React.FC = () => {
       onChange={(text: string) => {
         setPassword(text);
         updateSetting(text);
+      }}
+    />
+  );
+};
+
+export const UnlockMasterCalibration: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const [password, setPassword] = useState<string>('');
+
+  const onCancel = () => {
+    dispatch(setScreen('profileHome'));
+    dispatch(
+      setBubbleDisplay({ visible: true, component: 'advancedSettings' })
+    );
+  };
+
+  const onSubmitPassword = () => {
+    if (password === '8888') {
+      startMasterCalibration()
+        .then(() => {
+          dispatch(setScreen('profileHome'));
+        })
+        .catch((err) => {
+          dispatch(setScreen('profileHome'));
+          console.log(err);
+        });
+    }
+  };
+
+  return (
+    <CircleKeyboard
+      name={'Unlock Master Calibration'}
+      defaultValue={password.split('')}
+      onSubmit={onSubmitPassword}
+      onCancel={onCancel}
+      onChange={(text: string) => {
+        setPassword(text);
       }}
     />
   );

--- a/src/components/UnlockScreen/UnlockScreen.tsx
+++ b/src/components/UnlockScreen/UnlockScreen.tsx
@@ -48,7 +48,7 @@ export const UnlockMasterCalibration: React.FC = () => {
   const onCancel = () => {
     dispatch(setScreen('profileHome'));
     dispatch(
-      setBubbleDisplay({ visible: true, component: 'advancedSettings' })
+      setBubbleDisplay({ visible: true, component: 'manufacturingSettings' })
     );
   };
 

--- a/src/components/store/features/notifications/notification-slice.ts
+++ b/src/components/store/features/notifications/notification-slice.ts
@@ -8,7 +8,7 @@ import { RootState } from '../../store';
 import { api } from '../../../../api/api';
 import { APIError } from '@meticulous-home/espresso-api/dist';
 
-type ResponseOption = 'Update' | 'Auto Update' | 'Skip';
+type ResponseOption = 'Update' | 'Auto Update' | 'Skip' | string;
 
 export const MOTOR_HOT_KEY = 'motor_hot';
 export const MOTOR_COLD_KEY = 'motor_cold';
@@ -42,9 +42,8 @@ const notificationAdapter = createEntityAdapter({
   selectId: (notification: NotificationItem) => notification.id
 });
 
-interface NotificationState extends ReturnType<
-  typeof notificationAdapter.getInitialState
-> {
+interface NotificationState
+  extends ReturnType<typeof notificationAdapter.getInitialState> {
   motorHot: boolean;
 }
 

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -60,6 +60,7 @@ export type ScreenType =
   | 'retraction_volume'
   | 'manufacturingSettings'
   | 'displayAlignment'
+  | 'masterCalibrationLock'
   | 'unlock';
 
 interface ScreenState {

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -56,7 +56,10 @@ import { Manufacturing } from '../components/Settings/Advanced/Manufacturing';
 import { RetractionSettingGauge } from '../components/Settings/Advanced/RetractionVolume';
 import { useProfileContext } from '../context/ProfileContext';
 import { DisplayAlignment } from '../components/Settings/Advanced/DisplayAlignment';
-import { UnlockScreen } from '../components/UnlockScreen/UnlockScreen';
+import {
+  UnlockScreen,
+  UnlockMasterCalibration
+} from '../components/UnlockScreen/UnlockScreen';
 interface Route {
   component: ComponentType;
   parentTitle?: string | ((state: RootState) => string) | (() => JSX.Element);
@@ -101,6 +104,11 @@ const selectPurgeTitle = (state: RootState) => {
 const selectStatProfileName = (state: RootState) => state.stats.profile;
 
 export const routes: Record<ScreenType, Route> = {
+  masterCalibrationLock: {
+    component: UnlockMasterCalibration,
+    title: '',
+    bottomStatusHidden: true
+  },
   timeZoneConfig: {
     component: TimeZoneConfig,
     title: 'timeZoneConfig',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,23 +86,27 @@ export interface IPresetNumericalUnit extends IPresetBaseNumerical {
 }
 
 export interface IPresetNumericalPressure
-  extends IBasePresset, IPresetNumericalUnit {
+  extends IBasePresset,
+    IPresetNumericalUnit {
   key: PressureKey;
   unit: 'bar';
 }
 export interface IPresetNumericalTemperature
-  extends IBasePresset, IPresetNumericalUnit {
+  extends IBasePresset,
+    IPresetNumericalUnit {
   key: TemperatureKey;
   unit: '°c';
 }
 export interface IPresetNumericalDose
-  extends IBasePresset, IPresetNumericalUnit {
+  extends IBasePresset,
+    IPresetNumericalUnit {
   key: DoseKey;
   unit: 'g';
 }
 
 export interface IPresetNumericalOutput
-  extends IBasePresset, IPresetNumericalUnit {
+  extends IBasePresset,
+    IPresetNumericalUnit {
   key: OutputKey;
   unit: 'g';
 }


### PR DESCRIPTION
## What was done?

Move the `master calibration` action into the `manufacturing` menu and lock it behind a password and a warning notification

## Why?

Users should not easily access the action, as it requires pattern weights that they might not have at hand, messing with the scale calibration

> Action inside the manufacturing menu
<img width="487" height="490" alt="image" src="https://github.com/user-attachments/assets/95f484f9-3ce7-4cc3-bf6f-d48bbd3601bd" />

> Disclaimer
<img width="487" height="490" alt="image" src="https://github.com/user-attachments/assets/2d69eb0d-ac63-49d6-ae94-b7c9b27d969e" />

> Password screen
<img width="487" height="490" alt="image" src="https://github.com/user-attachments/assets/c9bd29c6-3ea0-47f7-af92-ac8883ab3fff" />
