### PR TITLE
fix(heatingscreen): stuck in heating screen when aborting a brew

### DIFF
--- a/src/components/Heating/HeatingScreen.tsx
+++ b/src/components/Heating/HeatingScreen.tsx
@@ -134,7 +134,7 @@ export const HeatingScreen = () => {
     if (statsName === 'idle' && !hasNotifications && !profileStarting) {
       dispatch(setScreen('profileHome'));
     }
-  }, [statsName]);
+  }, [statsName, profileStarting]);
 
   // Automatically start the shot based on options menu selected
   useEffect(() => {

--- a/src/components/PressetSettings/PressetSettings.tsx
+++ b/src/components/PressetSettings/PressetSettings.tsx
@@ -178,6 +178,7 @@ export function PressetSettings(): JSX.Element {
               }
               return;
             }
+            setProfileStarting(false);
             console.error(`Failed starting profile: ${response.error}`);
           } else {
             console.error(`Failed loading profile: ${data.error}`);


### PR DESCRIPTION
add `profileStarting` state to the dependency array of the useEffect in charge of dispatching the `profileHome` screen on 'idle' machine

Also set the `profileStarting` state to `false` if we fail to start the profile from the `start without saving option` in the quick settings