### PR TITLE
Improve Wi-Fi menu responsiveness

### DIFF
--- a/src/components/Wifi/EnterWifiPassword.tsx
+++ b/src/components/Wifi/EnterWifiPassword.tsx
@@ -42,12 +42,16 @@ export function EnterWifiPassword(): JSX.Element {
   const isInvalidCredentials =
     connectToWifiMutation.isError &&
     connectionError?.code === 'invalid_credentials';
+  const shouldReturnToPassword =
+    connectToWifiMutation.isError &&
+    Boolean(wifi.selectedWifi) &&
+    connectionError?.code !== 'unsupported_security';
 
   useDimScreen();
   useHandleGestures({
     pressDown() {
       if (connectToWifiMutation.isSuccess || connectToWifiMutation.isError) {
-        if (isInvalidCredentials) {
+        if (shouldReturnToPassword) {
           connectToWifiMutation.reset();
           if (wifi.selectedWifi) {
             dispatch(
@@ -118,15 +122,18 @@ export function EnterWifiPassword(): JSX.Element {
   if (connectToWifiMutation.isError || connectToWifiMutation.isSuccess) {
     const connectHealth = connectToWifiMutation.data?.health;
     const hasConnectionWarning = Boolean(connectHealth?.degraded);
+    const errorTitle = isInvalidCredentials
+      ? 'Check password'
+      : connectionError?.code === 'wifi_join_failed'
+        ? 'Check WiFi'
+        : 'Could not connect to WiFi';
 
     return (
       <div className="main-container response">
         {connectToWifiMutation.isError && (
           <>
             <div className="connect-response-title error-entry">
-              {isInvalidCredentials
-                ? 'Incorrect password'
-                : 'Could not connect to WiFi'}
+              {errorTitle}
             </div>
             <div className="connect-response-message error-entry">
               {connectToWifiMutation.failureReason?.message}

--- a/src/components/Wifi/SelectWifi.tsx
+++ b/src/components/Wifi/SelectWifi.tsx
@@ -3,7 +3,6 @@ import './selectWifi.css';
 import { WifiIcon } from './WifiIcon';
 import { useAppDispatch } from '../store/hooks';
 import { selectWifi } from '../store/features/wifi/wifi-slice';
-import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { WiFiNetwork } from '@meticulous-home/espresso-api';
 import {
@@ -18,22 +17,34 @@ import Styled, {
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
 
+type WifiListItem = {
+  key: string;
+  label: string;
+  disabled?: boolean;
+};
+
 export const SelectWifi = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const { data, isFetching, isLoading } = useAvailableWiFiList();
+  const { data, isFetching } = useAvailableWiFiList();
   const { data: networkConfig } = useNetworkConfig({ idle: true });
 
   const wifiList = useMemo(() => {
-    if (!data) return [];
+    const networks = data || [];
 
-    const wifiList = data.map((wifi: WiFiNetwork) => ({
+    const wifiList: WifiListItem[] = networks.map((wifi: WiFiNetwork) => ({
       key: wifi.ssid,
       label: wifi.ssid
     }));
-    return [...wifiList, ...[{ key: 'back', label: 'Back' }]];
-  }, [data, isLoading]);
+    return [
+      ...wifiList,
+      ...(isFetching
+        ? [{ key: 'scanning', label: 'Scanning...', disabled: true }]
+        : []),
+      ...[{ key: 'back', label: 'Back' }]
+    ];
+  }, [data, isFetching]);
 
   useHandleGestures({
     left() {
@@ -43,12 +54,17 @@ export const SelectWifi = (): JSX.Element => {
       setActiveIndex((prev) => Math.min(prev + 1, wifiList.length - 1));
     },
     pressDown() {
-      if (wifiList[activeIndex].key === 'back') {
+      const selectedItem = wifiList[activeIndex];
+      if (!selectedItem || selectedItem.disabled) {
+        return;
+      }
+
+      if (selectedItem.key === 'back') {
         dispatch(
           setBubbleDisplay({ visible: true, component: 'wifiSettings' })
         );
       } else {
-        const ssid = wifiList[activeIndex].key;
+        const ssid = selectedItem.key;
         const useKnownCredentials = Boolean(
           networkConfig?.known_wifis && ssid in networkConfig.known_wifis
         );
@@ -78,16 +94,12 @@ export const SelectWifi = (): JSX.Element => {
     [activeIndex, wifiList]
   );
 
-  if (isLoading || isFetching) {
-    return <LoadingScreen />;
-  }
-
   return (
     <Styled.SettingsContainer>
       <Styled.Viewport>
         <Styled.OptionsContainer $translateY={optionPositionOutter}>
           {wifiList.map((option, index) =>
-            option.key === 'back' ? (
+            option.key === 'back' || option.disabled ? (
               <Styled.Option key={option.key}>
                 <span>{option.label}</span>
               </Styled.Option>
@@ -107,7 +119,7 @@ export const SelectWifi = (): JSX.Element => {
             $isInner={true}
           >
             {wifiList.map((option, index) =>
-              option.key === 'back' ? (
+              option.key === 'back' || option.disabled ? (
                 <Styled.Option key={option.key}>
                   <span>{option.label}</span>
                 </Styled.Option>

--- a/src/components/Wifi/WifiSettings.tsx
+++ b/src/components/Wifi/WifiSettings.tsx
@@ -29,7 +29,13 @@ export const WifiSettings = (): JSX.Element => {
     APMode.CLIENT
   );
 
-  const { data: networkConfig, error, isLoading, refetch } = useNetworkConfig();
+  const {
+    data: networkConfig,
+    dataUpdatedAt,
+    error,
+    isFetching,
+    refetch
+  } = useNetworkConfig();
   const updateNetworkConfigMutation = useUpdateNetworkConfig();
   const repairWiFiMutation = useRepairWiFi(queryClient);
 
@@ -44,19 +50,17 @@ export const WifiSettings = (): JSX.Element => {
   const wifiHealth = networkConfig?.health;
 
   const isApMode = networkConfigMode === APMode.AP;
-  const healthLabel = getWifiHealthStatusLabel(wifiHealth, isWifiConnected);
-  const loadingState = isLoading
-    ? 'loading'
-    : updateNetworkConfigMutation.isPending
-      ? `update-${networkConfigMode}`
-      : repairWiFiMutation.isPending
-        ? 'repair'
-        : 'idle';
+  const hasStaleNetworkConfig =
+    !networkConfig || (isFetching && Date.now() - dataUpdatedAt > 2000);
+  const healthLabel = hasStaleNetworkConfig
+    ? 'Checking...'
+    : getWifiHealthStatusLabel(wifiHealth, isWifiConnected);
+  const loadingState = updateNetworkConfigMutation.isPending
+    ? `update-${networkConfigMode}`
+    : repairWiFiMutation.isPending
+      ? 'repair'
+      : 'idle';
   const loadingMessages = useMemo(() => {
-    if (loadingState === 'loading') {
-      return ['Loading WiFi settings'];
-    }
-
     if (loadingState === `update-${APMode.AP}`) {
       return [
         'Starting hotspot',
@@ -251,11 +255,7 @@ export const WifiSettings = (): JSX.Element => {
     [activeIndex, wifiSettingItems]
   );
 
-  if (
-    isLoading ||
-    updateNetworkConfigMutation.isPending ||
-    repairWiFiMutation.isPending
-  ) {
+  if (updateNetworkConfigMutation.isPending || repairWiFiMutation.isPending) {
     return <LoadingScreen message={loadingMessages[loadingMessageIndex]} />;
   }
 

--- a/src/hooks/useWifi.tsx
+++ b/src/hooks/useWifi.tsx
@@ -21,13 +21,14 @@ export const NETWORK_CONFIG_QUERY_KEY = 'networkConfig';
 
 const DEFAULT_NETWORK_REFETCH_INTERVAL = 5000;
 const IDLE_NETWORK_REFETCH_INTERVAL = 60000;
+const WIFI_LIST_REFETCH_INTERVAL = 5000;
 
 // Hook to fetch network config
 export const useNetworkConfig = (options?: { idle?: boolean }) => {
   return useQuery({
     queryKey: [NETWORK_CONFIG_QUERY_KEY],
     queryFn: getWifiStatus,
-    staleTime: 0,
+    staleTime: 2000,
     refetchInterval: options?.idle
       ? IDLE_NETWORK_REFETCH_INTERVAL
       : DEFAULT_NETWORK_REFETCH_INTERVAL
@@ -38,6 +39,7 @@ export const useNetworkConfig = (options?: { idle?: boolean }) => {
 export const useUpdateNetworkConfig = () => {
   return useMutation({
     mutationFn: (data: Partial<WiFiConfig>) => updateNetworkConfig(data),
+    retry: false,
     onError: (error) => {
       console.error('Error updating Network Config:', error);
     },
@@ -50,6 +52,7 @@ export const useUpdateNetworkConfig = () => {
 export const useRepairWiFi = (queryClient?: QueryClient) => {
   return useMutation({
     mutationFn: repairWifi,
+    retry: false,
     onError: (error) => {
       console.error('Error repairing Wi-Fi:', error);
     },
@@ -65,8 +68,8 @@ export const useAvailableWiFiList = () => {
   return useQuery({
     queryKey: [LIST_WIFI_QUERY_KEY],
     queryFn: listAvailableWiFi,
-    staleTime: 0,
-    refetchInterval: false,
+    staleTime: WIFI_LIST_REFETCH_INTERVAL,
+    refetchInterval: WIFI_LIST_REFETCH_INTERVAL,
     refetchOnMount: 'always',
     refetchOnReconnect: false,
     refetchOnWindowFocus: false
@@ -79,6 +82,7 @@ export const useConnectToWiFi = () => {
 
   return useMutation({
     mutationFn: (data: WifiConnectCredentials) => connectToWiFi(data),
+    retry: false,
     onError: (error) => {
       console.error('Error connecting to Wi-Fi:', error);
     },


### PR DESCRIPTION
## Summary
- Let the Wi-Fi settings menu render immediately instead of showing a loading screen while status refreshes.
- Show cached network status until it is actually stale, reducing the visible flash of old Wi-Fi health labels.
- Let “Connect to a new network” open immediately with cached scan results, while continuing to refresh the list every 5 seconds.
- Add a non-selectable `Scanning...` row instead of blocking the network list behind a spinner.
- Disable automatic React Query retries for Wi-Fi mode updates, repair, and connect operations so a single user action does not repeat the full Wi-Fi workflow unexpectedly.
- Return users to the password screen after ambiguous Wi-Fi join failures so they can retry or correct the password without restarting the flow.

## Validation
- `npx prettier --config .prettierrc --write src/components/Wifi/EnterWifiPassword.tsx src/components/Wifi/SelectWifi.tsx src/components/Wifi/WifiSettings.tsx src/hooks/useWifi.tsx`
- `git diff --check`
- `npm run types` currently fails on existing non-Wi-Fi issues in BugReport/Sentry/API typings (`@sentry/react`, `@oneidentity/zstd-js/decompress`, and missing bug report API exports).
