### PR TITLE
Improve Wi-Fi diagnostics and setup UX

### DIFF
--- a/src/api/wifi.ts
+++ b/src/api/wifi.ts
@@ -6,10 +6,96 @@ import {
   WiFiNetwork,
   WifiStatus
 } from '@meticulous-home/espresso-api';
-import { api } from './api';
+import { API_URL, api } from './api';
+
+export type WifiHealthStatus = {
+  mode: string;
+  link_connected: boolean;
+  has_ipv4: boolean;
+  gateway_reachable: boolean;
+  dns_resolves: boolean;
+  internet_reachable: boolean;
+  ap_active: boolean;
+  degraded: boolean;
+  last_error: string;
+  message?: string;
+  last_recovery_action: string;
+  last_recovery_result: string;
+};
+
+export type KnownWifi = {
+  ssid: string;
+  type?: string;
+};
+
+export type ExtendedWifiStatus = WifiStatus & {
+  health?: WifiHealthStatus;
+  known_wifis?: Record<string, KnownWifi | string>;
+};
+
+export type WifiConnectResult = {
+  status: string;
+  health?: WifiHealthStatus;
+};
+
+export type WifiConnectCredentials =
+  | WiFiCredentials
+  | {
+      type: 'PSK' | 'SAE';
+      ssid: string;
+      password?: string;
+    };
+
+export class WiFiConnectionError extends Error {
+  code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = 'WiFiConnectionError';
+    this.code = code;
+  }
+}
+
+function getApiErrorMessage(error: unknown, fallback: string): string {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'response' in error &&
+    error.response &&
+    typeof error.response === 'object' &&
+    'data' in error.response
+  ) {
+    const data = error.response.data as Partial<APIError> & {
+      message?: string;
+    };
+    return data.error || data.message || fallback;
+  }
+
+  if (error instanceof Error) {
+    return error.message || fallback;
+  }
+
+  return fallback;
+}
+
+function getApiErrorCode(error: unknown): string | undefined {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'response' in error &&
+    error.response &&
+    typeof error.response === 'object' &&
+    'data' in error.response
+  ) {
+    const data = error.response.data as { code?: string };
+    return data.code;
+  }
+
+  return undefined;
+}
 
 // Wrapper for getWiFiConfig
