### PR TITLE
feat: add clock format toggle (12h/24h)

### DIFF
--- a/src/components/IdleScreen/DigitalClock.tsx
+++ b/src/components/IdleScreen/DigitalClock.tsx
@@ -2,23 +2,36 @@ import { useEffect, useState } from 'react';
 
 import { setBrightness } from '../../api/api';
 import { useNetworkConfig } from '../../hooks/useWifi';
+import { useSettings } from '../../hooks/useSettings';
 
 import { MetCatClock } from './MetCatClock';
 import { DigitalClockBase } from './DigitalClockBase';
 import './DigitalClock.css';
 
-export function formatTime() {
+export function formatTime(use24Hour?: boolean) {
   const time = new Date();
-  const localeString = time.toLocaleTimeString().toUpperCase();
-  // This would be the perfect usecase for a regex. But it is somehow significantly slower :C
-  const am = localeString.includes('AM') && 'AM';
-  const pm = localeString.includes('PM') && 'PM';
-  const midday = am || pm;
+  const hours24 = time.getHours();
+  
+  let hours: number;
+  let midday: string | undefined;
+  
+  if (use24Hour) {
+    hours = hours24;
+    midday = undefined;
+  } else {
+    const localeString = time.toLocaleTimeString().toUpperCase();
+    // This would be the perfect usecase for a regex. But it is somehow significantly slower :C
+    const am = localeString.includes('AM') && 'AM';
+    const pm = localeString.includes('PM') && 'PM';
+    midday = am || pm;
+    hours = midday ? ((hours24 + 11) % 12) + 1 : hours24;
+  }
+  
   return {
-    hours: midday ? ((time.getHours() + 11) % 12) + 1 : time.getHours(),
+    hours,
     minutes: time.getMinutes(),
     seconds: time.getSeconds(),
-    midday: midday
+    midday
   };
 }
 
@@ -27,7 +40,9 @@ export function DigitalClock({
 }: {
   useMetCat: boolean;
 }): JSX.Element {
-  const [time, setTime] = useState(formatTime());
+  const { data: globalSettings } = useSettings();
+  const use24Hour = (globalSettings as any)?.clock_format_24_hour === true;
+  const [time, setTime] = useState(formatTime(use24Hour));
 
   const { data: networkConfig, refetch: refetchNetworkConfig } =
     useNetworkConfig();
@@ -35,13 +50,13 @@ export function DigitalClock({
   useEffect(() => {
     refetchNetworkConfig();
     setBrightness({ brightness: 0 });
-    const intervalId = setInterval(() => setTime(formatTime()), 250);
+    const intervalId = setInterval(() => setTime(formatTime(use24Hour)), 250);
 
     return () => {
       setBrightness({ brightness: 1 });
       clearInterval(intervalId);
     };
-  }, []);
+  }, [use24Hour]);
 
   const isWifiConnected = networkConfig?.status.connected;
   const ClockComponent = useMetCat ? MetCatClock : DigitalClockBase;

--- a/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
+++ b/src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx
@@ -8,7 +8,7 @@ import '../../../OSStatus/OSStatus.css';
 
 import type { SettingsItem, TimeDateValues } from '../../../../types';
 import type { Settings } from '@meticulous-home/espresso-api';
-import { useSettings } from '../../../../hooks/useSettings';
+import { useSettings, useUpdateSettings } from '../../../../hooks/useSettings';
 import { useCurrentTime } from '../../../../hooks/useCurrentTime';
 
 import Styled, {
@@ -39,6 +39,12 @@ const initialSettings: SettingsItem[] = [
     value: false
   },
   {
+    key: 'clock_format',
+    label: 'Clock Format',
+    getLabel: (settings: any) => `${(settings.clock_format_24_hour === true) ? '24h' : '12h'}`,
+    visible: true
+  },
+  {
     key: 'back',
     label: 'Back'
   }
@@ -49,6 +55,7 @@ export function TimeDate(): JSX.Element {
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const [activeIndex, setActiveIndex] = useState(0);
   const { data: globalSettings, isSuccess } = useSettings();
+  const updateSettings = useUpdateSettings();
 
   const { hours, minutes, day, month, year } = useCurrentTime();
 
@@ -96,6 +103,16 @@ export function TimeDate(): JSX.Element {
           case 'set_date': {
             dispatch(
               setBubbleDisplay({ visible: true, component: 'dateConfig' })
+            );
+            break;
+          }
+          case 'clock_format': {
+            const currentValue =
+              (globalSettings as any)?.clock_format_24_hour === true;
+            updateSettings.mutate(
+              {
+                clock_format_24_hour: !currentValue
+              } as any
             );
             break;
           }


### PR DESCRIPTION
## What was done?
Toggle in the Time/Date settings to switch between a 12-hour (AM/PM) to 24-hour clock formats and vice versa.

## Why?
Users can choose their preferred clock format

## Additional comments & remarks
* Adjust clock format for digital clock and MetCat
* [Backend changes are required](https://github.com/MeticulousHome/meticulous-backend/pull/303/)

## Full detail of changes made to each function
* `src/components/Settings/Advanced/TimeDate/TimeDateConfig.tsx`: Toggle to switch between 12-hour and 24-hour formats
* `src/components/IdleScreen/DigitalClock.tsx: Formats hours as 0-23 (24-hour) or 1-12 with AM/PM (12-hour).