### PR TITLE
Lock factory reset behind serial entry

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -32,6 +32,7 @@ interface IKeyboardProps {
   onChange?: (text: string) => void;
   onlyLetters?: boolean;
   capitalizeFirstLetter?: boolean;
+  shouldIgnoreGesture?: boolean;
 }
 
 export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
@@ -301,7 +302,7 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
         }
       }
     },
-    bubbleDisplay.interceptsGesture
+    props.shouldIgnoreGesture ?? bubbleDisplay.interceptsGesture
   );
 
   const toUpperOrLowerCase = (

--- a/src/components/Settings/Advanced/FactoryReset.tsx
+++ b/src/components/Settings/Advanced/FactoryReset.tsx
@@ -6,6 +6,8 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useFactoryReset } from '../../../hooks/useMachine';
 import { LoadingScreen } from '../../../components/LoadingScreen/LoadingScreen';
 import { SettingsItem } from '../../../types';
+import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
+import { CircleKeyboard } from '../../CircleKeyboard/CircleKeyboard';
 
 export type StaticSettingsItem = SettingsItem & {
   useableWidthPercentage?: number;
@@ -15,7 +17,12 @@ export const FactoryReset = () => {
   const dispatch = useAppDispatch();
   const factoryReset = useFactoryReset();
   const [activeIndex, setActiveIndex] = useState(1);
+  const [serialInput, setSerialInput] = useState('');
+  const [serialRejected, setSerialRejected] = useState(false);
+  const [isUnlocked, setIsUnlocked] = useState(false);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const { data: deviceInfo, isPending: deviceInfoPending } = useDeviceInfo();
+  const deviceSerial = String(deviceInfo?.serial ?? '').trim();
 
   const settings: StaticSettingsItem[] = [
     {
@@ -54,11 +61,53 @@ export const FactoryReset = () => {
         }
       }
     },
-    !bubbleDisplay.interceptsGesture
+    !isUnlocked || !bubbleDisplay.interceptsGesture
   );
 
-  if (factoryReset.isPending || factoryReset.isSuccess) {
+  if (
+    factoryReset.isPending ||
+    factoryReset.isSuccess ||
+    (!isUnlocked && deviceInfoPending)
+  ) {
     return <LoadingScreen />;
+  }
+
+  const goBackToAdvancedSettings = () => {
+    dispatch(
+      setBubbleDisplay({ visible: true, component: 'advancedSettings' })
+    );
+  };
+
+  if (!isUnlocked) {
+    const unlockTitle = serialRejected
+      ? 'Serial does not match'
+      : 'Enter Serial Number';
+
+    return (
+      <CircleKeyboard
+        name={unlockTitle}
+        defaultValue={serialInput.split('')}
+        onSubmit={(input: string) => {
+          if (
+            deviceSerial.length > 0 &&
+            input.trim().toLowerCase() === deviceSerial.toLowerCase()
+          ) {
+            setSerialRejected(false);
+            setIsUnlocked(true);
+            return;
+          }
+
+          setSerialRejected(true);
+          setSerialInput('');
+        }}
+        onCancel={goBackToAdvancedSettings}
+        onChange={(input: string) => {
+          setSerialInput(input);
+          setSerialRejected(false);
+        }}
+        shouldIgnoreGesture={!bubbleDisplay.interceptsGesture}
+      />
+    );
   }
 
   return (

--- a/src/components/Settings/Advanced/FactoryReset.tsx
+++ b/src/components/Settings/Advanced/FactoryReset.tsx
@@ -19,7 +19,7 @@ export const FactoryReset = () => {
   const [activeIndex, setActiveIndex] = useState(1);
   const [serialInput, setSerialInput] = useState('');
   const [serialRejected, setSerialRejected] = useState(false);
-  const [isUnlocked, setIsUnlocked] = useState(false);
+  const [isSerialPromptOpen, setIsSerialPromptOpen] = useState(false);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const { data: deviceInfo, isPending: deviceInfoPending } = useDeviceInfo();
   const deviceSerial = String(deviceInfo?.serial ?? '').trim();
@@ -51,7 +51,9 @@ export const FactoryReset = () => {
         const activeItem = settings[activeIndex].key;
         switch (activeItem) {
           case 'factory_reset':
-            factoryReset.mutate();
+            setSerialInput('');
+            setSerialRejected(false);
+            setIsSerialPromptOpen(true);
             break;
           default:
             dispatch(
@@ -61,24 +63,24 @@ export const FactoryReset = () => {
         }
       }
     },
-    !isUnlocked || !bubbleDisplay.interceptsGesture
+    isSerialPromptOpen || !bubbleDisplay.interceptsGesture
   );
 
   if (
     factoryReset.isPending ||
     factoryReset.isSuccess ||
-    (!isUnlocked && deviceInfoPending)
+    (isSerialPromptOpen && deviceInfoPending)
   ) {
     return <LoadingScreen />;
   }
 
-  const goBackToAdvancedSettings = () => {
-    dispatch(
-      setBubbleDisplay({ visible: true, component: 'advancedSettings' })
-    );
+  const closeSerialPrompt = () => {
+    setSerialInput('');
+    setSerialRejected(false);
+    setIsSerialPromptOpen(false);
   };
 
-  if (!isUnlocked) {
+  if (isSerialPromptOpen) {
     const unlockTitle = serialRejected
       ? 'Serial does not match'
       : 'Enter Serial Number';
@@ -93,14 +95,14 @@ export const FactoryReset = () => {
             input.trim().toLowerCase() === deviceSerial.toLowerCase()
           ) {
             setSerialRejected(false);
-            setIsUnlocked(true);
+            factoryReset.mutate();
             return;
           }
 
           setSerialRejected(true);
           setSerialInput('');
         }}
-        onCancel={goBackToAdvancedSettings}
+        onCancel={closeSerialPrompt}
         onChange={(input: string) => {
           setSerialInput(input);
           setSerialRejected(false);


### PR DESCRIPTION
Summary
- Gate the factory reset screen with a serial-number entry lock before showing reset controls.
- Reuse device info serial data and the circular keyboard input flow.
- Keep the existing factory reset action unchanged after the serial matches.

Validation
- npm run types
- npm run lint
- npm run format:check
- npm run build
- npm run dev -- --host 127.0.0.1 --port 5173, then curl -I http://127.0.0.1:5173/ returned HTTP 200

Linear: MET-7