### PR TITLE
feat(profilehomescreen): emit profileHover on encoder select

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -21,6 +21,7 @@ import { LastLabel } from './LastLabel';
 import { useIsOnline } from '../../hooks/useIsOnline';
 import { loadProfileData, startProfile } from '../../api/profile';
 import { DownloadIcon } from './DownloadIcon';
+import { useSocket } from '../store/SocketManager';
 
 const CARD_GAP = 79;
 const CARD_SIZE = PROFILE_ENTRY_SIZE + CARD_GAP;
@@ -71,6 +72,7 @@ export const ProfileHomeScreen = () => {
   const { data: globalSettings } = useSettings();
   const { isIdle: shouldGoToIdle } = useIdleTimer();
   const isOnline = useIsOnline();
+  const socket = useSocket();
 
   const profileState = useProfileContext();
 

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -226,6 +226,14 @@ export const ProfileHomeScreen = () => {
           if (!localHoverState) {
             setLocalHoverState(true);
             setTransitionDirection('none');
+            const profile = mergedProfiles?.[activeOption];
+            if (profile?.id) {
+              socket.emit('profileHover', {
+                id: profile.id,
+                from: 'dial',
+                type: 'focus'
+              });
+            }
             if (!isOnline) return;
             pressThroughTimer.current = setTimeout(() => {
               setIsPressingDown(true);


### PR DESCRIPTION
## Summary

When a user selects (focuses) a profile on the physical device by pressing the encoder, other connected Socket.IO clients — such as the iOS app — have no way to know which profile is currently active on the machine. This is because `ProfileHomeScreen` never emits a `profileHover` event.

The backend already handles forwarding via `forwardProfileHover` (`backend.py`), and the iOS app already emits `profileHover` when selecting profiles. This PR completes the bidirectional sync by having the dial emit the same event on encoder press.

## Changes

Single file change in `ProfileHomeScreen.tsx`:

- Import `useSocket` from `SocketManager` (reuses the existing shared socket instance)
- Emit `profileHover` with `{ id, from: 'dial', type: 'focus' }` in the `pressDown` handler when transitioning to the focused (zoomed-in) state

The event payload matches the format already used by the iOS app. The `from: 'dial'` field allows `SocketProviderValue` to correctly filter out self-emitted events, as it already does on [line 172](https://github.com/MeticulousHome/meticulous-dial/blob/beta/src/components/store/SocketProviderValue.tsx#L172).

## Testing

Verified locally by running the Vite dev server (`npm run dev`) pointed at a physical machine. Confirmed via an independent Socket.IO monitor client that the backend receives and rebroadcasts the `profileHover` event to other connected clients on encoder press.