### PR TITLE
Track dial home readiness

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use byte_unit::{Byte, Unit};
+use std::fs;
 use std::process::Command;
 use tauri::AppHandle;
 use tauri::Manager;
@@ -6,16 +7,31 @@ use tauri::Manager;
 mod config;
 mod profiles;
 
+const DIAL_READY_MARKER: &str = "/run/meticulous-dial-ready";
+const DIAL_HOME_READY_MARKER: &str = "/run/meticulous-dial-home-ready";
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn ready(app_handle: AppHandle) {
     println!("React is reporting ready!");
+    let _ = fs::remove_file(DIAL_HOME_READY_MARKER);
+    if let Err(error) = fs::write(DIAL_READY_MARKER, "ready\n") {
+        eprintln!("Failed to write dial ready marker: {}", error);
+    }
     let window = app_handle.get_webview_window("main").unwrap();
     #[cfg(not(debug_assertions))]
     {
         window.set_fullscreen(true).unwrap();
     }
     window.show().unwrap();
+}
+
+#[tauri::command]
+fn home_ready() {
+    println!("React profile home screen is reporting ready!");
+    if let Err(error) = fs::write(DIAL_HOME_READY_MARKER, "ready\n") {
+        eprintln!("Failed to write dial home ready marker: {}", error);
+    }
 }
 
 #[tauri::command]
@@ -114,7 +130,7 @@ pub fn run() {
                 )) // add the terminal (stdout) as log target
                 .build(),
         )
-        .invoke_handler(tauri::generate_handler![ready, get_profiles])
+        .invoke_handler(tauri::generate_handler![ready, home_ready, get_profiles])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -22,6 +22,7 @@ import { useIsOnline } from '../../hooks/useIsOnline';
 import { loadProfileData, startProfile } from '../../api/profile';
 import { DownloadIcon } from './DownloadIcon';
 import { useSocket } from '../store/SocketManager';
+import { invoke } from '@tauri-apps/api/core';
 
 const CARD_GAP = 79;
 const CARD_SIZE = PROFILE_ENTRY_SIZE + CARD_GAP;
@@ -91,6 +92,7 @@ export const ProfileHomeScreen = () => {
     useState<dialDirection>('none');
   const [isPressingDown, setIsPressingDown] = useState(false);
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
+  const homeReadyReported = useRef(false);
 
   const nodeRefs = useRef<Record<string, Ref<HTMLDivElement>>>({});
   const requiresPurge = useRef<boolean>(false);
@@ -149,6 +151,13 @@ export const ProfileHomeScreen = () => {
 
   useEffect(() => {
     if (!mergedProfiles) return;
+
+    if (!homeReadyReported.current && '__TAURI_INTERNALS__' in window) {
+      homeReadyReported.current = true;
+      invoke('home_ready').catch((error) => {
+        console.error('Failed to report profile home ready:', error);
+      });
+    }
 
     if (activeOption > mergedProfiles.length) {
       setActiveOption(mergedProfiles.length);


### PR DESCRIPTION
## Summary
- Add a Tauri `home_ready` command so the dial can report when it reaches the usable profile home screen.
- Keep `/run/meticulous-dial-ready` as the webview/React app mounted signal.
- Add `/run/meticulous-dial-home-ready` as the stronger signal that `ProfileHomeScreen` mounted and has `mergedProfiles` available.

## High-level conditions
- `dial_ready` means React mounted `App` and successfully called the Tauri `ready` command. This proves the dial webview and Tauri command bridge are alive, but it does not prove the profile home screen loaded.
- `dial_home_ready` means the dial reached `ProfileHomeScreen` with profiles resolved. This distinguishes the current pulsing-white-dot failure mode, where the app starts but never reaches the home/profile carousel.
- The home-ready marker is cleared when `ready` runs, so a dial app restart in the same OS boot cannot reuse a stale home-ready marker.

## Related PRs
- Backend smoke state endpoint: https://github.com/MeticulousHome/meticulous-backend/pull/360
- Hawkbit attribute publisher: https://github.com/MeticulousHome/meticulous-machine/pull/78

## Validation
- `cargo check`
- `npm ci`
- `npm run types`
- `git diff --check`
