### PR TITLE
Feat/quick report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.102.7",
       "license": "MIT",
       "dependencies": {
-        "@meticulous-home/espresso-api": "^0.10.12",
+        "@meticulous-home/espresso-api": "^0.11.0",
         "@meticulous-home/espresso-profile": "^0.4.2",
+        "@oneidentity/zstd-js": "^1.0.3",
         "@reduxjs/toolkit": "^2.11.2",
         "@tanstack/react-query": "^5.91.0",
         "@tauri-apps/api": "^2.10.1",
@@ -1600,9 +1601,9 @@
       }
     },
     "node_modules/@meticulous-home/espresso-api": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.10.12.tgz",
-      "integrity": "sha512-ltjNUMkY5A4FcitUAzQ/+MjtPEI+HfawiTGXIVYIuVfqTaJjR28PWKI58Lk3jfDaGbba2k28vDQo4h0IPB3JGQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.11.0.tgz",
+      "integrity": "sha512-rJn6UY08HqlguQRWlWvNh1VX5dio1dV1AcWeUIUT3HuuFqLHQ2ZRCS43kJBuhEgrdGZq51TTU7mjzfQs/cRhTw==",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",
@@ -1822,6 +1823,15 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@oneidentity/zstd-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@oneidentity/zstd-js/-/zstd-js-1.0.3.tgz",
+      "integrity": "sha512-Jm6sawqxLzBrjC4sg2BeXToa33yPzUmq20CKsehKY2++D/gHb/oSwVjNgT+RH4vys+r8FynrgcNzGwhZWMLzfQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@types/emscripten": "^1.39.4"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3258,6 +3268,12 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@meticulous-home/espresso-profile": "^0.4.2",
         "@oneidentity/zstd-js": "^1.0.3",
         "@reduxjs/toolkit": "^2.11.2",
+        "@sentry/react": "^10.53.1",
         "@tanstack/react-query": "^5.91.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-log": "^2.8.0",
@@ -2839,6 +2840,97 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz",
+      "integrity": "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.53.1.tgz",
+      "integrity": "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.53.1.tgz",
+      "integrity": "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz",
+      "integrity": "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.53.1.tgz",
+      "integrity": "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry-internal/feedback": "10.53.1",
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry-internal/replay-canvas": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.53.1.tgz",
+      "integrity": "sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@simple-libs/child-process-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.102.7",
       "license": "MIT",
       "dependencies": {
-        "@meticulous-home/espresso-api": "^0.11.0",
+        "@meticulous-home/espresso-api": "^0.11.1",
         "@meticulous-home/espresso-profile": "^0.4.2",
         "@oneidentity/zstd-js": "^1.0.3",
         "@reduxjs/toolkit": "^2.11.2",
@@ -1602,9 +1602,9 @@
       }
     },
     "node_modules/@meticulous-home/espresso-api": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.11.0.tgz",
