### PR TITLE
chore(circlekeyboard): better capslock indicator

### DIFF
--- a/src/components/CircleKeyboard/CircleKeyboard.tsx
+++ b/src/components/CircleKeyboard/CircleKeyboard.tsx
@@ -80,6 +80,12 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
   const captionRef = useRef<HTMLDivElement>(null);
   const [caption, setCaption] = useState(defaultValue || []);
 
+  const capsLockIconClass = capsLockActive.keep
+    ? 'caps-locked'
+    : capsLockActive.active
+      ? 'caps-active'
+      : 'caps-inactive';
+
   useEffect(() => {
     setCaption(defaultValue || []);
   }, [defaultValue]);
@@ -177,15 +183,20 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
       },
       doubleClick() {
         if (mainLetter === 'capslock') {
-          if (capsLockActive.active && caption.length === 0) {
-            setCapsLockActive({ ...capsLockActive, keep: true });
-            return;
-          }
-
-          setCapsLockActive({
-            active: !capsLockActive.active,
-            keep: !capsLockActive.keep
-          });
+          setCapsLockActive((currentCapsLockActive) =>
+            currentCapsLockActive.keep
+              ? { active: false, keep: false }
+              : { active: true, keep: true }
+          );
+        }
+      },
+      click() {
+        if (mainLetter === 'capslock') {
+          setCapsLockActive((currentCapsLockActive) =>
+            currentCapsLockActive.active
+              ? { active: false, keep: false }
+              : { active: true, keep: false }
+          );
         }
       },
       pressDown() {
@@ -240,10 +251,6 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
             onCancel();
             return;
           case 'capslock':
-            setCapsLockActive({
-              active: !capsLockActive.active,
-              keep: capsLockActive.keep ? false : capsLockActive.keep
-            });
             return;
           case 'keyboardType':
             if (keyboardType === KEYBOARD_TYPE.Default) {
@@ -398,9 +405,7 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
           <text
             key={index}
             y={-44}
-            className={`letter-space ${
-              capsLockActive.active ? 'caps-active' : 'caps-inactive'
-            }`}
+            className={`letter-space ${capsLockIconClass}`}
           >
             &#xe803;
           </text>
@@ -465,16 +470,18 @@ export function CircleKeyboard(props: IKeyboardProps): JSX.Element {
         );
       case 'capslock':
         return (
-          <div className="main-letter-space icon-capslock-selected">
+          <div
+            className={`main-letter-space icon-capslock-selected ${capsLockIconClass}`}
+          >
             <div className="relative">
               <span
                 className={
-                  'main-letter__label main-letter__label--bottom-20 $main-letter__label-color--white'
+                  'main-letter__label main-letter__label--bottom-20 main-letter__label-color--white'
                 }
               >
                 {capsLockActive.active ? 'capslock' : 'CAPSLOCK'}
               </span>
-              <div className={'main-letter__label-color--white'}>&#xe803;</div>
+              <div>&#xe803;</div>
             </div>
           </div>
         );

--- a/src/components/CircleKeyboard/circle-keyboard.css
+++ b/src/components/CircleKeyboard/circle-keyboard.css
@@ -150,12 +150,40 @@
   top: 30px;
 }
 
-.caps-active {
+.caps-locked {
   fill: #fff;
+  color: #fff;
+}
+
+.caps-active {
+  fill: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.4);
 }
 
 .caps-inactive {
+  fill: transparent;
+  stroke: rgba(255, 255, 255, 0.4);
+  stroke-width: 0.5px;
+  paint-order: stroke fill;
   color: rgba(255, 255, 255, 0.4);
+}
+
+.icon-capslock-selected.caps-inactive .relative > div {
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 2px rgba(255, 255, 255, 0.4);
+}
+
+.icon-capslock-selected.caps-active .relative > div {
+  color: rgba(255, 255, 255, 0.4);
+  -webkit-text-fill-color: rgba(255, 255, 255, 0.4);
+  -webkit-text-stroke: 0;
+}
+
+.icon-capslock-selected.caps-locked .relative > div {
+  color: #fff;
+  -webkit-text-fill-color: #fff;
+  -webkit-text-stroke: 5px #000;
 }
 
 .blink {


### PR DESCRIPTION
## What was done?

Add a third indicator of the capslock to really know if it is just active
or really locking letters to caps

Use a non-filled icon when the caps are inactive
Use the filled muted icon when the caps are active
Use the filled bold icon when the caps are locked

## Why?

Better user interface

## Screenshots

### Caps inactive
<img width="482" height="481" alt="image" src="https://github.com/user-attachments/assets/094e2d79-1c23-456e-be6e-9fd6b4b1286f" />

### Caps active
<img width="482" height="481" alt="image" src="https://github.com/user-attachments/assets/6ac555d2-cf48-4fc5-80fd-fb8610fdfc1d" />


### Caps locked
<img width="482" height="481" alt="image" src="https://github.com/user-attachments/assets/7aba7d12-08dd-468b-a4ff-8501e1469546" />
