### PR TITLE
fix(dial): add local time zone offset calculation to the analog clock

### DIFF
--- a/src/components/IdleScreen/AnalogClock.tsx
+++ b/src/components/IdleScreen/AnalogClock.tsx
@@ -95,6 +95,9 @@ function rotateString(degrees: number): string {
   return ROTATE_STRINGS[idx % 3600];
 }
 
+// getTimezoneOffset() returns UTC - local in minutes
+const TZ_OFFSET_MS = new Date().getTimezoneOffset() * 60 * 1000;
+
 export function AnalogClock() {
   const requestId = useRef<number>(-1);
   const hourRef = useRef(null);
@@ -112,7 +115,7 @@ export function AnalogClock() {
     // Use Date.now() + integer arithmetic instead of new Date() to avoid
     // allocating a Date object every frame (~60/sec).
     const now = Date.now();
-    const ms = now % 86400000; // ms since midnight UTC
+    const ms = (now - TZ_OFFSET_MS) % 86400000; // ms since midnight local time
     const totalSeconds = ms / 1000;
     const seconds = totalSeconds % 60;
     const totalMinutes = totalSeconds / 60;


### PR DESCRIPTION
## What was done?

We add Local Time Zone Offset calculation to the Analog Clock.

## Why?

In a recent PR, `new Date()` was removed within the `animateTime` function and was replaced by `Date.now()`. However, `Date.now()` returns the `ms` in UTC. This results in the Analog Clock displaying the UTC time, instead of the user's local time.

## Additional comments & remarks

## Full detail of changes made to each function

```
// getTimezoneOffset() returns UTC - local in minutes
const TZ_OFFSET_MS = new Date().getTimezoneOffset() * 60 * 1000;
...
const ms = (now - TZ_OFFSET_MS) % 86400000; // ms since midnight local time
```

## Test (Locally in browser):
My local time is EST:
<img width="505" height="526" alt="image" src="https://github.com/user-attachments/assets/02cd07c8-3a2a-4487-b6ca-818f3a3f9cbf" />
