### PR TITLE
fix(heatingscreen): fix glitch if dial app crashes on click to start

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -76,7 +76,7 @@ export const HeatingScreen = () => {
   const hasNotifications = useAppSelector(
     notificationSelector.selectHasNotifications
   );
-  const [optionSeletected, setOptionSelected] = useState(null);
+  const [optionSeletected, setOptionSelected] = useState('push_to_brew');
 
   // The stages dont necessarily correctly report the temperature target
   // so we need to cache it with the state below


### PR DESCRIPTION
If the dial app crashes or gets restarted while on `click to start` screen, the `option_selected` state is kept as `null` beacuse there is no `OptionsMenu` component that updates its value, as it did not get mounted

Now we start the `option_selected` state as `push_to_brew` and it will get correctly updated when the `OptionsMenu` component mounts, if it does not mount, as does after the restart, the `push_to_brew` option will be active allowing the brew to continue
