### PR TITLE
Harden automatic Sentry event privacy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
 import { sanitizeAutomaticSentryEvent } from './sentryPrivacy';
 
 const SENTRY_DSN =
-  'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7';
+  'https://d958eb514629903cf133ad2b19e80ead@sentry.meticulousespresso.com/8';
 
 if (SENTRY_DSN) {
   Sentry.init({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,13 +25,22 @@ import './globals.css';
 
 import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
 import { sanitizeAutomaticSentryEvent } from './sentryPrivacy';
+import { useDeviceInfo } from './hooks/useDeviceOSStatus';
+import { version as dialVersion } from '../package.json';
 
 const SENTRY_DSN =
   'https://d958eb514629903cf133ad2b19e80ead@sentry.meticulousespresso.com/8';
+const DIAL_RELEASE = `meticulous-dial@${dialVersion}`;
 
 if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
+    release: DIAL_RELEASE,
+    initialScope: {
+      tags: {
+        'dial-version': dialVersion
+      }
+    },
     sendDefaultPii: false,
     maxBreadcrumbs: 0,
     beforeBreadcrumb: () => null,
@@ -45,6 +54,25 @@ if (SENTRY_DSN) {
       )
   });
 }
+
+const SentryRuntimeMetadata = () => {
+  const { data: deviceInfo } = useDeviceInfo();
+
+  useEffect(() => {
+    if (!deviceInfo) {
+      return;
+    }
+
+    if (deviceInfo.image_version) {
+      Sentry.setTag('build-version', deviceInfo.image_version);
+    }
+    if (deviceInfo.image_build_channel) {
+      Sentry.setTag('build-channel', deviceInfo.image_build_channel);
+    }
+  }, [deviceInfo]);
+
+  return null;
+};
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -114,6 +142,7 @@ const App = (): JSX.Element => {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <SentryRuntimeMetadata />
       <div className="meticulous-main-canvas">
         {dev && <div className="main-circle-overlay" />}
         <IdleTimerProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,25 @@ import { invoke } from '@tauri-apps/api/core';
 import './globals.css';
 
 import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
+import { sanitizeAutomaticSentryEvent } from './sentryPrivacy';
 
-// const SENTRY_DSN = 'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7'; //self hosted
 const SENTRY_DSN =
-  'https://8d8dbea1f60d65c201b7f40f8a5ee20c@o4506723336060928.ingest.us.sentry.io/4511430165921792';
+  'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7';
 
 if (SENTRY_DSN) {
   Sentry.init({
-    dsn: SENTRY_DSN
+    dsn: SENTRY_DSN,
+    sendDefaultPii: false,
+    maxBreadcrumbs: 0,
+    beforeBreadcrumb: () => null,
+    beforeSend: sanitizeAutomaticSentryEvent,
+    integrations: (defaultIntegrations) =>
+      defaultIntegrations.filter(
+        (integration) =>
+          !['Breadcrumbs', 'HttpContext', 'BrowserSession'].includes(
+            integration.name
+          )
+      )
   });
 }
 

--- a/src/sentryPrivacy.ts
+++ b/src/sentryPrivacy.ts
@@ -1,0 +1,100 @@
+import type { ErrorEvent } from '@sentry/react';
+
+const sensitiveKeys = new Set([
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'credential',
+  'authorization',
+  'cookie',
+  'api_key',
+  'auth_key',
+  'root_password',
+  'ssid',
+  'apname',
+  'knownwifis',
+  'ip',
+  'ip_address',
+  'ipaddress',
+  'client_ip',
+  'remote_addr',
+  'hostname',
+  'machine_name',
+  'email',
+  'username'
+]);
+
+const normalizedKey = (key: string) =>
+  key.trim().toLowerCase().replace(/[- ]/g, '_');
+
+const isSensitiveKey = (key: string) => {
+  const normalized = normalizedKey(key);
+  return (
+    sensitiveKeys.has(normalized) ||
+    [...sensitiveKeys].some(
+      (part) =>
+        normalized.startsWith(`${part}_`) ||
+        normalized.endsWith(`_${part}`) ||
+        normalized.includes(`_${part}_`)
+    )
+  );
+};
+
+const scrubStructuredValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(scrubStructuredValue);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => !isSensitiveKey(key))
+        .map(([key, item]) => [key, scrubStructuredValue(item)])
+    );
+  }
+
+  return value;
+};
+
+const removeFrameVariables = (event: ErrorEvent) => {
+  event.exception?.values?.forEach((exception) => {
+    exception.stacktrace?.frames?.forEach((frame) => {
+      delete frame.vars;
+    });
+  });
+};
+
+export const sanitizeAutomaticSentryEvent = (event: ErrorEvent): ErrorEvent => {
+  const sanitized = structuredClone(event);
+  delete sanitized.breadcrumbs;
+  delete sanitized.request;
+  delete sanitized.user;
+  delete sanitized.server_name;
+
+  if (sanitized.tags) {
+    sanitized.tags = Object.fromEntries(
+      Object.entries(sanitized.tags).filter(
+        ([key]) =>
+          !['machine', 'machine_name', 'hostname'].includes(
+            normalizedKey(key)
+          ) && !isSensitiveKey(key)
+      )
+    );
+  }
+
+  if (sanitized.contexts) {
+    sanitized.contexts = scrubStructuredValue(
+      sanitized.contexts
+    ) as ErrorEvent['contexts'];
+  }
+
+  if (sanitized.extra) {
+    sanitized.extra = scrubStructuredValue(
+      sanitized.extra
+    ) as ErrorEvent['extra'];
+  }
+
+  removeFrameVariables(sanitized);
+  return sanitized;
+};


### PR DESCRIPTION
## Summary
- Route Dial automatic events only to the self-hosted Sentry project.
- Use the newly issued Dial project client key so machines with the disabled legacy key remain blocked.
- Disable automatic breadcrumbs, default PII, HTTP context, and browser-session collection.
- Sanitize structured automatic events and remove local stack-frame variables and sensitive metadata.
- Add the searchable `dial-version`, `build-version`, and `build-channel` tags and set the native release to `meticulous-dial@<dial-version>`.
- Leave `BugReport.tsx` and the manual feedback payload construction and attachments unchanged for the separate manual-report workstream.

## Related PRs
- [Backend automatic events and config allowlist](https://github.com/MeticulousHome/meticulous-backend/pull/370)
- [Linux crash reporter](https://github.com/MeticulousHome/systemd-crash-reporter/pull/8)
- [ESP diagnostics](https://github.com/MeticulousHome/EspressoFirmware/pull/489)

## Validation
- `npm run types`
- `npm run lint`
- Focused Prettier check for `src/App.tsx`
- `npm run build`