### PR TITLE
Backpropagate stable hotfixes to beta

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
 import { sanitizeAutomaticSentryEvent } from './sentryPrivacy';
 
 const SENTRY_DSN =
-  'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7';
+  'https://d958eb514629903cf133ad2b19e80ead@sentry.meticulousespresso.com/8';
 
 if (SENTRY_DSN) {
   Sentry.init({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,13 +25,22 @@ import './globals.css';
 
 import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
 import { sanitizeAutomaticSentryEvent } from './sentryPrivacy';
+import { useDeviceInfo } from './hooks/useDeviceOSStatus';
+import { version as dialVersion } from '../package.json';
 
 const SENTRY_DSN =
   'https://d958eb514629903cf133ad2b19e80ead@sentry.meticulousespresso.com/8';
+const DIAL_RELEASE = `meticulous-dial@${dialVersion}`;
 
 if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
+    release: DIAL_RELEASE,
+    initialScope: {
+      tags: {
+        'dial-version': dialVersion
+      }
+    },
     sendDefaultPii: false,
     maxBreadcrumbs: 0,
     beforeBreadcrumb: () => null,
@@ -45,6 +54,25 @@ if (SENTRY_DSN) {
       )
   });
 }
+
+const SentryRuntimeMetadata = () => {
+  const { data: deviceInfo } = useDeviceInfo();
+
+  useEffect(() => {
+    if (!deviceInfo) {
+      return;
+    }
+
+    if (deviceInfo.image_version) {
+      Sentry.setTag('build-version', deviceInfo.image_version);
+    }
+    if (deviceInfo.image_build_channel) {
+      Sentry.setTag('build-channel', deviceInfo.image_build_channel);
+    }
+  }, [deviceInfo]);
+
+  return null;
+};
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -114,6 +142,7 @@ const App = (): JSX.Element => {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <SentryRuntimeMetadata />
       <div className="meticulous-main-canvas">
         {dev && <div className="main-circle-overlay" />}
         <IdleTimerProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,25 @@ import { invoke } from '@tauri-apps/api/core';
 import './globals.css';
 
 import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
+import { sanitizeAutomaticSentryEvent } from './sentryPrivacy';
 
-// const SENTRY_DSN = 'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7'; //self hosted
 const SENTRY_DSN =
-  'https://8d8dbea1f60d65c201b7f40f8a5ee20c@o4506723336060928.ingest.us.sentry.io/4511430165921792';
+  'https://1db6232932da96602bced5b3f4716ba2@sentry.meticulousespresso.com/7';
 
 if (SENTRY_DSN) {
   Sentry.init({
-    dsn: SENTRY_DSN
+    dsn: SENTRY_DSN,
+    sendDefaultPii: false,
+    maxBreadcrumbs: 0,
+    beforeBreadcrumb: () => null,
+    beforeSend: sanitizeAutomaticSentryEvent,
+    integrations: (defaultIntegrations) =>
+      defaultIntegrations.filter(
+        (integration) =>
+          !['Breadcrumbs', 'HttpContext', 'BrowserSession'].includes(
+            integration.name
+          )
+      )
   });
 }
 

--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -30,12 +30,6 @@ const initialSettings: SettingsItem[] = [
       settings.ssh_enabled ? 'ENABLED' : 'DISABLED'
   },
   {
-    key: 'telemetry_service_enabled',
-    label: 'Telemetry Service',
-    getLabel: (settings: Settings) =>
-      settings.telemetry_service_enabled ? 'ENABLED' : 'DISABLED'
-  },
-  {
     key: 'displayAlignment',
     label: 'Display Alignment Screen',
     visible: true
@@ -160,12 +154,6 @@ export const AdvancedSettings = () => {
           case 'ssh_enabled':
             updateSettings.mutate({
               ssh_enabled: !globalSettings.ssh_enabled
-            });
-            break;
-          case 'telemetry_service_enabled':
-            updateSettings.mutate({
-              telemetry_service_enabled:
-                !globalSettings.telemetry_service_enabled
             });
             break;
           case 'telemetry_opt_in':

--- a/src/components/Settings/Advanced/Advanced.tsx
+++ b/src/components/Settings/Advanced/Advanced.tsx
@@ -35,13 +35,6 @@ const initialSettings: SettingsItem[] = [
     visible: true
   },
   {
-    key: 'telemetry_opt_in',
-    label: 'Share debug motor data',
-    getLabel: (settings: Settings) =>
-      settings.allow_debug_sending ? 'ENABLED' : 'DISABLED',
-    visible: true
-  },
-  {
     key: 'set_update_channel',
     label: 'Update channel',
     getLabel: (settings: Settings) => settings.update_channel,
@@ -154,11 +147,6 @@ export const AdvancedSettings = () => {
           case 'ssh_enabled':
             updateSettings.mutate({
               ssh_enabled: !globalSettings.ssh_enabled
-            });
-            break;
-          case 'telemetry_opt_in':
-            updateSettings.mutate({
-              allow_debug_sending: !globalSettings.allow_debug_sending
             });
             break;
           case 'set_update_channel':

--- a/src/sentryPrivacy.ts
+++ b/src/sentryPrivacy.ts
@@ -1,0 +1,100 @@
+import type { ErrorEvent } from '@sentry/react';
+
+const sensitiveKeys = new Set([
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'credential',
+  'authorization',
+  'cookie',
+  'api_key',
+  'auth_key',
+  'root_password',
+  'ssid',
+  'apname',
+  'knownwifis',
+  'ip',
+  'ip_address',
+  'ipaddress',
+  'client_ip',
+  'remote_addr',
+  'hostname',
+  'machine_name',
+  'email',
+  'username'
+]);
+
+const normalizedKey = (key: string) =>
+  key.trim().toLowerCase().replace(/[- ]/g, '_');
+
+const isSensitiveKey = (key: string) => {
+  const normalized = normalizedKey(key);
+  return (
+    sensitiveKeys.has(normalized) ||
+    [...sensitiveKeys].some(
+      (part) =>
+        normalized.startsWith(`${part}_`) ||
+        normalized.endsWith(`_${part}`) ||
+        normalized.includes(`_${part}_`)
+    )
+  );
+};
+
+const scrubStructuredValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(scrubStructuredValue);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => !isSensitiveKey(key))
+        .map(([key, item]) => [key, scrubStructuredValue(item)])
+    );
+  }
+
+  return value;
+};
+
+const removeFrameVariables = (event: ErrorEvent) => {
+  event.exception?.values?.forEach((exception) => {
+    exception.stacktrace?.frames?.forEach((frame) => {
+      delete frame.vars;
+    });
+  });
+};
+
+export const sanitizeAutomaticSentryEvent = (event: ErrorEvent): ErrorEvent => {
+  const sanitized = structuredClone(event);
+  delete sanitized.breadcrumbs;
+  delete sanitized.request;
+  delete sanitized.user;
+  delete sanitized.server_name;
+
+  if (sanitized.tags) {
+    sanitized.tags = Object.fromEntries(
+      Object.entries(sanitized.tags).filter(
+        ([key]) =>
+          !['machine', 'machine_name', 'hostname'].includes(
+            normalizedKey(key)
+          ) && !isSensitiveKey(key)
+      )
+    );
+  }
+
+  if (sanitized.contexts) {
+    sanitized.contexts = scrubStructuredValue(
+      sanitized.contexts
+    ) as ErrorEvent['contexts'];
+  }
+
+  if (sanitized.extra) {
+    sanitized.extra = scrubStructuredValue(
+      sanitized.extra
+    ) as ErrorEvent['extra'];
+  }
+
+  removeFrameVariables(sanitized);
+  return sanitized;
+};


### PR DESCRIPTION
## Summary
- Merge the current `stable` history into `beta` so future channel promotions retain commit ancestry.
- Remove the obsolete Fluent Bit and debug-shot telemetry settings.
- Carry forward automatic Sentry privacy hardening and Dial version metadata.

## Related PRs
- [Backend beta backpropagation](https://github.com/MeticulousHome/meticulous-backend/pull/373)
- [Dial beta backpropagation](https://github.com/MeticulousHome/meticulous-dial/pull/563)
- [Firmware beta backpropagation](https://github.com/MeticulousHome/EspressoFirmware/pull/491)
- [Machine image beta backpropagation](https://github.com/MeticulousHome/meticulous-machine/pull/95)
- [Crash reporter beta backpropagation](https://github.com/MeticulousHome/systemd-crash-reporter/pull/10)

## Validation
- `npm run types`
- `npm run lint`
- `npm run build`
- `git diff --check origin/beta...HEAD`
- Confirmed both current `origin/beta` and `origin/stable` are ancestors of the merge commit.