### PR TITLE
Remove Fluent Bit setting from Dial

### DIFF
--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -30,12 +30,6 @@ const initialSettings: SettingsItem[] = [
       settings.ssh_enabled ? 'ENABLED' : 'DISABLED'
   },
   {
-    key: 'telemetry_service_enabled',
-    label: 'Telemetry Service',
-    getLabel: (settings: Settings) =>
-      settings.telemetry_service_enabled ? 'ENABLED' : 'DISABLED'
-  },
-  {
     key: 'displayAlignment',
     label: 'Display Alignment Screen',
     visible: true
@@ -160,12 +154,6 @@ export const AdvancedSettings = () => {
           case 'ssh_enabled':
             updateSettings.mutate({
               ssh_enabled: !globalSettings.ssh_enabled
-            });
-            break;
-          case 'telemetry_service_enabled':
-            updateSettings.mutate({
-              telemetry_service_enabled:
-                !globalSettings.telemetry_service_enabled
             });
             break;
           case 'telemetry_opt_in':


### PR DESCRIPTION
## What was done?

- Removed the obsolete `Telemetry Service` item from Advanced Settings.
- Removed the Dial action that posted `telemetry_service_enabled` updates to the backend.

## Why?

Fluent Bit is being retired from the stable machine image because its device-wide journal and node-metrics pipeline is not used and can forward personal information. The companion backend change removes `telemetry_service_enabled`; leaving the Dial control would display a stale setting and submit an update that the backend rejects.

## Additional comments & remarks

Companion PRs:
- https://github.com/MeticulousHome/meticulous-machine/pull/92
- https://github.com/MeticulousHome/meticulous-backend/pull/368

The separate `Share debug motor data` setting is unchanged because it does not control Fluent Bit.

## Full detail of changes made to each function

- `initialSettings`: removed the `telemetry_service_enabled` entry so the option no longer appears.
- `pressDown`: removed the matching switch case so Dial no longer sends that retired setting.

## Validation

- `npm run types`
- `npm run lint`
- `npm run build`
- Confirmed no Fluent Bit or `telemetry_service_enabled` references remain under `src`.
- `git diff --check`
- The repository-wide Prettier check remains red on 133 pre-existing `stable` files, including the edited file before this change; the diff adds no formatting changes.