-      "integrity": "sha512-rJn6UY08HqlguQRWlWvNh1VX5dio1dV1AcWeUIUT3HuuFqLHQ2ZRCS43kJBuhEgrdGZq51TTU7mjzfQs/cRhTw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@meticulous-home/espresso-api/-/espresso-api-0.11.1.tgz",
+      "integrity": "sha512-YKFOt6Ei3AlAhqfvFrIhaiuv+UBhC2uxdRcp2jDePHPm88F3o8fBxP6xre7zrgn/NYRFPbho9NzbO4dCUOyKyw==",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "vite": "^7.3.1"
   },
   "dependencies": {
-    "@meticulous-home/espresso-api": "^0.11.0",
+    "@meticulous-home/espresso-api": "^0.11.1",
     "@meticulous-home/espresso-profile": "^0.4.2",
     "@oneidentity/zstd-js": "^1.0.3",
     "@reduxjs/toolkit": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,9 @@
     "vite": "^7.3.1"
   },
   "dependencies": {
-    "@meticulous-home/espresso-api": "^0.10.12",
+    "@meticulous-home/espresso-api": "^0.11.0",
     "@meticulous-home/espresso-profile": "^0.4.2",
+    "@oneidentity/zstd-js": "^1.0.3",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.91.0",
     "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@meticulous-home/espresso-profile": "^0.4.2",
     "@oneidentity/zstd-js": "^1.0.3",
     "@reduxjs/toolkit": "^2.11.2",
+    "@sentry/react": "^10.53.1",
     "@tanstack/react-query": "^5.91.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,9 @@ import './globals.css';
 
 import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
 
-const SENTRY_DSN = '';
+// const SENTRY_DSN = 'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7'; //self hosted
+const SENTRY_DSN =
+  'https://8d8dbea1f60d65c201b7f40f8a5ee20c@o4506723336060928.ingest.us.sentry.io/4511430165921792';
 
 if (SENTRY_DSN) {
   Sentry.init({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import { useEffect, useState } from 'react';
 import * as ReactDOM from 'react-dom/client';
+import * as Sentry from '@sentry/react';
 import { Provider } from 'react-redux';
 
 import { useAppDispatch, useAppSelector } from './components/store/hooks';
@@ -23,6 +24,14 @@ import { invoke } from '@tauri-apps/api/core';
 import './globals.css';
 
 import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
+
+const SENTRY_DSN = '';
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN
+  });
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/components/BugReport/BugReport.tsx
+++ b/src/components/BugReport/BugReport.tsx
@@ -67,6 +67,7 @@ export interface DraftFile {
 
 export const getContentType = (filename: string) => {
   if (filename.endsWith('.json')) return 'application/json';
+  if (filename.endsWith('.zst')) return 'application/zstd';
   if (filename.endsWith('.txt') || filename.endsWith('.log')) {
     return 'text/plain';
   }
@@ -193,24 +194,32 @@ const getTicketEventID = (reportInfo: ReportInfo) => {
   return `${machineID}-${localID}`;
 };
 
+const buildDraftAttachment = (draftFile: Uint8Array): DraftFile => {
+  const name = `bug-report-information.tar.zst`;
+
+  return {
+    name,
+    data: draftFile,
+    contentType: getContentType(name)
+  };
+};
+
 const sendSentryFeedback = async ({
   reportInfo,
-  files
+  attachment
 }: {
   reportInfo: ReportInfo;
-  files: DraftFile[];
+  attachment: DraftFile;
 }) => {
   if (!Sentry.isInitialized()) {
     throw new Error('Sentry is not initialized');
   }
 
-  const attachments = files.filter(
-    (file) => file.name.split('/').pop() !== 'report_info.json'
-  );
-
   const eventID = Sentry.captureFeedback(
     {
-      message: reportInfo.description || 'Bug report submitted',
+      ...(reportInfo.machineID ? { name: reportInfo.machineID } : {}),
+      message:
+        reportInfo.description || 'Bug report submitted through quick report',
       source: 'custom',
       ...(reportInfo.baseEventID
         ? { associatedEventId: reportInfo.baseEventID }
@@ -223,11 +232,13 @@ const sendSentryFeedback = async ({
           'meticulous.report_source': 'dial'
         }
       },
-      attachments: attachments.map((file) => ({
-        filename: file.name.replace(/\//g, '_'),
-        data: file.data,
-        contentType: file.contentType
-      }))
+      attachments: [
+        {
+          filename: attachment.name.replace(/\//g, '_'),
+          data: attachment.data,
+          contentType: attachment.contentType
+        }
+      ]
     }
   );
 
@@ -264,7 +275,8 @@ export const BugReport = (): JSX.Element => {
           key: 'reportIssue',
           label: 'Report an issue',
           useableWidthPercentage: 81
-        }
+        },
+        { key: 'back', label: 'Back', useableWidthPercentage: 81 }
       ];
     }
 
@@ -386,6 +398,7 @@ export const BugReport = (): JSX.Element => {
 
       setSubmissionStage('buildingFeedback');
       const reportInfo = parseReportInfo(files);
+      const attachment = buildDraftAttachment(draftFile);
       if (timedOut) return;
 
       setSubmissionStage('ticketing');
@@ -402,7 +415,7 @@ export const BugReport = (): JSX.Element => {
       if (timedOut) return;
 
       setSubmissionStage('sendingFeedback');
-      const eventID = await sendSentryFeedback({ reportInfo, files });
+      const eventID = await sendSentryFeedback({ reportInfo, attachment });
       if (timedOut) return;
 
       setSubmissionStage('savingRecord');
@@ -465,6 +478,9 @@ export const BugReport = (): JSX.Element => {
           startCreateReport();
           break;
         case 'back':
+          if (reportScreen === ReportScreen.message) {
+            exitToQuickSettings();
+          }
           setReportScreen(ReportScreen.message);
           setReportStatus(ReportStatus.idle);
           setActiveIndex(0);
@@ -516,8 +532,8 @@ export const BugReport = (): JSX.Element => {
               </div>
               <div style={{ marginTop: '10px' }}>
                 <span>
-                  Clicking on <strong>Submit</strong>will send us the ticket and
-                  will give You a report <strong>tracking number</strong>
+                  Clicking on <strong>Submit</strong> will send us the ticket
+                  and provide You with a report <strong>tracking number</strong>
                 </span>
               </div>
             </>
@@ -536,13 +552,8 @@ export const BugReport = (): JSX.Element => {
           <div style={{ marginTop: '10px' }}>
             <span>
               Your report has been generated with ticket number{' '}
-              <strong>${ticketRef.current}</strong>. You can ask for information
+              <strong>{ticketRef.current}</strong>. You can ask for information
               about it by contacting support.
-            </span>
-          </div>
-          <div style={{ marginTop: '10px' }}>
-            <span>
-              You can enhance Your ticket details using the mobile app
             </span>
           </div>
         </>
@@ -558,13 +569,15 @@ export const BugReport = (): JSX.Element => {
     reportStatus === ReportStatus.slowFetch
   ) {
     return (
-      <div className="bug-report-loading">
-        <div className="settings-explanation-shaper-left" />
-        <div className="settings-explanation-shaper-right" />
-        {reportStatus !== ReportStatus.submitting && (
-          <span className="bug-report-loading-text">{message}</span>
-        )}
-        <LoadingScreen />
+      <div className="bug-report-loading settings-explanation-container">
+        <div className="settings-explanation">
+          <div className="settings-explanation-shaper-left" />
+          <div className="settings-explanation-shaper-right" />
+          {reportStatus !== ReportStatus.submitting && (
+            <span className="bug-report-loading-text">{message}</span>
+          )}
+          <LoadingScreen />
+        </div>
       </div>
     );
   }
@@ -583,7 +596,7 @@ export const BugReport = (): JSX.Element => {
             <div className="settings-explanation-shaper-left" />
             <div className="settings-explanation-shaper-right" />
             {/* <span className="bug-report-message">{message}</span> */}
-            <span>{message}</span>
+            <div>{message}</div>
           </>
         )}
       </div>

--- a/src/components/BugReport/BugReport.tsx
+++ b/src/components/BugReport/BugReport.tsx
@@ -76,7 +76,8 @@ export const getContentType = (filename: string) => {
 };
 
 const SUPPORT_WEBSITE_URL = 'https://meticuloushome.com/pages/contact';
-const service_url = 'https://example.invalid/ticket';
+const service_url =
+  'https://a3qhsgqqfk.execute-api.us-east-1.amazonaws.com/Prod/ticket';
 
 const textDecoder = new TextDecoder();
 

--- a/src/components/BugReport/BugReport.tsx
+++ b/src/components/BugReport/BugReport.tsx
@@ -1,0 +1,3 @@
+export const BugReport = (): JSX.Element => {
+  return <></>;
+};

--- a/src/components/BugReport/BugReport.tsx
+++ b/src/components/BugReport/BugReport.tsx
@@ -1,3 +1,617 @@
+import { useMemo, useRef, useState } from 'react';
+import { ZstdDec, ZstdInit } from '@oneidentity/zstd-js/decompress';
+import * as Sentry from '@sentry/react';
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
+import { QrGeneratedImage } from '../QR/QrImage';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../store/features/screens/screens-slice';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+
+import {
+  ReportInfo,
+  DraftInfo,
+  MeticulousIDRequestType
+} from '@meticulous-home/espresso-api';
+
+import { api } from '../../api/api';
+
+import './bugReport.css';
+
+enum ReportScreen {
+  message = 'message',
+  reportingBug = 'reportingBug',
+  contactInfo = 'contactInfo',
+  submitted = 'submitted'
+}
+
+enum ReportStatus {
+  idle = 'idle',
+  fetching = 'fetching',
+  slowFetch = 'slowFetch',
+  fetched = 'fetched',
+  submitting = 'submitting',
+  failed = 'failed'
+}
+
+type SubmissionFailType =
+  | 'creation'
+  | 'sentrySubmission'
+  | 'submissionMark'
+  | 'TicketTrackRequest'
+  | 'submissionTimeout'
+  | 'reportLoad';
+
+type SubmissionStateType =
+  | null
+  | 'fetchingFile'
+  | 'decompressing'
+  | 'buildingFeedback'
+  | 'ticketing'
+  | 'sendingFeedback'
+  | 'savingRecord';
+
+type BugReportOption = {
+  key: 'contactInfo' | 'reportIssue' | 'back' | 'submit' | 'exit';
+  label: string;
+  useableWidthPercentage: number;
+};
+
+export interface DraftFile {
+  name: string;
+  data: Uint8Array;
+  contentType: string;
+}
+
+export const getContentType = (filename: string) => {
+  if (filename.endsWith('.json')) return 'application/json';
+  if (filename.endsWith('.txt') || filename.endsWith('.log')) {
+    return 'text/plain';
+  }
+  if (filename.endsWith('.csv')) return 'text/csv';
+  return 'application/octet-stream';
+};
+
+const SUPPORT_WEBSITE_URL = 'https://meticuloushome.com/pages/contact';
+const service_url = 'https://example.invalid/ticket';
+
+const textDecoder = new TextDecoder();
+
+const reportSubmissionError =
+  'failed to submit the report. Please contact us for further information';
+
+const captureException = (error: unknown) => {
+  console.error(error);
+  if (Sentry.isInitialized()) {
+    Sentry.captureException(error);
+  }
+};
+
+const readTarString = (data: Uint8Array, start: number, length: number) => {
+  const slice = data.slice(start, start + length);
+  const end = slice.indexOf(0);
+  return textDecoder.decode(end >= 0 ? slice.slice(0, end) : slice).trim();
+};
+
+const readTarSize = (data: Uint8Array, offset: number) => {
+  const sizeText = readTarString(data, offset + 124, 12);
+  return Number.parseInt(sizeText || '0', 8);
+};
+
+const isEmptyTarBlock = (data: Uint8Array, offset: number) => {
+  for (
+    let index = offset;
+    index < offset + 512 && index < data.length;
+    index++
+  ) {
+    if (data[index] !== 0) return false;
+  }
+  return true;
+};
+
+const untar = (data: Uint8Array): DraftFile[] => {
+  const files: DraftFile[] = [];
+  let offset = 0;
+
+  while (offset + 512 <= data.length && !isEmptyTarBlock(data, offset)) {
+    const name = readTarString(data, offset, 100);
+    const prefix = readTarString(data, offset + 345, 155);
+    const typeFlag = readTarString(data, offset + 156, 1);
+    const size = readTarSize(data, offset);
+    const fileStart = offset + 512;
+    const fileEnd = fileStart + size;
+
+    if (name && (!typeFlag || typeFlag === '0')) {
+      const filename = prefix ? `${prefix}/${name}` : name;
+      files.push({
+        name: filename,
+        data: data.slice(fileStart, fileEnd),
+        contentType: getContentType(filename)
+      });
+    }
+
+    offset = fileStart + Math.ceil(size / 512) * 512;
+  }
+
+  return files;
+};
+
+const decompressReportDraft = async (compressed: Uint8Array) => {
+  const { ZstdSimple, ZstdStream }: ZstdDec = await ZstdInit();
+
+  try {
+    return ZstdSimple.decompress(compressed);
+  } catch {
+    return ZstdStream.decompress(compressed);
+  }
+};
+
+const parseReportFiles = async (compressed: Uint8Array) => {
+  const decompressed = await decompressReportDraft(compressed);
+  const files = untar(decompressed);
+
+  if (files.length > 0) {
+    return files;
+  }
+
+  throw new Error('Report draft did not contain a readable tar archive');
+};
+
+const parseReportInfo = (files: DraftFile[]): ReportInfo => {
+  const reportInfoFile = files.find(
+    (file) => file.name.split('/').pop() === 'report_info.json'
+  );
+
+  if (!reportInfoFile) {
+    throw new Error('report_info.json missing from report draft');
+  }
+
+  return JSON.parse(textDecoder.decode(reportInfoFile.data));
+};
+
+const reportInfoTags = (reportInfo: ReportInfo) => {
+  return Object.fromEntries(
+    Object.entries(reportInfo)
+      .filter(([, value]) => value !== null && value !== undefined)
+      .map(([key, value]) => [
+        key,
+        typeof value === 'object' ? JSON.stringify(value) : String(value)
+      ])
+  );
+};
+
+const getTicketEventID = (reportInfo: ReportInfo) => {
+  const machineID = reportInfo.machineID?.trim();
+  const localID = reportInfo.localID?.trim();
+
+  if (!machineID || !localID) {
+    throw new Error('Report info is missing machineID or localID');
+  }
+
+  return `${machineID}-${localID}`;
+};
+
+const sendSentryFeedback = async ({
+  reportInfo,
+  files
+}: {
+  reportInfo: ReportInfo;
+  files: DraftFile[];
+}) => {
+  if (!Sentry.isInitialized()) {
+    throw new Error('Sentry is not initialized');
+  }
+
+  const attachments = files.filter(
+    (file) => file.name.split('/').pop() !== 'report_info.json'
+  );
+
+  const eventID = Sentry.captureFeedback(
+    {
+      message: reportInfo.description || 'Bug report submitted',
+      source: 'custom',
+      ...(reportInfo.baseEventID
+        ? { associatedEventId: reportInfo.baseEventID }
+        : {})
+    },
+    {
+      captureContext: {
+        tags: {
+          ...reportInfoTags(reportInfo),
+          'meticulous.report_source': 'dial'
+        }
+      },
+      attachments: attachments.map((file) => ({
+        filename: file.name.replace(/\//g, '_'),
+        data: file.data,
+        contentType: file.contentType
+      }))
+    }
+  );
+
+  const sent = await Sentry.flush(10_000);
+  if (!sent) {
+    throw new Error('Sentry feedback flush timed out');
+  }
+
+  return eventID;
+};
+
 export const BugReport = (): JSX.Element => {
-  return <></>;
+  const dispatch = useAppDispatch();
+  const currentScreen = useAppSelector((state) => state.screen.value);
+  const previousScreen = useAppSelector((state) => state.screen.prev);
+  const [reportScreen, setReportScreen] = useState(ReportScreen.message);
+  const [reportStatus, setReportStatus] = useState(ReportStatus.idle);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [failureError, setFailureError] = useState('');
+  const draftInfoRef = useRef<DraftInfo | null>(null);
+  const failureRef = useRef<SubmissionFailType | null>(null);
+  const ticketRef = useRef<number | null>(null);
+  const submissionStateRef = useRef<SubmissionStateType>(null);
+
+  const options = useMemo<BugReportOption[]>(() => {
+    if (reportScreen === ReportScreen.message) {
+      return [
+        {
+          key: 'contactInfo',
+          label: 'Contact info',
+          useableWidthPercentage: 81
+        },
+        {
+          key: 'reportIssue',
+          label: 'Report an issue',
+          useableWidthPercentage: 81
+        }
+      ];
+    }
+
+    if (reportScreen === ReportScreen.contactInfo) {
+      return [{ key: 'back', label: 'Back', useableWidthPercentage: 81 }];
+    }
+
+    if (
+      reportScreen === ReportScreen.reportingBug &&
+      reportStatus === ReportStatus.fetched
+    ) {
+      return [
+        { key: 'submit', label: 'Submit', useableWidthPercentage: 81 },
+        { key: 'exit', label: 'Exit', useableWidthPercentage: 81 }
+      ];
+    }
+
+    if (
+      reportScreen === ReportScreen.reportingBug &&
+      reportStatus === ReportStatus.failed
+    ) {
+      return [{ key: 'exit', label: 'Exit', useableWidthPercentage: 81 }];
+    }
+
+    if (reportScreen === ReportScreen.submitted) {
+      return [{ key: 'exit', label: 'Exit', useableWidthPercentage: 81 }];
+    }
+
+    return [];
+  }, [reportScreen, reportStatus]);
+
+  const exitToQuickSettings = () => {
+    const targetScreen =
+      currentScreen === 'bug-report'
+        ? previousScreen || 'profileHome'
+        : currentScreen;
+
+    if (targetScreen !== currentScreen) {
+      dispatch(setScreen(targetScreen));
+      return;
+    }
+    dispatch(setBubbleDisplay({ visible: true, component: 'quick-settings' }));
+  };
+
+  const startCreateReport = async () => {
+    setReportScreen(ReportScreen.reportingBug);
+    setReportStatus(ReportStatus.fetching);
+    setActiveIndex(0);
+    failureRef.current = null;
+    draftInfoRef.current = null;
+
+    const slowTimeout = setTimeout(() => {
+      setReportStatus(ReportStatus.slowFetch);
+    }, 60 * 1000);
+
+    try {
+      const create_response = await api.createReport();
+      if ('error' in create_response) {
+        throw Error(create_response.error);
+      }
+      draftInfoRef.current = create_response;
+      setReportStatus(ReportStatus.fetched);
+    } catch (error) {
+      failureRef.current = 'creation';
+      setFailureError(
+        'There was an error while getting the necessary information, You may contact us for further instructions'
+      );
+      setReportStatus(ReportStatus.failed);
+      captureException(error);
+    } finally {
+      clearTimeout(slowTimeout);
+    }
+  };
+
+  const failSubmission = (
+    failure: SubmissionFailType,
+    errorMessage: string,
+    error: unknown
+  ) => {
+    failureRef.current = failure;
+    setFailureError(errorMessage);
+    setReportStatus(ReportStatus.failed);
+    submissionStateRef.current = null;
+    captureException(error);
+  };
+
+  const setSubmissionStage = (stage: SubmissionStateType) => {
+    submissionStateRef.current = stage;
+  };
+
+  const submitReport = async () => {
+    if (!draftInfoRef.current?.localID) {
+      failSubmission('reportLoad', reportSubmissionError, 'No draft report');
+      return;
+    }
+
+    setReportStatus(ReportStatus.submitting);
+    failureRef.current = null;
+
+    let timedOut = false;
+    const submissionTimeout = setTimeout(() => {
+      timedOut = true;
+      failSubmission(
+        'submissionTimeout',
+        reportSubmissionError,
+        'Report submission timed out'
+      );
+    }, 60 * 1000);
+
+    try {
+      setSubmissionStage('fetchingFile');
+      const draftFile = await api.getDraftReport(draftInfoRef.current.localID);
+      if ('error' in draftFile) throw Error(draftFile.error);
+      if (timedOut) return;
+
+      setSubmissionStage('decompressing');
+      const files = await parseReportFiles(draftFile);
+      if (timedOut) return;
+
+      setSubmissionStage('buildingFeedback');
+      const reportInfo = parseReportInfo(files);
+      if (timedOut) return;
+
+      setSubmissionStage('ticketing');
+      const ticketPayload: MeticulousIDRequestType = {
+        eventID: getTicketEventID(reportInfo)
+      };
+      const ticket = await api.getMeticulousReportTracking(
+        service_url,
+        ticketPayload
+      );
+      if (typeof ticket === 'object') throw Error(ticket.error);
+      ticketRef.current = ticket;
+      reportInfo.ticket = ticket;
+      if (timedOut) return;
+
+      setSubmissionStage('sendingFeedback');
+      const eventID = await sendSentryFeedback({ reportInfo, files });
+      if (timedOut) return;
+
+      setSubmissionStage('savingRecord');
+      await api.markSubmittedReport({
+        localID: draftInfoRef.current.localID,
+        eventID,
+        ticket,
+        submissionTime: Math.floor(Date.now() / 1000)
+      });
+      if (timedOut) return;
+
+      setSubmissionStage(null);
+      setReportScreen(ReportScreen.submitted);
+      setReportStatus(ReportStatus.idle);
+    } catch (error) {
+      if (timedOut) return;
+
+      if (submissionStateRef.current === 'sendingFeedback') {
+        failSubmission('sentrySubmission', reportSubmissionError, error);
+      } else if (submissionStateRef.current === 'ticketing') {
+        failSubmission(
+          'TicketTrackRequest',
+          'Failed getting ticket number. Please contact us for further information',
+          error
+        );
+      } else if (submissionStateRef.current === 'savingRecord') {
+        failSubmission(
+          'submissionMark',
+          `failed to update your reports record, dont worry we received the ticket with number ${ticketRef.current}, save the ticket number for further tracking. Please contact us for further information`,
+          error
+        );
+      } else {
+        failSubmission('reportLoad', reportSubmissionError, error);
+      }
+    } finally {
+      clearTimeout(submissionTimeout);
+    }
+  };
+
+  useHandleGestures({
+    left() {
+      if (options.length === 0) return;
+      setActiveIndex((prev) => Math.max(prev - 1, 0));
+    },
+    right() {
+      if (options.length === 0) return;
+      setActiveIndex((prev) => Math.min(prev + 1, options.length - 1));
+    },
+    pressDown() {
+      const activeOption = options[activeIndex];
+      if (!activeOption || reportStatus === ReportStatus.submitting) return;
+
+      switch (activeOption.key) {
+        case 'contactInfo':
+          setReportScreen(ReportScreen.contactInfo);
+          setReportStatus(ReportStatus.idle);
+          setActiveIndex(0);
+          break;
+        case 'reportIssue':
+          startCreateReport();
+          break;
+        case 'back':
+          setReportScreen(ReportScreen.message);
+          setReportStatus(ReportStatus.idle);
+          setActiveIndex(0);
+          break;
+        case 'submit':
+          submitReport();
+          break;
+        case 'exit':
+          exitToQuickSettings();
+          break;
+      }
+    }
+  });
+
+  const message = useMemo(() => {
+    if (reportScreen === ReportScreen.message) {
+      return (
+        <>
+          <div style={{ marginTop: '10px' }}>
+            <span>
+              This action will send debug data and provide You with a{' '}
+              <strong>bug report number</strong>.
+            </span>
+          </div>
+          <div style={{ marginTop: '10px' }}>
+            <span>
+              Click on <strong>contact info</strong> to display QR coded contact
+              information or <strong>report an issue</strong> to continue.
+            </span>
+          </div>
+          <div style={{ marginTop: '10px' }}>
+            <span>We strongly recommend reporting from the mobile app</span>
+          </div>
+        </>
+      );
+    }
+
+    if (reportScreen === ReportScreen.reportingBug) {
+      switch (reportStatus) {
+        case ReportStatus.fetching:
+          return 'Please wait while we compile the necessary information';
+        case ReportStatus.slowFetch:
+          return 'This is taking longer than expected, please wait';
+        case ReportStatus.fetched:
+          return (
+            <>
+              <div style={{ marginTop: '10px' }}>
+                <span>We are almost done.</span>
+              </div>
+              <div style={{ marginTop: '10px' }}>
+                <span>
+                  Clicking on <strong>Submit</strong>will send us the ticket and
+                  will give You a report <strong>tracking number</strong>
+                </span>
+              </div>
+            </>
+          );
+        case ReportStatus.failed:
+          return failureError;
+      }
+    }
+
+    if (reportScreen === ReportScreen.submitted) {
+      return (
+        <>
+          <div style={{ marginTop: '10px' }}>
+            <span>Thanks for Your feedback</span>
+          </div>
+          <div style={{ marginTop: '10px' }}>
+            <span>
+              Your report has been generated with ticket number{' '}
+              <strong>${ticketRef.current}</strong>. You can ask for information
+              about it by contacting support.
+            </span>
+          </div>
+          <div style={{ marginTop: '10px' }}>
+            <span>
+              You can enhance Your ticket details using the mobile app
+            </span>
+          </div>
+        </>
+      );
+    }
+
+    return '';
+  }, [failureError, reportScreen, reportStatus]);
+
+  if (
+    reportStatus === ReportStatus.submitting ||
+    reportStatus === ReportStatus.fetching ||
+    reportStatus === ReportStatus.slowFetch
+  ) {
+    return (
+      <div className="bug-report-loading">
+        <div className="settings-explanation-shaper-left" />
+        <div className="settings-explanation-shaper-right" />
+        {reportStatus !== ReportStatus.submitting && (
+          <span className="bug-report-loading-text">{message}</span>
+        )}
+        <LoadingScreen />
+      </div>
+    );
+  }
+
+  return (
+    <div className="main-quick-settings settings-explanation-container">
+      <div className="settings-explanation">
+        {reportScreen === ReportScreen.contactInfo ? (
+          <QrGeneratedImage
+            size={240}
+            value={SUPPORT_WEBSITE_URL}
+            description="Scan to open Meticulous contact information"
+          />
+        ) : (
+          <>
+            <div className="settings-explanation-shaper-left" />
+            <div className="settings-explanation-shaper-right" />
+            {/* <span className="bug-report-message">{message}</span> */}
+            <span>{message}</span>
+          </>
+        )}
+      </div>
+      {options.length > 0 && (
+        <div
+          className="settings-fixed-item-container"
+          style={{ marginBottom: '50px' }}
+        >
+          {options.map((item, index) => {
+            const width = item.useableWidthPercentage || 90;
+            return (
+              <div
+                key={item.key}
+                className={`settings-fixed-item settings-item ${
+                  index === activeIndex ? 'active-setting' : ''
+                }`}
+                style={{
+                  marginBottom: '5px',
+                  width: `${width}%`,
+                  paddingRight: `${90 - width}%`
+                }}
+              >
+                <span className="settings-fixed-item-text">{item.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 };

--- a/src/components/BugReport/BugReport.tsx
+++ b/src/components/BugReport/BugReport.tsx
@@ -39,6 +39,7 @@ enum ReportStatus {
 type SubmissionFailType =
   | 'creation'
   | 'sentrySubmission'
+  | 'reportUpdate'
   | 'submissionMark'
   | 'TicketTrackRequest'
   | 'submissionTimeout'
@@ -50,6 +51,7 @@ type SubmissionStateType =
   | 'decompressing'
   | 'buildingFeedback'
   | 'ticketing'
+  | 'updatingReport'
   | 'sendingFeedback'
   | 'savingRecord';
 
@@ -184,12 +186,21 @@ const reportInfoTags = (reportInfo: ReportInfo) => {
   );
 };
 
-const getTicketEventID = (reportInfo: ReportInfo) => {
-  const machineID = reportInfo.machineID?.trim();
-  const localID = reportInfo.localID?.trim();
+const isReportError = (response: unknown): response is { error: string } => {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'error' in response &&
+    typeof response.error === 'string'
+  );
+};
+
+const getTicketEventID = (draftInfo: DraftInfo) => {
+  const machineID = draftInfo.machineID?.trim();
+  const localID = draftInfo.localID?.trim();
 
   if (!machineID || !localID) {
-    throw new Error('Report info is missing machineID or localID');
+    throw new Error('Draft info is missing machineID or localID');
   }
 
   return `${machineID}-${localID}`;
@@ -335,7 +346,7 @@ export const BugReport = (): JSX.Element => {
 
     try {
       const create_response = await api.createReport();
-      if ('error' in create_response) {
+      if (isReportError(create_response)) {
         throw Error(create_response.error);
       }
       draftInfoRef.current = create_response;
@@ -369,7 +380,8 @@ export const BugReport = (): JSX.Element => {
   };
 
   const submitReport = async () => {
-    if (!draftInfoRef.current?.localID) {
+    const draftInfo = draftInfoRef.current;
+    if (!draftInfo?.localID) {
       failSubmission('reportLoad', reportSubmissionError, 'No draft report');
       return;
     }
@@ -388,9 +400,28 @@ export const BugReport = (): JSX.Element => {
     }, 60 * 1000);
 
     try {
+      setSubmissionStage('ticketing');
+      const ticketPayload: MeticulousIDRequestType = {
+        eventID: getTicketEventID(draftInfo)
+      };
+      const ticket = await api.getMeticulousReportTracking(
+        service_url,
+        ticketPayload
+      );
+      if (isReportError(ticket)) throw Error(ticket.error);
+      ticketRef.current = ticket;
+      if (timedOut) return;
+
+      setSubmissionStage('updatingReport');
+      const updateResponse = await api.updateReport(draftInfo.localID, {
+        ticket
+      });
+      if (isReportError(updateResponse)) throw Error(updateResponse.error);
+      if (timedOut) return;
+
       setSubmissionStage('fetchingFile');
-      const draftFile = await api.getDraftReport(draftInfoRef.current.localID);
-      if ('error' in draftFile) throw Error(draftFile.error);
+      const draftFile = await api.getDraftReport(draftInfo.localID);
+      if (isReportError(draftFile)) throw Error(draftFile.error);
       if (timedOut) return;
 
       setSubmissionStage('decompressing');
@@ -400,18 +431,6 @@ export const BugReport = (): JSX.Element => {
       setSubmissionStage('buildingFeedback');
       const reportInfo = parseReportInfo(files);
       const attachment = buildDraftAttachment(draftFile);
-      if (timedOut) return;
-
-      setSubmissionStage('ticketing');
-      const ticketPayload: MeticulousIDRequestType = {
-        eventID: getTicketEventID(reportInfo)
-      };
-      const ticket = await api.getMeticulousReportTracking(
-        service_url,
-        ticketPayload
-      );
-      if (typeof ticket === 'object') throw Error(ticket.error);
-      ticketRef.current = ticket;
       reportInfo.ticket = ticket;
       if (timedOut) return;
 
@@ -420,12 +439,15 @@ export const BugReport = (): JSX.Element => {
       if (timedOut) return;
 
       setSubmissionStage('savingRecord');
-      await api.markSubmittedReport({
-        localID: draftInfoRef.current.localID,
+      const markSubmittedResponse = await api.markSubmittedReport({
+        localID: draftInfo.localID,
         eventID,
         ticket,
         submissionTime: Math.floor(Date.now() / 1000)
       });
+      if (isReportError(markSubmittedResponse)) {
+        throw Error(markSubmittedResponse.error);
+      }
       if (timedOut) return;
 
       setSubmissionStage(null);

--- a/src/components/BugReport/bugReport.css
+++ b/src/components/BugReport/bugReport.css
@@ -1,0 +1,15 @@
+.bug-report-loading {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+
+.bug-report-loading-text {
+  font-size: 22px;
+  margin-top: 24px;
+  max-width: 420px;
+  text-align: center;
+}

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -84,6 +84,10 @@ const defaultSettings: QuickSettingOption[] = [
     label: 'config'
   },
   {
+    key: 'bug_report',
+    label: 'Report an issue'
+  },
+  {
     key: 'exit',
     label: 'exit'
   }
@@ -304,6 +308,12 @@ export function QuickSettings(): JSX.Element {
           case 'config': {
             dispatch(
               setBubbleDisplay({ visible: true, component: 'settings' })
+            );
+            break;
+          }
+          case 'bug_report': {
+            dispatch(
+              setBubbleDisplay({ visible: true, component: 'bug-report' })
             );
             break;
           }

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -109,6 +109,10 @@ const inBrewSettings: QuickSettingOption[] = [
     label: 'config'
   },
   {
+    key: 'bug_report',
+    label: 'Report an issue'
+  },
+  {
     key: 'exit',
     label: 'exit'
   }

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -26,6 +26,7 @@ export type ScreenType =
   | 'connectWifiMenu'
   | 'selectWifi'
   | 'connectWifiViaApp'
+  | 'bug-report'
   | 'OSStatus'
   | 'enterWifiPassword'
   | 'quick-settings'

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -13,6 +13,7 @@ import { WifiDetails } from '../components/Wifi/WifiDetails';
 import { RootState } from '../components/store/store';
 import { Notification } from '../components/Notification/Notification';
 import { ConnectWifiViaApp } from '../components/Wifi/ConnetWifiViaApp';
+import { BugReport } from '../components/BugReport/BugReport';
 import { OSStatus } from '../components/OSStatus/OSStatus';
 import { QuickSettings } from '../../src/components/QuickSettings/QuickSettings';
 import { SnakeGame } from '../../src/components/Snake/Snake';
@@ -345,6 +346,11 @@ export const routes: Record<ScreenType, Route> = {
   connectWifiViaApp: {
     component: ConnectWifiViaApp,
     title: 'connect to wifi via app',
+    bottomStatusHidden: true
+  },
+  'bug-report': {
+    component: BugReport,
+    title: 'report an issue',
     bottomStatusHidden: true
   },
   enterWifiPassword: {


### PR DESCRIPTION
## What was done?
 Implement a quick report option in the quick settings menu
## Why?
To allow the users submit a report issue the moment it occurs, without the need of having the mobile app at hand

## Additional comments & remarks

## Full detail of changes made to each function

A new screen `bug-report` is created, based on the settings explanation style to allow the display of long messages and options.

included Sentry as dependency for sending the report as an user feedback

It follows the workflow:
 - request a report creation to the backend
 - on user submit:
     - request the ticketing service for a tracking number
     - update the issue with the ticket number
     - fetch the issue report information
     - submit the feedback to sentry


https://github.com/user-attachments/assets/4419f629-1040-47c1-8904-52562b97cec5

