### PR TITLE
Keep connected apps in sync with Dial profile rotation

### DIFF
--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -93,6 +93,8 @@ export const ProfileHomeScreen = () => {
   const [isPressingDown, setIsPressingDown] = useState(false);
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
   const homeReadyReported = useRef(false);
+  const activeOptionRef = useRef(activeOption);
+  activeOptionRef.current = activeOption;
 
   const nodeRefs = useRef<Record<string, Ref<HTMLDivElement>>>({});
   const requiresPurge = useRef<boolean>(false);
@@ -171,33 +173,56 @@ export const ProfileHomeScreen = () => {
     }
   }, [mergedProfiles, activeOption]);
 
+  const emitProfileHover = (profileIndex: number, type: 'focus' | 'scroll') => {
+    const profile = mergedProfiles?.[profileIndex];
+    if (profile?.id) {
+      socket.emit('profileHover', {
+        id: profile.id,
+        from: 'dial',
+        type
+      });
+    }
+  };
+
+  const moveActiveOption = (next: number) => {
+    if (next === activeOptionRef.current) return;
+
+    activeOptionRef.current = next;
+    setActiveOption(next);
+    emitProfileHover(next, 'scroll');
+  };
+
   const rotateLeft = () => {
     if (localHoverState) {
       setLocalHoverState(false);
+      emitProfileHover(activeOptionRef.current, 'scroll');
       return;
     }
-    if (activeOption !== mergedProfiles?.length) {
+    if (activeOptionRef.current !== mergedProfiles?.length) {
       setTransitionDirection('none');
       requestAnimationFrame(() => {
         setTransitionDirection('right');
       });
     }
-    setActiveOption((prev) => Math.min(prev + 1, mergedProfiles?.length || 0));
+    moveActiveOption(
+      Math.min(activeOptionRef.current + 1, mergedProfiles?.length || 0)
+    );
   };
 
   const rotateRight = () => {
     if (localHoverState) {
       setLocalHoverState(false);
+      emitProfileHover(activeOptionRef.current, 'scroll');
       return;
     }
-    if (activeOption !== 0) {
+    if (activeOptionRef.current !== 0) {
       setTransitionDirection('none');
 
       requestAnimationFrame(() => {
         setTransitionDirection('left');
       });
     }
-    setActiveOption((prev) => Math.max(prev - 1, 0));
+    moveActiveOption(Math.max(activeOptionRef.current - 1, 0));
   };
 
   useHandleGestures(
@@ -231,14 +256,7 @@ export const ProfileHomeScreen = () => {
           if (!localHoverState) {
             setLocalHoverState(true);
             setTransitionDirection('none');
-            const profile = mergedProfiles?.[activeOption];
-            if (profile?.id) {
-              socket.emit('profileHover', {
-                id: profile.id,
-                from: 'dial',
-                type: 'focus'
-              });
-            }
+            emitProfileHover(activeOptionRef.current, 'focus');
             if (!isOnline) return;
             pressThroughTimer.current = setTimeout(() => {
               setIsPressingDown(true);


### PR DESCRIPTION
## What this fixes

When someone rotated the machine Dial to browse a different profile, the Dial updated only its own screen. It did not tell the backend—or a connected mobile app—which profile was now highlighted. As a result, the app could not follow the Dial even though the app already understood live profile-selection messages.

## What changed

- Send the existing `profileHover` message with `type: "scroll"` whenever a physical Dial rotation actually moves to another profile.
- Send the same browsing message when rotation exits a focused profile, so connected apps leave the focused state too.
- Continue sending `type: "focus"` when the Dial is pressed.
- Do not send a profile message at a carousel boundary or for the New Profile card, which has no profile ID.
- Keep rapid rotations accurate by tracking the latest Dial position synchronously.

In user terms: as the Dial moves between profiles, a connected app can now move with it. Pressing the Dial still communicates the stronger “this profile is selected” state.

## Relationship to the mobile fix

This is the Dial half of [meticulous-mobile PR 154](https://github.com/MeticulousHome/meticulous-mobile/pull/154). PR 154 makes the machine authoritative when the app connects and makes the mobile carousel respond to incoming `scroll` and `focus` messages without sending them back to the machine. Both changes are needed for complete two-way synchronization.

## Validation completed

- `npm run format:check`
- `npm run types`
- `npm run lint`
- `npm run build`
- Built an ARM64 Debian package and installed it on a Meticulous machine.
- Confirmed the updated Dial and backend remained active with zero service restarts and no error-level logs.
- Ran the full mobile suite for the companion change: 77/77 tests passed, plus lint, TypeScript, and an iOS simulator build.

## Adversarial validation

- Sent 160 rapid selection events alternating between Dial-originated and app-originated updates. Neither the Dial, backend, nor iOS app crashed or restarted, and Dial memory remained stable.
- Force-closed the iOS app, moved the machine to Allonge, and relaunched. The app opened on Allonge.
- Confirmed a machine-driven carousel move does not echo an app selection back to the machine.
- Confirmed normal app startup, live Dial rotation, rapid rotation, and return to the original Medium Contact profile.
- Smoke-tested the Community screen because the mobile companion change touches the shared carousel component.

## Specific machine + app tests

Use a mobile build containing meticulous-mobile PR 154 and a Dial build containing this PR.

1. Put the Dial on profile A, force-close the app, and reopen it. Confirm the app opens on profile A.
2. Rotate the Dial from profile A to profile B without pressing it. Confirm the app carousel moves to profile B immediately.
3. Rotate several notches quickly. Confirm the app lands on the same final profile as the Dial.
4. Press the Dial on a profile. Confirm that profile becomes focused/selected in the app.
5. Rotate once while the profile is focused. Confirm both the Dial and app leave the focused state without changing profiles; rotate again and confirm both move together.
6. Enable reversed home-screen scrolling on the Dial and repeat the rotation test. Confirm the app follows the profile shown by the Dial, regardless of physical direction.
7. Rotate to the New Profile card. Confirm the app does not jump to an unrelated profile and no error occurs.
8. Swipe to a profile in the app. Confirm the Dial follows it and neither carousel bounces or loops.