### PR TITLE
Lock factory reset behind full-screen serial prompt

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -32,6 +32,7 @@ interface IKeyboardProps {
   onChange?: (text: string) => void;
   onlyLetters?: boolean;
   capitalizeFirstLetter?: boolean;
+  shouldIgnoreGesture?: boolean;
 }
 
 export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
@@ -301,7 +302,7 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
         }
       }
     },
-    bubbleDisplay.interceptsGesture
+    props.shouldIgnoreGesture ?? bubbleDisplay.interceptsGesture
   );
 
   const toUpperOrLowerCase = (

--- a/src/components/Settings/Advanced/FactoryReset.css
+++ b/src/components/Settings/Advanced/FactoryReset.css
@@ -1,0 +1,12 @@
+.factory-reset-serial-keyboard {
+  position: fixed;
+  inset: 0;
+  width: 480px;
+  height: 480px;
+  background: #0f0f0f;
+  z-index: 1;
+}
+
+.factory-reset-serial-keyboard .circle-keyboard-container {
+  inset: 0;
+}

--- a/src/components/Settings/Advanced/FactoryReset.tsx
+++ b/src/components/Settings/Advanced/FactoryReset.tsx
@@ -6,6 +6,9 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { useFactoryReset } from '../../../hooks/useMachine';
 import { LoadingScreen } from '../../../components/LoadingScreen/LoadingScreen';
 import { SettingsItem } from '../../../types';
+import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
+import { CircleKeyboard } from '../../CircleKeyboard/CircleKeyboard';
+import './FactoryReset.css';
 
 export type StaticSettingsItem = SettingsItem & {
   useableWidthPercentage?: number;
@@ -15,7 +18,12 @@ export const FactoryReset = () => {
   const dispatch = useAppDispatch();
   const factoryReset = useFactoryReset();
   const [activeIndex, setActiveIndex] = useState(1);
+  const [isSerialPromptOpen, setIsSerialPromptOpen] = useState(false);
+  const [serialInput, setSerialInput] = useState('');
+  const [serialRejected, setSerialRejected] = useState(false);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const { data: deviceInfo, isPending: deviceInfoPending } = useDeviceInfo();
+  const deviceSerial = String(deviceInfo?.serial ?? '').trim();
 
   const settings: StaticSettingsItem[] = [
     {
@@ -44,7 +52,9 @@ export const FactoryReset = () => {
         const activeItem = settings[activeIndex].key;
         switch (activeItem) {
           case 'factory_reset':
-            factoryReset.mutate();
+            setSerialInput('');
+            setSerialRejected(false);
+            setIsSerialPromptOpen(true);
             break;
           default:
             dispatch(
@@ -54,11 +64,53 @@ export const FactoryReset = () => {
         }
       }
     },
-    !bubbleDisplay.interceptsGesture
+    isSerialPromptOpen || !bubbleDisplay.interceptsGesture
   );
 
-  if (factoryReset.isPending || factoryReset.isSuccess) {
+  if (
+    factoryReset.isPending ||
+    factoryReset.isSuccess ||
+    (isSerialPromptOpen && deviceInfoPending)
+  ) {
     return <LoadingScreen />;
+  }
+
+  const closeSerialPrompt = () => {
+    setSerialInput('');
+    setSerialRejected(false);
+    setIsSerialPromptOpen(false);
+  };
+
+  if (isSerialPromptOpen) {
+    return (
+      <div className="factory-reset-serial-keyboard">
+        <CircleKeyboard
+          name={
+            serialRejected ? 'Serial does not match' : 'Enter Serial Number'
+          }
+          defaultValue={serialInput.split('')}
+          onSubmit={(input: string) => {
+            if (
+              deviceSerial.length > 0 &&
+              input.trim().toLowerCase() === deviceSerial.toLowerCase()
+            ) {
+              setSerialRejected(false);
+              factoryReset.mutate();
+              return;
+            }
+
+            setSerialRejected(true);
+            setSerialInput('');
+          }}
+          onCancel={closeSerialPrompt}
+          onChange={(input: string) => {
+            setSerialInput(input);
+            setSerialRejected(false);
+          }}
+          shouldIgnoreGesture={!bubbleDisplay.interceptsGesture}
+        />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- keep the factory reset warning as the first confirmation step
- require the device serial number before calling the factory reset API
- render the serial keyboard on a fixed 480px app canvas so the side-menu strip is covered while entering the serial

## Validation
- git diff --check origin/beta..HEAD
- npm run types
- npm run lint
- npm run format:check
- npm run build
- npm run dev -- --host 127.0.0.1 --port 5173 + curl -I http://127.0.0.1:5173/

Linear: MET-7