### PR TITLE
Remove debug shot telemetry setting

### DIFF
--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -35,13 +35,6 @@ const initialSettings: SettingsItem[] = [
     visible: true
   },
   {
-    key: 'telemetry_opt_in',
-    label: 'Share debug motor data',
-    getLabel: (settings: Settings) =>
-      settings.allow_debug_sending ? 'ENABLED' : 'DISABLED',
-    visible: true
-  },
-  {
     key: 'set_update_channel',
     label: 'Update channel',
     getLabel: (settings: Settings) => settings.update_channel,
@@ -154,11 +147,6 @@ export const AdvancedSettings = () => {
           case 'ssh_enabled':
             updateSettings.mutate({
               ssh_enabled: !globalSettings.ssh_enabled
-            });
-            break;
-          case 'telemetry_opt_in':
-            updateSettings.mutate({
-              allow_debug_sending: !globalSettings.allow_debug_sending
             });
             break;
           case 'set_update_channel':


### PR DESCRIPTION
## Summary
- Remove the **Share debug motor data** option from Advanced Settings.
- Remove the handler that updates `allow_debug_sending`, preventing new opt-ins through the Dial.
- Pair with MeticulousHome/meticulous-backend#369, which disables the upload path and retires the setting.

## Validation
- `npx prettier --config .prettierrc --check src/components/Settings/Advanced/Advanced.tsx`
- `npx eslint src/components/Settings/Advanced/Advanced.tsx`
- `npm run types`
- Global `npm run format:check` remains blocked by existing formatting drift across `stable`; the modified file passes the focused check.