### PR TITLE
feat: add sound volume control

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -63,6 +63,52 @@ export const setBrightness = async ({ brightness }: BrightnessRequest) => {
   }
 };
 
+export const getSoundVolume = async (): Promise<number> => {
+  try {
+    const server = API_URL;
+    const url = server + `/api/v1/sounds/volume`;
+    const response = await fetch(url, { method: 'GET' });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    if ('error' in data) {
+      throw new Error((data as APIError).error);
+    }
+    return data.volume;
+  } catch (error) {
+    console.error('Error getting sound volume', error);
+    throw error;
+  }
+};
+
+export const setSoundVolume = async (volume: number): Promise<void> => {
+  try {
+    const server = API_URL;
+    const url = server + `/api/v1/sounds/volume`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ volume })
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `HTTP error! status: ${response.status}, body: ${errorText}`
+      );
+    }
+    const data = await response.json();
+    if ('error' in data) {
+      throw new Error((data as APIError).error);
+    }
+  } catch (error) {
+    console.error('Error setting sound volume', error);
+    throw error;
+  }
+};
+
 export const getTimezoneRegion = async (
   region_type: regionType,
   filter: string

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useSettings, useUpdateSettings } from '../../hooks/useSettings';
 import type { SettingsItem } from '../../types';
+import { useSoundVolume } from '../../hooks/useSoundVolume.tsx'
 
 import Styled, { VIEWPORT_HEIGHT } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
@@ -35,6 +36,12 @@ const initialSettings: SettingsItem[] = [
     visible: true
   },
   {
+    key: 'sound_volume',
+    label: 'Sound Volume',
+    visible: true,
+    getLabel: () => '' 
+  },
+  {
     key: 'calibrate',
     label: 'calibrate scale'
   },
@@ -54,6 +61,7 @@ const initialSettings: SettingsItem[] = [
 
 export function Settings(): JSX.Element {
   const { data: globalSettings, isSuccess } = useSettings();
+  const { data: soundVolume } = useSoundVolume();
 
   const dispatch = useAppDispatch();
   const [activeIndex, setActiveIndex] = useState(0);
@@ -68,11 +76,14 @@ export function Settings(): JSX.Element {
     }
     return initialSettings.map((item) => ({
       ...item,
-      label: item.getLabel
-        ? `${item.label}: ${item.getLabel(globalSettings)}`
-        : item.label
+      label:
+        item.key === 'sound_volume'
+          ? `${item.label}${soundVolume !== undefined && typeof soundVolume === 'number' ? `: ${Math.round(soundVolume)}%` : ''}`
+          : item.getLabel
+            ? `${item.label}: ${item.getLabel(globalSettings)}`
+            : item.label
     }));
-  }, [globalSettings, isSuccess]);
+  }, [globalSettings, isSuccess, soundVolume]);
 
   useHandleGestures(
     {
@@ -116,6 +127,12 @@ export function Settings(): JSX.Element {
               enable_sounds: !globalSettings.enable_sounds
             });
             break;
+            case 'sound_volume':
+              dispatch(
+                setBubbleDisplay({ visible: false, component: undefined })
+              );
+              dispatch(setScreen('soundVolume'));
+              break;
           case 'time_date':
             dispatch(
               setBubbleDisplay({ visible: true, component: 'timeDate' })

--- a/src/components/Settings/SoundVolume.tsx
+++ b/src/components/Settings/SoundVolume.tsx
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react';
+import { Gauge } from '../SettingNumerical/Gauge';
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../store/features/screens/screens-slice';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { useDimScreen } from '../../hooks/useDimScreen';
+import { useSoundVolume, useUpdateSoundVolume } from '../../hooks/useSoundVolume';
+
+const MIN_VOLUME = 0;
+const MAX_VOLUME = 100; 
+const INTERVAL = 5;
+
+export const SoundVolumeGauge: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const prevScreen = useAppSelector((state) => state.screen.prev);
+  const { data: currentVolume, isLoading } = useSoundVolume();
+  const updateVolume = useUpdateSoundVolume();
+  const [localVolume, setLocalVolume] = useState(70);
+
+  useDimScreen();
+
+  // Update local volume when data loads
+  useEffect(() => {
+    if (currentVolume !== undefined) {
+      setLocalVolume(Math.round(currentVolume));
+    }
+  }, [currentVolume]);
+
+  useHandleGestures({
+    left() {
+      const newValue = Math.max(localVolume - INTERVAL, MIN_VOLUME);
+      setLocalVolume(newValue);
+    },
+    right() {
+      const newValue = Math.min(localVolume + INTERVAL, MAX_VOLUME);
+      setLocalVolume(newValue);
+    },
+    pressDown() {
+      updateVolume.mutate(localVolume, {
+        onSuccess: () => {
+          dispatch(setScreen(prevScreen));
+          dispatch(setBubbleDisplay({ visible: true, component: 'settings' }));
+        }
+      });
+    }
+  });
+
+  return (
+    <div className="gauge-container">
+      <Gauge
+        value={isLoading ? 0 : localVolume}
+        maxValue={MAX_VOLUME}
+        minValue={MIN_VOLUME}
+        precision={0}
+        unit="percentage"
+      />
+    </div>
+  );
+};

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -61,6 +61,7 @@ export type ScreenType =
   | 'displayAlignment'
   | 'masterCalibrationLock'
   | 'deviceInfoQR'
+  | 'soundVolume'
   | 'unlock';
 
 interface ScreenState {

--- a/src/hooks/useSoundVolume.tsx
+++ b/src/hooks/useSoundVolume.tsx
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getSoundVolume, setSoundVolume } from '../api/api';
+
+const SOUND_VOLUME_QUERY_KEY = 'soundVolume';
+
+// Hook to fetch sound volume
+export const useSoundVolume = () => {
+  return useQuery({
+    queryKey: [SOUND_VOLUME_QUERY_KEY],
+    queryFn: getSoundVolume,
+    staleTime: 5000,
+    retry: false
+  });
+};
+
+// Hook to update sound volume
+export const useUpdateSoundVolume = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: setSoundVolume,
+    onError: (error) => {
+      console.error('Error setting sound volume:', error);
+      // On error, refetch to get the actual value
+      queryClient.invalidateQueries({ queryKey: [SOUND_VOLUME_QUERY_KEY] });
+    },
+    onSuccess: (_, volume) => {
+      // Optimistically update the cache
+      queryClient.setQueryData([SOUND_VOLUME_QUERY_KEY], volume);
+      // Invalidate to ensure we have the latest value
+      queryClient.invalidateQueries({ queryKey: [SOUND_VOLUME_QUERY_KEY] });
+    }
+  });
+};

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -32,6 +32,7 @@ import { IdleScreen } from '../components/IdleScreen/IdleScreen';
 import { HeatingScreen } from '../components/Heating/HeatingScreen';
 import { TimeDate } from '../components/Settings/Advanced/TimeDate/TimeDateConfig';
 import { TimeZoneConfig } from '../components/Settings/Advanced/TimeDate/TimeZone/TimeZoneConfig';
