### PR TITLE
fix(ui barometer): font-type ignored by typo

### DIFF
--- a/src/components/Barometer/barometer.css
+++ b/src/components/Barometer/barometer.css
@@ -29,7 +29,7 @@ Barometer styles
 }
 
 .bar-needle__value {
-  font-family: 'ABC Diatype Mono' I !important;
+  font-family: 'ABC Diatype Mono' !important;
   font-size: 50px;
   letter-spacing: -1.5px;
   color: #e0dcd0;

--- a/src/components/PurgePiston/piston.css
+++ b/src/components/PurgePiston/piston.css
@@ -28,7 +28,7 @@
 
 .value {
   width: 4rem;
-  font-family: 'ABC Diatype Mono' I !important;
+  font-family: 'ABC Diatype Mono' !important;
   z-index: 10;
   display: flex;
   flex-direction: column;
@@ -36,7 +36,7 @@
 }
 
 .value span {
-  font-family: 'ABC Diatype Mono' I !important;
+  font-family: 'ABC Diatype Mono' !important;
   font-size: 18px;
   color: gray;
   margin-top: 5px;


### PR DESCRIPTION
## What was done?
fix `font-family` css attribute

That `I` was preventing the `font-family` attribute to be applied