### PR TITLE
Chore/handle brew refusal

### DIFF
--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -155,9 +155,9 @@ export function PressetSettings(): JSX.Element {
             { ...settingsProfile },
             settingsProfile.settings
           );
-          setProfileStarting(true);
           const data = await loadProfileData(profile);
-          if (data) {
+          if (typeof data === 'object' && 'profile' in data) {
+            setProfileStarting(true);
             await startProfile();
           }
           dispatch(setScreen('profileHome'));

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -109,17 +109,20 @@ export const ProfileHomeScreen = () => {
       const { isLast, temporary, ...cleanProfile } = profile;
       const data = await loadProfileData(cleanProfile);
 
-      if (data) {
+      if ('profile' in data) {
         await startProfile();
+        return true;
       }
+      return false;
     };
 
     setProfileStarting(true);
-    loadAndStartProfile();
-    if (!requiresPurge.current) {
-      dispatch(setScreen('heating'));
-    } else {
-      dispatch(setScreen('manual-purge'));
+    if (await loadAndStartProfile()) {
+      if (!requiresPurge.current) {
+        dispatch(setScreen('heating'));
+      } else {
+        dispatch(setScreen('manual-purge'));
+      }
     }
   };
 

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -109,21 +109,33 @@ export const ProfileHomeScreen = () => {
       const { isLast, temporary, ...cleanProfile } = profile;
       const data = await loadProfileData(cleanProfile);
 
-      if ('profile' in data) {
+      if (typeof data === 'object' && 'profile' in data) {
         await startProfile();
         return true;
       }
       return false;
     };
+    // If the request response takes longer than 500ms
+    // most likelly has succedded the `refusal` stage in the backend
+    // If it returned quicker, might be an error
+    // This is to keep the ilusion of continuity in the UI, and not have a loading screen
+    // while the profile is being parsed by the backend and the ESP
 
-    setProfileStarting(true);
-    if (await loadAndStartProfile()) {
+    const timeout = setTimeout(() => {
+      setProfileStarting(true);
       if (!requiresPurge.current) {
         dispatch(setScreen('heating'));
       } else {
         dispatch(setScreen('manual-purge'));
       }
-    }
+    }, 500);
+
+    await loadAndStartProfile();
+    clearTimeout(timeout);
+    setProfileStarting(false);
+    setIsPressingDown(false);
+    if (pressThroughTimer.current) clearTimeout(pressThroughTimer.current);
+    pressThroughTimer.current = null;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## What was done?
Avoid the screen transition from `profileHomeScreen` to `purging` or `heating` if the response from the backend is an error 
 
## Why?
The backend in the [PR#301](https://github.com/MeticulousHome/meticulous-backend/pull/301) can refuse the brew request with a 403 forbidden error response, so, in those cases no other screen should be dispatched.

In the case the request is accepted and the brew continues, the backend usually takes over 1s to respond, as it does after processing and sendig the profile to be parsed. In that time the `profileHomeScreen` will keep flashing.

To fix that we dont wait (completely) for the backend response, only wait for the 403 error to get back as this response is almost immediate (~50ms). We set up a 500ms timeout and if the request response comes before that, its more likely an error response, else a successful response and with the timeout cb we can dispatch the other `purging` or `heating` screen accordingly and (almost) without much notice