-export async function getWifiStatus(): Promise<WifiStatus> {
+export async function getWifiStatus(): Promise<ExtendedWifiStatus> {
   try {
     const response = await api.getWiFiStatus();
     const data = response.data;
@@ -33,6 +119,22 @@ export async function getWifiStatus(): Promise<WifiStatus> {
   }
 }
 
+export async function repairWifi(): Promise<WifiHealthStatus> {
+  try {
+    const response = await fetch(`${API_URL}/api/v1/wifi/repair`, {
+      method: 'POST'
+    });
+    const data = await response.json();
+    if (!response.ok || 'error' in data) {
+      throw new Error(data?.error || 'Error repairing Wi-Fi.');
+    }
+    return data.health as WifiHealthStatus;
+  } catch (error) {
+    console.error('Network error while repairing Wi-Fi: ', error.message);
+    throw new Error(error.message || 'Network error while repairing Wi-Fi.');
+  }
+}
+
 // Wrapper for setWiFiConfig
 export async function updateNetworkConfig(
   config: Partial<WiFiConfig>
@@ -48,7 +150,7 @@ export async function updateNetworkConfig(
     if (error.response) {
       console.error('Error updating Network Config: ', error.response.data);
       throw new Error(
-        error.response.data?.message || 'Error updating Network Config.'
+        getApiErrorMessage(error, 'Error updating Network Config.')
       );
     } else {
       console.error(
@@ -107,22 +209,29 @@ export async function listAvailableWiFi(): Promise<WiFiNetwork[]> {
 }
 
 // Wrapper for connectToWiFi
-export async function connectToWiFi(config: WiFiCredentials): Promise<void> {
+export async function connectToWiFi(
+  config: WifiConnectCredentials
+): Promise<WifiConnectResult> {
   try {
-    const response = await api.connectToWiFi(config);
+    const response = await api.connectToWiFi(config as WiFiCredentials);
     const data = response.data;
     if (data && 'error' in data) {
       throw new Error((data as APIError).error);
     }
+    return data as unknown as WifiConnectResult;
   } catch (error) {
     if (error.response) {
       console.error('Error connecting to Wi-Fi: ', error.response.data);
-      throw new Error(
-        error.response.data?.message || 'Error connecting to Wi-Fi.'
+      throw new WiFiConnectionError(
+        getApiErrorMessage(error, 'Error connecting to Wi-Fi.'),
+        getApiErrorCode(error)
       );
     } else {
       console.error('Network error while connecting to Wi-Fi: ', error.message);
-      throw new Error('Network error while connecting to Wi-Fi.');
+      throw new WiFiConnectionError(
+        getApiErrorMessage(error, 'Network error while connecting to Wi-Fi.'),
+        getApiErrorCode(error)
+      );
     }
   }
 }

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -1,9 +1,14 @@
 import './loadingScreen.css';
 
-export function LoadingScreen() {
+type LoadingScreenProps = {
+  message?: string;
+};
+
+export function LoadingScreen({ message }: LoadingScreenProps) {
   return (
     <div className="loading-center">
       <div className="loader" />
+      {message ? <div className="loading-message">{message}</div> : null}
     </div>
   );
 }

--- a/src/components/LoadingScreen/loadingScreen.css
+++ b/src/components/LoadingScreen/loadingScreen.css
@@ -1,7 +1,14 @@
 .loading-center {
   position: fixed;
-  top: calc(50% - 40px);
-  left: calc(50% - 40px);
+  top: 50%;
+  left: 50%;
+  display: flex;
+  width: 170px;
+  transform: translate(-50%, -50%);
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
 }
 
 .loader {
@@ -11,6 +18,16 @@
   width: 80px;
   height: 80px;
   animation: spin 1s linear infinite;
+}
+
+.loading-message {
+  max-width: 150px;
+  color: #f5c444;
+  font-family: 'ABC Diatype Mono';
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 @keyframes spin {

--- a/src/components/LoadingScreen/loadingScreen.css
+++ b/src/components/LoadingScreen/loadingScreen.css
@@ -1,17 +1,12 @@
 .loading-center {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  display: flex;
-  width: 170px;
-  transform: translate(-50%, -50%);
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
-  text-align: center;
+  inset: 0;
 }
 
 .loader {
+  position: absolute;
+  top: calc(50% - 40px);
+  left: calc(50% - 40px);
   border: 5px solid #f3f3f3;
   border-top: 5px solid #f5c444;
   border-radius: 50%;
@@ -21,12 +16,17 @@
 }
 
 .loading-message {
-  max-width: 150px;
-  color: #f5c444;
+  position: absolute;
+  top: calc(50% + 68px);
+  left: 50%;
+  width: 170px;
+  transform: translateX(-50%);
+  color: #fff;
   font-family: 'ABC Diatype Mono';
   font-size: 14px;
   font-weight: 700;
   line-height: 1.2;
+  text-align: center;
   text-transform: uppercase;
 }
 

--- a/src/components/Wifi/DeleteWifiMenu.tsx
+++ b/src/components/Wifi/DeleteWifiMenu.tsx
@@ -43,7 +43,12 @@ export const DeleteWifiMenu = (): JSX.Element => {
       switch (items[activeIndex].key) {
         case 'connect': {
           dispatch(setBubbleDisplay({ visible: false, component: undefined }));
-          dispatch(selectWifi(selectedWifiToDelete));
+          dispatch(
+            selectWifi({
+              ssid: selectedWifiToDelete,
+              useKnownCredentials: true
+            })
+          );
           dispatch(setScreen('enterWifiPassword'));
           break;
         }
@@ -91,14 +96,13 @@ export const DeleteWifiMenu = (): JSX.Element => {
   if (deleteKnownWifiMutation.isError) {
     return (
       <div className="main-container response">
-        <div className={`connect-response error-entry`}>
+        <div className="connect-response-title error-entry">
           An error occured. Please try again
         </div>
-        <div className={`connect-response error-entry`}>
+        <div className="connect-response-message error-entry">
           {deleteKnownWifiMutation.failureReason?.message}
         </div>
-        <br />
-        <div key="back" className={`settings-item active-setting connect-item`}>
+        <div key="back" className="settings-item active-setting connect-item">
           <div className="settings-entry connect-button">Ok</div>
         </div>
       </div>

--- a/src/components/Wifi/EnterWifiPassword.tsx
+++ b/src/components/Wifi/EnterWifiPassword.tsx
@@ -7,11 +7,17 @@ import {
 } from '../store/features/screens/screens-slice';
 import { useAppSelector } from '../store/hooks';
 import { AppDispatch } from '../store/store';
-import { useConnectToWiFi, useNetworkConfig } from '../../hooks/useWifi';
-import { useEffect, useMemo, useState } from 'react';
+import { useConnectToWiFi } from '../../hooks/useWifi';
+import { useEffect, useRef, useState } from 'react';
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { useDimScreen } from '../../hooks/useDimScreen';
+import {
+  getWifiHealthMessage,
+  getWifiHealthStatusLabel
+} from './wifiHealthMessages';
+import { selectWifi } from '../store/features/wifi/wifi-slice';
+import { WiFiConnectionError } from '../../api/wifi';
 
 import './wifiResult.css';
 
@@ -22,47 +28,61 @@ export function EnterWifiPassword(): JSX.Element {
   const [knownPassword, setKnownPassword] = useState<string | undefined>(
     undefined
   );
+  const knownConnectionSubmitted = useRef(false);
 
   const screen = useAppSelector(
     (state) => state.screen,
     (prev, next) => prev === next
   );
 
-  const { data, isLoading } = useNetworkConfig();
   const connectToWifiMutation = useConnectToWiFi();
+  const connectionError = connectToWifiMutation.error as
+    | WiFiConnectionError
+    | undefined;
+  const isInvalidCredentials =
+    connectToWifiMutation.isError &&
+    connectionError?.code === 'invalid_credentials';
+
   useDimScreen();
   useHandleGestures({
     pressDown() {
       if (connectToWifiMutation.isSuccess || connectToWifiMutation.isError) {
+        if (isInvalidCredentials) {
+          connectToWifiMutation.reset();
+          if (wifi.selectedWifi) {
+            dispatch(
+              selectWifi({
+                ssid: wifi.selectedWifi,
+                useKnownCredentials: false
+              })
+            );
+          }
+          return;
+        }
         dispatch(setScreen('profileHome'));
       }
     }
   });
 
-  const knownWifis = useMemo(() => {
-    if (!data?.known_wifis) {
-      return [];
+  useEffect(() => {
+    knownConnectionSubmitted.current = false;
+  }, [wifi.selectedWifi, wifi.selectedWifiUseKnownCredentials]);
+
+  useEffect(() => {
+    if (
+      !wifi.selectedWifiUseKnownCredentials ||
+      !wifi.selectedWifi ||
+      knownConnectionSubmitted.current
+    ) {
+      return;
     }
 
-    return Object.keys(data?.known_wifis).map((key: string) => {
-      const entry = data.known_wifis[key];
-      if (typeof entry === 'string') {
-        return { password: entry, ssid: key };
-      }
-      return entry;
-    }) as { password: string; ssid: string }[];
-  }, [data]);
-
-  useEffect(
-    () =>
-      setKnownPassword(
-        knownWifis.find((knownWifi) => knownWifi.ssid === wifi.selectedWifi)
-          ?.password
-      ),
-    [knownWifis]
-  );
+    knownConnectionSubmitted.current = true;
+    connectToWifiMutation.mutate({ type: 'PSK', ssid: wifi.selectedWifi });
+  }, [wifi.selectedWifi, wifi.selectedWifiUseKnownCredentials]);
 
   const updateSetting = (password: string) => {
+    setKnownPassword(password);
     console.log(
       'Log ~ EnterWifiPassword ~ ssid',
       wifi.selectedWifi,
@@ -86,27 +106,48 @@ export function EnterWifiPassword(): JSX.Element {
     );
   };
 
-  if ((!data && isLoading) || connectToWifiMutation.isPending) {
+  if (
+    connectToWifiMutation.isPending ||
+    (wifi.selectedWifiUseKnownCredentials &&
+      !connectToWifiMutation.isError &&
+      !connectToWifiMutation.isSuccess)
+  ) {
     return <LoadingScreen />;
   }
 
   if (connectToWifiMutation.isError || connectToWifiMutation.isSuccess) {
+    const connectHealth = connectToWifiMutation.data?.health;
+    const hasConnectionWarning = Boolean(connectHealth?.degraded);
+
     return (
       <div className="main-container response">
         {connectToWifiMutation.isError && (
           <>
-            <div className={`connect-response error-entry`}>
-              An error occured. Please try again
+            <div className="connect-response-title error-entry">
+              {isInvalidCredentials
+                ? 'Incorrect password'
+                : 'Could not connect to WiFi'}
             </div>
-            <div className={`connect-response error-entry`}>
+            <div className="connect-response-message error-entry">
               {connectToWifiMutation.failureReason?.message}
             </div>
           </>
         )}
         {connectToWifiMutation.isSuccess && (
-          <div className={`connect-response `}>Successfully Connected</div>
+          <>
+            <div className="connect-response-title">Connected</div>
+            {hasConnectionWarning && (
+              <>
+                <div className="connect-response-status">
+                  {getWifiHealthStatusLabel(connectHealth, true)}
+                </div>
+                <div className="connect-response-message">
+                  {getWifiHealthMessage(connectHealth)}
+                </div>
+              </>
+            )}
+          </>
         )}
-        <br />
         <div key="back" className={`settings-item active-setting connect-item`}>
           <div className="settings-entry connect-button">Ok</div>
         </div>

--- a/src/components/Wifi/SelectWifi.tsx
+++ b/src/components/Wifi/SelectWifi.tsx
@@ -10,7 +10,7 @@ import {
   setBubbleDisplay,
   setScreen
 } from '../store/features/screens/screens-slice';
-import { useAvailableWiFiList } from '../../hooks/useWifi';
+import { useAvailableWiFiList, useNetworkConfig } from '../../hooks/useWifi';
 
 import Styled, {
   VIEWPORT_HEIGHT,
@@ -22,7 +22,8 @@ export const SelectWifi = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const { data, isLoading } = useAvailableWiFiList();
+  const { data, isFetching, isLoading } = useAvailableWiFiList();
+  const { data: networkConfig } = useNetworkConfig({ idle: true });
 
   const wifiList = useMemo(() => {
     if (!data) return [];
@@ -47,8 +48,12 @@ export const SelectWifi = (): JSX.Element => {
           setBubbleDisplay({ visible: true, component: 'wifiSettings' })
         );
       } else {
+        const ssid = wifiList[activeIndex].key;
+        const useKnownCredentials = Boolean(
+          networkConfig?.known_wifis && ssid in networkConfig.known_wifis
+        );
         dispatch(setBubbleDisplay({ visible: false, component: undefined }));
-        dispatch(selectWifi(wifiList[activeIndex].key));
+        dispatch(selectWifi({ ssid, useKnownCredentials }));
         dispatch(setScreen('enterWifiPassword'));
       }
     }
@@ -73,7 +78,7 @@ export const SelectWifi = (): JSX.Element => {
     [activeIndex, wifiList]
   );
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return <LoadingScreen />;
   }
 

--- a/src/components/Wifi/WifiDetails.tsx
+++ b/src/components/Wifi/WifiDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
@@ -37,18 +37,11 @@ import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosit
 export const WifiDetails = (): JSX.Element => {
   const [activeIndex, setActiveIndex] = useState(0);
   const dispatch = useAppDispatch();
-  const { data, isLoading, isSuccess, refetch } = useNetworkConfig();
+  const { data, isLoading, isSuccess } = useNetworkConfig();
   const wifiStatus = data?.status;
   const networkConfig = data?.config;
   const wifiHealth = data?.health;
   const isHotspotActive = wifiHealth?.mode === 'AP' && wifiHealth?.ap_active;
-
-  useEffect(() => {
-    const refetchInterval = setInterval(() => {
-      refetch();
-    }, 500);
-    return () => clearInterval(refetchInterval);
-  }, []);
 
   const wifiItems = useMemo(() => {
     if (!isSuccess || !data) return initialWifiItems;

--- a/src/components/Wifi/WifiDetails.tsx
+++ b/src/components/Wifi/WifiDetails.tsx
@@ -6,6 +6,11 @@ import { useAppDispatch } from '../store/hooks';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import './wifiDetails.css';
 import { useNetworkConfig } from '../../hooks/useWifi';
+import {
+  getWifiHealthMessage,
+  getWifiHealthStatusLabel,
+  getWifiRecoveryMessage
+} from './wifiHealthMessages';
 
 const initialWifiItems = [
   { key: 'network', label: 'NETWORK' },
@@ -14,6 +19,12 @@ const initialWifiItems = [
   { key: 'ap_password', label: 'AP PASSWORD' },
   { key: 'ips', label: 'IP' },
   { key: 'mac', label: 'MAC' },
+  { key: 'health', label: 'HEALTH' },
+  { key: 'gateway', label: 'GATEWAY' },
+  { key: 'dns', label: 'DNS' },
+  { key: 'internet', label: 'INTERNET' },
+  { key: 'last_error', label: 'LAST ERROR' },
+  { key: 'recovery', label: 'RECOVERY' },
   { key: 'back', label: 'Back' }
 ];
 
@@ -29,6 +40,7 @@ export const WifiDetails = (): JSX.Element => {
   const { data, isLoading, isSuccess, refetch } = useNetworkConfig();
   const wifiStatus = data?.status;
   const networkConfig = data?.config;
+  const wifiHealth = data?.health;
 
   useEffect(() => {
     const refetchInterval = setInterval(() => {
@@ -46,7 +58,21 @@ export const WifiDetails = (): JSX.Element => {
       ap_name: networkConfig?.apName || '',
       ap_password: networkConfig?.apPassword || '',
       ips: wifiStatus?.ips?.[0] || '',
-      mac: wifiStatus?.mac || ''
+      mac: wifiStatus?.mac || '',
+      health: getWifiHealthStatusLabel(wifiHealth, wifiStatus?.connected),
+      gateway: wifiHealth
+        ? wifiHealth.gateway_reachable
+          ? 'OK'
+          : 'FAILED'
+        : '',
+      dns: wifiHealth ? (wifiHealth.dns_resolves ? 'OK' : 'FAILED') : '',
+      internet: wifiHealth
+        ? wifiHealth.internet_reachable
+          ? 'OK'
+          : 'FAILED'
+        : '',
+      last_error: getWifiHealthMessage(wifiHealth),
+      recovery: getWifiRecoveryMessage(wifiHealth)
     };
 
     return initialWifiItems.map((item) =>
@@ -57,7 +83,7 @@ export const WifiDetails = (): JSX.Element => {
             label: `${item.label}: ${valuesMap[item.key] || ''}`
           }
     );
-  }, [wifiStatus, networkConfig, isSuccess]);
+  }, [wifiStatus, networkConfig, wifiHealth, isSuccess]);
 
   useHandleGestures({
     left() {

--- a/src/components/Wifi/WifiDetails.tsx
+++ b/src/components/Wifi/WifiDetails.tsx
@@ -41,6 +41,7 @@ export const WifiDetails = (): JSX.Element => {
   const wifiStatus = data?.status;
   const networkConfig = data?.config;
   const wifiHealth = data?.health;
+  const isHotspotActive = wifiHealth?.mode === 'AP' && wifiHealth?.ap_active;
 
   useEffect(() => {
     const refetchInterval = setInterval(() => {
@@ -60,17 +61,27 @@ export const WifiDetails = (): JSX.Element => {
       ips: wifiStatus?.ips?.[0] || '',
       mac: wifiStatus?.mac || '',
       health: getWifiHealthStatusLabel(wifiHealth, wifiStatus?.connected),
-      gateway: wifiHealth
-        ? wifiHealth.gateway_reachable
-          ? 'OK'
-          : 'FAILED'
-        : '',
-      dns: wifiHealth ? (wifiHealth.dns_resolves ? 'OK' : 'FAILED') : '',
-      internet: wifiHealth
-        ? wifiHealth.internet_reachable
-          ? 'OK'
-          : 'FAILED'
-        : '',
+      gateway: isHotspotActive
+        ? 'N/A'
+        : wifiHealth
+          ? wifiHealth.gateway_reachable
+            ? 'OK'
+            : 'FAILED'
+          : '',
+      dns: isHotspotActive
+        ? 'N/A'
+        : wifiHealth
+          ? wifiHealth.dns_resolves
+            ? 'OK'
+            : 'FAILED'
+          : '',
+      internet: isHotspotActive
+        ? 'N/A'
+        : wifiHealth
+          ? wifiHealth.internet_reachable
+            ? 'OK'
+            : 'FAILED'
+          : '',
       last_error: getWifiHealthMessage(wifiHealth),
       recovery: getWifiRecoveryMessage(wifiHealth)
     };
@@ -83,7 +94,7 @@ export const WifiDetails = (): JSX.Element => {
             label: `${item.label}: ${valuesMap[item.key] || ''}`
           }
     );
-  }, [wifiStatus, networkConfig, wifiHealth, isSuccess]);
+  }, [wifiStatus, networkConfig, wifiHealth, isHotspotActive, isSuccess]);
 
   useHandleGestures({
     left() {

--- a/src/components/Wifi/WifiSettings.tsx
+++ b/src/components/Wifi/WifiSettings.tsx
@@ -24,6 +24,7 @@ export const WifiSettings = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const queryClient = useQueryClient();
   const [activeIndex, setActiveIndex] = useState(0);
+  const [loadingMessageIndex, setLoadingMessageIndex] = useState(0);
   const [networkConfigMode, setNetworkConfigMode] = useState<APMode>(
     APMode.CLIENT
   );
@@ -51,6 +52,53 @@ export const WifiSettings = (): JSX.Element => {
 
   const isApMode = networkConfigMode === APMode.AP;
   const healthLabel = getWifiHealthStatusLabel(wifiHealth, isWifiConnected);
+  const loadingState = isLoading
+    ? 'loading'
+    : updateNetworkConfigMutation.isPending
+      ? `update-${networkConfigMode}`
+      : repairWiFiMutation.isPending
+        ? 'repair'
+        : 'idle';
+  const loadingMessages = useMemo(() => {
+    if (loadingState === 'loading') {
+      return ['Loading WiFi settings'];
+    }
+
+    if (loadingState === `update-${APMode.AP}`) {
+      return [
+        'Starting hotspot',
+        'Trying WiFi channels',
+        'Checking hotspot',
+        'Keeping current WiFi safe'
+      ];
+    }
+
+    if (loadingState === `update-${APMode.CLIENT}`) {
+      return ['Joining WiFi mode', 'Checking connection', 'Updating WiFi'];
+    }
+
+    if (loadingState === 'repair') {
+      return ['Checking WiFi', 'Trying recovery', 'Verifying connection'];
+    }
+
+    return [];
+  }, [loadingState]);
+
+  useEffect(() => {
+    setLoadingMessageIndex(0);
+
+    if (loadingMessages.length <= 1) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setLoadingMessageIndex(
+        (current) => (current + 1) % loadingMessages.length
+      );
+    }, 7000);
+
+    return () => clearInterval(interval);
+  }, [loadingMessages]);
 
   const wifiSettingItems = useMemo(
     () => [
@@ -215,7 +263,7 @@ export const WifiSettings = (): JSX.Element => {
     updateNetworkConfigMutation.isPending ||
     repairWiFiMutation.isPending
   ) {
-    return <LoadingScreen />;
+    return <LoadingScreen message={loadingMessages[loadingMessageIndex]} />;
   }
 
   if (

--- a/src/components/Wifi/WifiSettings.tsx
+++ b/src/components/Wifi/WifiSettings.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import './wifiSettings.css';
 import { useAppDispatch } from '../store/hooks';
 
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
-import { useNetworkConfig, useUpdateNetworkConfig } from '../../hooks/useWifi';
+import {
+  useNetworkConfig,
+  useRepairWiFi,
+  useUpdateNetworkConfig
+} from '../../hooks/useWifi';
 import { APMode } from '@meticulous-home/espresso-api';
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
 import Styled, {
@@ -13,9 +18,11 @@ import Styled, {
   MARQUEE_MIN_TEXT_LENGTH
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
+import { getWifiHealthStatusLabel } from './wifiHealthMessages';
 
 export const WifiSettings = (): JSX.Element => {
   const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
   const [activeIndex, setActiveIndex] = useState(0);
   const [networkConfigMode, setNetworkConfigMode] = useState<APMode>(
     APMode.CLIENT
@@ -23,6 +30,7 @@ export const WifiSettings = (): JSX.Element => {
 
   const { data: networkConfig, error, isLoading, refetch } = useNetworkConfig();
   const updateNetworkConfigMutation = useUpdateNetworkConfig();
+  const repairWiFiMutation = useRepairWiFi(queryClient);
 
   useEffect(() => {
     const refetchInterval = setInterval(() => {
@@ -39,14 +47,16 @@ export const WifiSettings = (): JSX.Element => {
   }, [networkConfig]);
 
   const isWifiConnected = networkConfig?.status.connected;
+  const wifiHealth = networkConfig?.health;
 
-  const isApMode = isWifiConnected && networkConfigMode === APMode.AP;
+  const isApMode = networkConfigMode === APMode.AP;
+  const healthLabel = getWifiHealthStatusLabel(wifiHealth, isWifiConnected);
 
   const wifiSettingItems = useMemo(
     () => [
       {
         key: 'status',
-        label: `Status: ${isWifiConnected ? 'CONNECTED' : 'NOT CONNECTED'}`,
+        label: `Status: ${healthLabel}`,
         visible: true
       },
       {
@@ -75,6 +85,11 @@ export const WifiSettings = (): JSX.Element => {
         visible: true
       },
       {
+        key: 'repair',
+        label: 'Repair WiFi',
+        visible: true
+      },
+      {
         key: 'save',
         label: 'Save',
         visible: networkConfigMode !== networkConfig?.config.mode
@@ -85,7 +100,7 @@ export const WifiSettings = (): JSX.Element => {
         visible: true
       }
     ],
-    [isWifiConnected, isApMode, networkConfigMode]
+    [healthLabel, isWifiConnected, isApMode, networkConfigMode]
   );
 
   useHandleGestures(
@@ -103,7 +118,11 @@ export const WifiSettings = (): JSX.Element => {
       },
       pressDown() {
         // In case of error we go back
-        if (updateNetworkConfigMutation.isError || error) {
+        if (
+          updateNetworkConfigMutation.isError ||
+          repairWiFiMutation.isError ||
+          error
+        ) {
           dispatch(
             setBubbleDisplay({ visible: true, component: 'quick-settings' })
           );
@@ -156,12 +175,21 @@ export const WifiSettings = (): JSX.Element => {
             );
             break;
           }
+          case 'repair': {
+            repairWiFiMutation.mutate(undefined, {
+              onSuccess: () => {
+                refetch();
+              }
+            });
+            setActiveIndex(0);
+            break;
+          }
           default:
             break;
         }
       }
     },
-    updateNetworkConfigMutation.isPending
+    updateNetworkConfigMutation.isPending || repairWiFiMutation.isPending
   );
   const optionPositionOutter = useMemo(
     () =>
@@ -182,25 +210,36 @@ export const WifiSettings = (): JSX.Element => {
     [activeIndex, wifiSettingItems]
   );
 
-  if (isLoading || updateNetworkConfigMutation.isPending) {
+  if (
+    isLoading ||
+    updateNetworkConfigMutation.isPending ||
+    repairWiFiMutation.isPending
+  ) {
     return <LoadingScreen />;
   }
 
-  if (updateNetworkConfigMutation.isError || error) {
+  if (
+    updateNetworkConfigMutation.isError ||
+    repairWiFiMutation.isError ||
+    error
+  ) {
+    const title = repairWiFiMutation.isError
+      ? 'Network issue'
+      : 'Could not update WiFi';
+    const message = updateNetworkConfigMutation.isError
+      ? updateNetworkConfigMutation.error?.message ||
+        'Could not update WiFi. Please try again.'
+      : repairWiFiMutation.isError
+        ? repairWiFiMutation.error?.message ||
+          'WiFi repair could not complete. Please check the network.'
+        : 'Connection could not be verified. Please check the connection details.';
+
     return (
-      <div className="quick-settings">
-        <div
-          className={` deleted-response ${
-            updateNetworkConfigMutation.isError ? 'error-entry' : ''
-          }`}
-        >
-          {updateNetworkConfigMutation.isError
-            ? 'An unknown error occured. Please try again'
-            : 'Connection could not be verified, please check the connection details'}
-        </div>
-        <br />
-        <div key="back" className={`settings-item active-setting deleted-item`}>
-          <div className="settings-entry deleted-button">Ok</div>
+      <div className="main-container response">
+        <div className="connect-response-title error-entry">{title}</div>
+        <div className="connect-response-message error-entry">{message}</div>
+        <div key="back" className="settings-item active-setting connect-item">
+          <div className="settings-entry connect-button">Ok</div>
         </div>
       </div>
     );

--- a/src/components/Wifi/WifiSettings.tsx
+++ b/src/components/Wifi/WifiSettings.tsx
@@ -34,13 +34,6 @@ export const WifiSettings = (): JSX.Element => {
   const repairWiFiMutation = useRepairWiFi(queryClient);
 
   useEffect(() => {
-    const refetchInterval = setInterval(() => {
-      refetch();
-    }, 500);
-    return () => clearInterval(refetchInterval);
-  }, [updateNetworkConfigMutation.status]);
-
-  useEffect(() => {
     if (!networkConfig?.config.mode) {
       return;
     }

--- a/src/components/Wifi/wifiHealthMessages.ts
+++ b/src/components/Wifi/wifiHealthMessages.ts
@@ -5,6 +5,13 @@ export function getWifiHealthMessage(health?: WifiHealthStatus): string {
     return '';
   }
 
+  if (health.mode === 'AP' && health.ap_active) {
+    return (
+      health.message ||
+      "Hotspot active. Connect your phone or computer to the machine's Wi-Fi network."
+    );
+  }
+
   if (!health.degraded) {
     return 'HEALTHY';
   }
@@ -43,6 +50,10 @@ export function getWifiHealthStatusLabel(
 
   if (!health) {
     return 'UNKNOWN';
+  }
+
+  if (health.mode === 'AP' && health.ap_active) {
+    return 'HOTSPOT ACTIVE';
   }
 
   if (!health.degraded) {

--- a/src/components/Wifi/wifiHealthMessages.ts
+++ b/src/components/Wifi/wifiHealthMessages.ts
@@ -1,0 +1,91 @@
+import { WifiHealthStatus } from '../../api/wifi';
+
+export function getWifiHealthMessage(health?: WifiHealthStatus): string {
+  if (!health) {
+    return '';
+  }
+
+  if (!health.degraded) {
+    return 'HEALTHY';
+  }
+
+  if (health.message) {
+    return health.message;
+  }
+
+  switch (health.last_error) {
+    case 'internet_unreachable':
+      return 'Connected to Wi-Fi, but this network does not appear to have internet access. Check the router or phone hotspot data connection.';
+    case 'dns_unreachable':
+      return 'Connected to Wi-Fi, but DNS is not working. Check the router internet or DNS settings.';
+    case 'gateway_unreachable':
+      return 'Connected to Wi-Fi, but the router is not responding. Move closer or restart the router.';
+    case 'missing_ipv4':
+      return 'Connected to Wi-Fi, but the router did not assign an IP address. Check DHCP settings on the router.';
+    case 'wifi_device_unavailable':
+      return 'Wi-Fi is still starting. Wait a moment and try again.';
+    case 'wifi_not_connected':
+      return 'The machine is not connected to Wi-Fi.';
+    case 'hotspot_not_active':
+      return 'The machine could not start its Wi-Fi hotspot. Please try again.';
+    default:
+      return 'Wi-Fi could not be verified. Please check the network and try again.';
+  }
+}
+
+export function getWifiHealthStatusLabel(
+  health?: WifiHealthStatus,
+  connected = true
+): string {
+  if (!connected) {
+    return 'NOT CONNECTED';
+  }
+
+  if (!health) {
+    return 'UNKNOWN';
+  }
+
+  if (!health.degraded) {
+    return 'CONNECTED';
+  }
+
+  switch (health.last_error) {
+    case 'internet_unreachable':
+      return 'NO INTERNET';
+    case 'dns_unreachable':
+      return 'DNS ISSUE';
+    case 'gateway_unreachable':
+      return 'ROUTER ISSUE';
+    case 'missing_ipv4':
+      return 'NO IP ADDRESS';
+    case 'wifi_device_unavailable':
+      return 'WIFI STARTING';
+    case 'wifi_not_connected':
+      return 'NOT CONNECTED';
+    case 'hotspot_not_active':
+      return 'HOTSPOT ISSUE';
+    default:
+      return 'CHECK NETWORK';
+  }
+}
+
+export function getWifiRecoveryMessage(health?: WifiHealthStatus): string {
+  if (!health?.last_recovery_result) {
+    return '';
+  }
+
+  switch (health.last_recovery_result) {
+    case 'not_needed':
+      return 'No repair needed';
+    case 'not_recoverable':
+      return 'Network/router issue';
+    case 'recovered':
+      return 'Repaired';
+    case 'failed':
+      return 'Repair failed';
+    case 'in_progress':
+      return 'Repairing';
+    default:
+      return health.last_recovery_result;
+  }
+}

--- a/src/components/Wifi/wifiResult.css
+++ b/src/components/Wifi/wifiResult.css
@@ -1,31 +1,58 @@
 .response {
-  margin-left: 80px;
   display: flex;
   flex-direction: column;
-  width: auto !important;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 340px !important;
+  min-height: 330px;
+  margin: 0 auto;
+  padding: 42px 48px 34px;
+  text-align: center;
 }
 
-.connect-response {
-  text-transform: uppercase;
-  font-size: 22px;
-  color: #dddddd;
-  text-align: left;
-  width: 100%;
-  justify-content: start;
-  font-weight: 400;
+.connect-response-title,
+.connect-response-status,
+.connect-response-message {
   font-family: 'ABC Diatype Mono';
-  height: fit-content;
-  margin-top: 100px;
+  font-weight: 400;
+  width: 100%;
+}
+
+.connect-response-title {
+  text-transform: uppercase;
+  font-size: 34px;
+  line-height: 1;
+  color: #dddddd;
+}
+
+.connect-response-status {
+  margin-top: 10px;
+  color: #f7df39;
+  font-size: 24px;
+  line-height: 1.08;
+  text-transform: uppercase;
+}
+
+.connect-response-message {
+  margin-top: 12px;
+  color: #dddddd;
+  font-size: 16px;
+  line-height: 1.18;
 }
 
 .connect-item {
   display: flex;
-  margin-top: 4px;
-  justify-content: space-between;
-  height: 30px;
+  align-items: center;
+  justify-content: center;
+  width: 120px !important;
+  height: 34px;
+  margin-top: 22px;
+  padding-left: 0;
 }
 
 .connect-button {
+  justify-content: center;
   font-size: 22px;
   text-transform: uppercase;
 }

--- a/src/components/store/features/wifi/wifi-slice.ts
+++ b/src/components/store/features/wifi/wifi-slice.ts
@@ -2,20 +2,41 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface WifiState {
   selectedWifi?: string;
+  selectedWifiUseKnownCredentials?: boolean;
   selectedWifiToDelete?: string;
 }
 
 const initialState: WifiState = {
   selectedWifi: undefined,
+  selectedWifiUseKnownCredentials: false,
   selectedWifiToDelete: undefined
 };
+
+type SelectWifiPayload =
+  | string
+  | {
+      ssid: string;
+      useKnownCredentials?: boolean;
+    };
 
 const wifiSlice = createSlice({
   name: 'wifi',
   initialState,
   reducers: {
-    selectWifi: (state: WifiState, action: PayloadAction<string>) => {
-      state.selectedWifi = action.payload;
+    selectWifi: (
+      state: WifiState,
+      action: PayloadAction<SelectWifiPayload>
+    ) => {
+      if (typeof action.payload === 'string') {
+        state.selectedWifi = action.payload;
+        state.selectedWifiUseKnownCredentials = false;
+        return;
+      }
+
+      state.selectedWifi = action.payload.ssid;
+      state.selectedWifiUseKnownCredentials = Boolean(
+        action.payload.useKnownCredentials
+      );
     },
     selectWifiToDelete: (state: WifiState, action: PayloadAction<string>) => {
       state.selectedWifiToDelete = action.payload;

--- a/src/hooks/useWifi.tsx
+++ b/src/hooks/useWifi.tsx
@@ -19,7 +19,7 @@ import {
 export const LIST_WIFI_QUERY_KEY = 'availableWifiList';
 export const NETWORK_CONFIG_QUERY_KEY = 'networkConfig';
 
-const DEFAULT_NETWORK_REFETCH_INTERVAL = 2000;
+const DEFAULT_NETWORK_REFETCH_INTERVAL = 5000;
 const IDLE_NETWORK_REFETCH_INTERVAL = 60000;
 
 // Hook to fetch network config

--- a/src/hooks/useWifi.tsx
+++ b/src/hooks/useWifi.tsx
@@ -1,11 +1,18 @@
-import { QueryClient, useMutation, useQuery } from '@tanstack/react-query';
+import {
+  QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query';
 
-import { WiFiConfig, WiFiCredentials } from '@meticulous-home/espresso-api';
+import { WiFiConfig } from '@meticulous-home/espresso-api';
 import {
   connectToWiFi,
   deleteKnownWifi,
   getWifiStatus,
   listAvailableWiFi,
+  repairWifi,
+  WifiConnectCredentials,
   updateNetworkConfig
 } from '../api/wifi';
 
@@ -40,14 +47,27 @@ export const useUpdateNetworkConfig = () => {
   });
 };
 
+export const useRepairWiFi = (queryClient?: QueryClient) => {
+  return useMutation({
+    mutationFn: repairWifi,
+    onError: (error) => {
+      console.error('Error repairing Wi-Fi:', error);
+    },
+    onSuccess: () => {
+      console.log('Wi-Fi repair completed successfully.');
+      queryClient?.invalidateQueries({ queryKey: [NETWORK_CONFIG_QUERY_KEY] });
+    }
+  });
+};
+
 // Hook to fetch available Wi-Fi list
 export const useAvailableWiFiList = () => {
   return useQuery({
     queryKey: [LIST_WIFI_QUERY_KEY],
     queryFn: listAvailableWiFi,
-    staleTime: Infinity,
+    staleTime: 0,
     refetchInterval: false,
-    refetchOnMount: false,
+    refetchOnMount: 'always',
     refetchOnReconnect: false,
     refetchOnWindowFocus: false
   });
@@ -55,13 +75,17 @@ export const useAvailableWiFiList = () => {
 
 // Hook to connect to Wi-Fi
 export const useConnectToWiFi = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    mutationFn: (data: WiFiCredentials) => connectToWiFi(data),
+    mutationFn: (data: WifiConnectCredentials) => connectToWiFi(data),
     onError: (error) => {
       console.error('Error connecting to Wi-Fi:', error);
     },
     onSuccess: () => {
       console.log('Connected to Wi-Fi successfully.');
+      queryClient.invalidateQueries({ queryKey: [NETWORK_CONFIG_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [LIST_WIFI_QUERY_KEY] });
     }
   });
 };


### PR DESCRIPTION
## Summary
- Improves the dial Wi-Fi screens with clearer health/status labels, diagnostic copy, and loading feedback while Wi-Fi operations are running.
- Handles invalid-password failures by returning users to the password entry flow instead of forcing them to restart the full network selection flow.
- Adds support for known Wi-Fi flows, including connecting without re-entering a password when NetworkManager already has credentials.
- Adjusts circular-screen layouts for Wi-Fi results and loading messages so text remains readable and better positioned on the dial display.

## Validation
- Manually validated Wi-Fi setup flows on the dial UI, including invalid password handling, no-internet messaging, hotspot status, repair feedback, and reboot persistence with the paired backend changes.