+import { SoundVolumeGauge } from '../components/Settings/SoundVolume.tsx';
 import SelectLetterCountry from '../components/Settings/Advanced/TimeDate/TimeZone/SelectLetterCountry';
 import CountrySettings from '../components/Settings/Advanced/TimeDate/TimeZone/CountrySettings';
 import TimeZoneSettings from '../components/Settings/Advanced/TimeDate/TimeZone/TimeZoneSettings';
@@ -434,5 +435,12 @@ export const routes: Record<ScreenType, Route> = {
     component: UnlockScreen,
     bottomStatusHidden: true,
     ignoreAsPrevious: true
+  },
+  soundVolume: {
+    component: SoundVolumeGauge,
+    title: 'Sound Volume',
+    bottomStatusHidden: true,
+    bottomTitle: 'Volume',
+    parent: 'settings'
   }
 };


### PR DESCRIPTION
## What was done?
Added sound volume control (0–100%) in Settings. Users can adjust volume via a gauge screen using dial gestures.

## Why?
* Allows granular volume control beyond the existing on/off toggle

## Additional comments & remarks
* Volume adjusts in 5% increments
* Uses existing Gauge component 
* [Backend changes needed](https://github.com/MeticulousHome/meticulous-backend/pull/303/)


## Full detail of changes made to each function
* `src/components/Settings/SoundVolume.tsx`: Component with dial controls
* `src/components/Settings/Settings.tsx`: Added "Sound Volume" menu item showing current percentage
* `src/api/api.ts`: API functions for GET/POST to /api/v1/sounds/volume
* `src/hooks/useSoundVolume.tsx`: State management
* `src/navigation/routes.ts`: Added route configuration
* `src/components/store/features/screens/screens-slice.ts`: Added to screen slice
