### PR TITLE
Backpropagate beta fixes to nightly

### DIFF
--- a/src/components/Wifi/WifiModeSettings.tsx
+++ b/src/components/Wifi/WifiModeSettings.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { APMode } from '@meticulous-home/espresso-api';
+
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import {
+  NETWORK_CONFIG_QUERY_KEY,
+  useNetworkConfig,
+  useUpdateNetworkConfig
+} from '../../hooks/useWifi';
+import Styled, {
+  MARQUEE_MIN_TEXT_LENGTH,
+  MenuAnnotation,
+  VIEWPORT_HEIGHT
+} from '../../styles/utils/mixins';
+import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
+import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
+import { setBubbleDisplay } from '../store/features/screens/screens-slice';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+
+type WifiModeItem = {
+  key: string;
+  label: string;
+  mode?: APMode;
+  hasSeparator?: boolean;
+};
+
+const wifiModeItems: WifiModeItem[] = [
+  {
+    key: 'client',
+    label: 'Join existing WiFi',
+    mode: APMode.CLIENT
+  },
+  {
+    key: 'standalone',
+    label: 'Create standalone WiFi',
+    mode: APMode.AP,
+    hasSeparator: true
+  },
+  {
+    key: 'save',
+    label: 'Save'
+  },
+  {
+    key: 'cancel',
+    label: 'Cancel'
+  }
+];
+
+const getLoadingMessages = (mode: APMode | null): string[] => {
+  if (mode === APMode.AP) {
+    return [
+      'Starting hotspot',
+      'Trying WiFi channels',
+      'Checking hotspot',
+      'Keeping current WiFi safe'
+    ];
+  }
+
+  if (mode === APMode.CLIENT) {
+    return ['Joining WiFi mode', 'Checking connection', 'Updating WiFi'];
+  }
+
+  return ['Updating WiFi'];
+};
+
+export const WifiModeSettings = (): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [draftMode, setDraftMode] = useState<APMode | null>(null);
+  const [loadingMessageIndex, setLoadingMessageIndex] = useState(0);
+  const { data: networkConfig, error, isLoading } = useNetworkConfig();
+  const updateNetworkConfigMutation = useUpdateNetworkConfig();
+  const currentMode = networkConfig?.config.mode;
+  const loadingMessages = useMemo(
+    () => getLoadingMessages(draftMode),
+    [draftMode]
+  );
+
+  useEffect(() => {
+    if (draftMode !== null || !currentMode) {
+      return;
+    }
+
+    setDraftMode(currentMode);
+    setActiveIndex(currentMode === APMode.AP ? 1 : 0);
+  }, [currentMode, draftMode]);
+
+  useEffect(() => {
+    setLoadingMessageIndex(0);
+
+    if (!updateNetworkConfigMutation.isPending || loadingMessages.length <= 1) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setLoadingMessageIndex(
+        (current) => (current + 1) % loadingMessages.length
+      );
+    }, 7000);
+
+    return () => clearInterval(interval);
+  }, [loadingMessages, updateNetworkConfigMutation.isPending]);
+
+  const returnToWifiSettings = () => {
+    dispatch(setBubbleDisplay({ visible: true, component: 'wifiSettings' }));
+  };
+
+  useHandleGestures(
+    {
+      left() {
+        setActiveIndex((previous) => Math.max(previous - 1, 0));
+      },
+      right() {
+        setActiveIndex((previous) =>
+          Math.min(previous + 1, wifiModeItems.length - 1)
+        );
+      },
+      pressDown() {
+        if (updateNetworkConfigMutation.isError || error) {
+          updateNetworkConfigMutation.reset();
+          returnToWifiSettings();
+          return;
+        }
+
+        const activeItem = wifiModeItems[activeIndex];
+        if (activeItem.mode) {
+          setDraftMode(activeItem.mode);
+          return;
+        }
+
+        if (activeItem.key === 'cancel') {
+          returnToWifiSettings();
+          return;
+        }
+
+        if (activeItem.key !== 'save' || !draftMode) {
+          return;
+        }
+
+        if (draftMode === currentMode) {
+          returnToWifiSettings();
+          return;
+        }
+
+        void queryClient.cancelQueries({
+          queryKey: [NETWORK_CONFIG_QUERY_KEY]
+        });
+        updateNetworkConfigMutation.mutate(
+          {
+            ...networkConfig?.config,
+            mode: draftMode
+          },
+          {
+            onSuccess: (updatedConfig) => {
+              queryClient.setQueryData(
+                [NETWORK_CONFIG_QUERY_KEY],
+                (current: typeof networkConfig) =>
+                  current
+                    ? {
+                        ...current,
+                        config: {
+                          ...current.config,
+                          ...updatedConfig
+                        }
+                      }
+                    : current
+              );
+              returnToWifiSettings();
+            }
+          }
+        );
+      }
+    },
+    !bubbleDisplay.interceptsGesture ||
+      isLoading ||
+      updateNetworkConfigMutation.isPending
+  );
+
+  const optionPositionOutter = useMemo(
+    () =>
+      calculateOptionPosition({
+        activeOptionIdx: activeIndex,
+        settings: wifiModeItems
+      }),
+    [activeIndex]
+  );
+
+  const optionPositionInner = useMemo(
+    () =>
+      calculateOptionPosition({
+        activeOptionIdx: activeIndex,
+        adjustmentFn: (position) => position - VIEWPORT_HEIGHT / 2,
+        settings: wifiModeItems
+      }),
+    [activeIndex]
+  );
+
+  if (isLoading) {
+    return <LoadingScreen message="Loading WiFi mode" />;
+  }
+
+  if (updateNetworkConfigMutation.isPending) {
+    return <LoadingScreen message={loadingMessages[loadingMessageIndex]} />;
+  }
+
+  if (updateNetworkConfigMutation.isError || error) {
+    const title = updateNetworkConfigMutation.isError
+      ? 'Could not update WiFi'
+      : 'Could not load WiFi mode';
+    const message = updateNetworkConfigMutation.isError
+      ? updateNetworkConfigMutation.error?.message ||
+        'Could not update WiFi. Please try again.'
+      : 'Could not load the current WiFi mode. Please try again.';
+
+    return (
+      <div className="main-container response">
+        <div className="connect-response-title error-entry">{title}</div>
+        <div className="connect-response-message error-entry">{message}</div>
+        <div key="back" className="settings-item active-setting connect-item">
+          <div className="settings-entry connect-button">Ok</div>
+        </div>
+      </div>
+    );
+  }
+
+  const getAnnotation = (item: WifiModeItem): 'current' | 'selected' | null => {
+    if (!item.mode) {
+      return null;
+    }
+
+    if (draftMode !== currentMode && item.mode === draftMode) {
+      return 'selected';
+    }
+
+    return item.mode === currentMode ? 'current' : null;
+  };
+
+  const renderOption = (
+    option: WifiModeItem,
+    index: number,
+    isInner: boolean
+  ) => {
+    const annotation = getAnnotation(option);
+
+    return (
+      <Styled.SelectedOption
+        key={option.key}
+        $hasSeparator={option.hasSeparator}
+        $isMarquee={
+          activeIndex === index && option.label.length > MARQUEE_MIN_TEXT_LENGTH
+        }
+      >
+        <span>{option.label}</span>
+        {annotation && (
+          <MenuAnnotation $marginRigth={isInner ? undefined : '1.2rem'}>
+            {annotation}
+          </MenuAnnotation>
+        )}
+      </Styled.SelectedOption>
+    );
+  };
+
+  return (
+    <Styled.SettingsContainer>
+      <Styled.Viewport>
+        <Styled.OptionsContainer $translateY={optionPositionOutter}>
+          {wifiModeItems.map((option, index) =>
+            renderOption(option, index, false)
+          )}
+        </Styled.OptionsContainer>
+        <Styled.ActiveIndicator>
+          <Styled.OptionsContainer
+            $translateY={optionPositionInner}
+            $isInner={true}
+          >
+            {wifiModeItems.map((option, index) =>
+              renderOption(option, index, true)
+            )}
+          </Styled.OptionsContainer>
+        </Styled.ActiveIndicator>
+      </Styled.Viewport>
+    </Styled.SettingsContainer>
+  );
+};

--- a/src/components/Wifi/WifiSettings.tsx
+++ b/src/components/Wifi/WifiSettings.tsx
@@ -6,11 +6,7 @@ import { useAppDispatch } from '../store/hooks';
 
 import { setBubbleDisplay } from '../store/features/screens/screens-slice';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
-import {
-  useNetworkConfig,
-  useRepairWiFi,
-  useUpdateNetworkConfig
-} from '../../hooks/useWifi';
+import { useNetworkConfig, useRepairWiFi } from '../../hooks/useWifi';
 import { APMode } from '@meticulous-home/espresso-api';
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen';
 import Styled, {
@@ -25,9 +21,6 @@ export const WifiSettings = (): JSX.Element => {
   const queryClient = useQueryClient();
   const [activeIndex, setActiveIndex] = useState(0);
   const [loadingMessageIndex, setLoadingMessageIndex] = useState(0);
-  const [networkConfigMode, setNetworkConfigMode] = useState<APMode>(
-    APMode.CLIENT
-  );
 
   const {
     data: networkConfig,
@@ -36,50 +29,24 @@ export const WifiSettings = (): JSX.Element => {
     isFetching,
     refetch
   } = useNetworkConfig();
-  const updateNetworkConfigMutation = useUpdateNetworkConfig();
   const repairWiFiMutation = useRepairWiFi(queryClient);
-
-  useEffect(() => {
-    if (!networkConfig?.config.mode) {
-      return;
-    }
-    setNetworkConfigMode(networkConfig?.config.mode);
-  }, [networkConfig]);
 
   const isWifiConnected = networkConfig?.status.connected;
   const wifiHealth = networkConfig?.health;
 
-  const isApMode = networkConfigMode === APMode.AP;
+  const isApMode = networkConfig?.config.mode === APMode.AP;
   const hasStaleNetworkConfig =
     !networkConfig || (isFetching && Date.now() - dataUpdatedAt > 2000);
   const healthLabel = hasStaleNetworkConfig
     ? 'Checking...'
     : getWifiHealthStatusLabel(wifiHealth, isWifiConnected);
-  const loadingState = updateNetworkConfigMutation.isPending
-    ? `update-${networkConfigMode}`
-    : repairWiFiMutation.isPending
-      ? 'repair'
-      : 'idle';
   const loadingMessages = useMemo(() => {
-    if (loadingState === `update-${APMode.AP}`) {
-      return [
-        'Starting hotspot',
-        'Trying WiFi channels',
-        'Checking hotspot',
-        'Keeping current WiFi safe'
-      ];
-    }
-
-    if (loadingState === `update-${APMode.CLIENT}`) {
-      return ['Joining WiFi mode', 'Checking connection', 'Updating WiFi'];
-    }
-
-    if (loadingState === 'repair') {
+    if (repairWiFiMutation.isPending) {
       return ['Checking WiFi', 'Trying recovery', 'Verifying connection'];
     }
 
     return [];
-  }, [loadingState]);
+  }, [repairWiFiMutation.isPending]);
 
   useEffect(() => {
     setLoadingMessageIndex(0);
@@ -135,17 +102,12 @@ export const WifiSettings = (): JSX.Element => {
         visible: true
       },
       {
-        key: 'save',
-        label: 'Save',
-        visible: networkConfigMode !== networkConfig?.config.mode
-      },
-      {
         key: 'back',
         label: 'Back',
         visible: true
       }
     ],
-    [healthLabel, isWifiConnected, isApMode, networkConfigMode]
+    [healthLabel, isWifiConnected, isApMode]
   );
 
   useHandleGestures(
@@ -163,23 +125,23 @@ export const WifiSettings = (): JSX.Element => {
       },
       pressDown() {
         // In case of error we go back
-        if (
-          updateNetworkConfigMutation.isError ||
-          repairWiFiMutation.isError ||
-          error
-        ) {
+        if (repairWiFiMutation.isError || error) {
           dispatch(
             setBubbleDisplay({ visible: true, component: 'quick-settings' })
           );
+          return;
         }
         const filter = wifiSettingItems.filter((item) => item.visible)[
           activeIndex
         ].key;
         switch (filter) {
           case 'network_mode': {
-            const mode =
-              networkConfigMode === APMode.AP ? APMode.CLIENT : APMode.AP;
-            setNetworkConfigMode(mode);
+            dispatch(
+              setBubbleDisplay({
+                visible: true,
+                component: 'wifiModeSettings'
+              })
+            );
             break;
           }
           case 'qr_code': {
@@ -192,14 +154,6 @@ export const WifiSettings = (): JSX.Element => {
             dispatch(
               setBubbleDisplay({ visible: true, component: 'wifiDetails' })
             );
-            break;
-          }
-          case 'save': {
-            updateNetworkConfigMutation.mutate({
-              ...networkConfig?.config,
-              mode: networkConfigMode
-            });
-            setActiveIndex(0);
             break;
           }
           case 'known_wifis': {
@@ -234,7 +188,7 @@ export const WifiSettings = (): JSX.Element => {
         }
       }
     },
-    updateNetworkConfigMutation.isPending || repairWiFiMutation.isPending
+    repairWiFiMutation.isPending
   );
   const optionPositionOutter = useMemo(
     () =>
@@ -255,25 +209,18 @@ export const WifiSettings = (): JSX.Element => {
     [activeIndex, wifiSettingItems]
   );
 
-  if (updateNetworkConfigMutation.isPending || repairWiFiMutation.isPending) {
+  if (repairWiFiMutation.isPending) {
     return <LoadingScreen message={loadingMessages[loadingMessageIndex]} />;
   }
 
-  if (
-    updateNetworkConfigMutation.isError ||
-    repairWiFiMutation.isError ||
-    error
-  ) {
+  if (repairWiFiMutation.isError || error) {
     const title = repairWiFiMutation.isError
       ? 'Network issue'
-      : 'Could not update WiFi';
-    const message = updateNetworkConfigMutation.isError
-      ? updateNetworkConfigMutation.error?.message ||
-        'Could not update WiFi. Please try again.'
-      : repairWiFiMutation.isError
-        ? repairWiFiMutation.error?.message ||
-          'WiFi repair could not complete. Please check the network.'
-        : 'Connection could not be verified. Please check the connection details.';
+      : 'Could not load WiFi';
+    const message = repairWiFiMutation.isError
+      ? repairWiFiMutation.error?.message ||
+        'WiFi repair could not complete. Please check the network.'
+      : 'Connection could not be verified. Please check the connection details.';
 
     return (
       <div className="main-container response">

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -21,6 +21,7 @@ export type ScreenType =
   | 'timeZoneConfig'
   | 'notifications'
   | 'wifiSettings'
+  | 'wifiModeSettings'
   | 'wifiQrMenu'
   | 'wifiDetails'
   | 'connectWifiMenu'

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -7,6 +7,7 @@ import { ScreenType } from '../components/store/features/screens/screens-slice';
 import { EditNameScreen } from '../components/EditNameScreen/EditNameScreen';
 import { ConnectWifiMenu } from '../components/Wifi/ConnectWifiMenu';
 import { WifiSettings } from './../components/Wifi/WifiSettings';
+import { WifiModeSettings } from '../components/Wifi/WifiModeSettings';
 import { SelectWifi } from '../components/Wifi/SelectWifi';
 import { EnterWifiPassword } from '../components/Wifi/EnterWifiPassword';
 import { WifiDetails } from '../components/Wifi/WifiDetails';
@@ -313,6 +314,11 @@ export const routes: Record<ScreenType, Route> = {
   wifiSettings: {
     component: WifiSettings,
     title: 'wifi settings',
+    bottomStatusHidden: true
+  },
+  wifiModeSettings: {
+    component: WifiModeSettings,
+    title: 'wifi mode',
     bottomStatusHidden: true
   },
   wifiQrMenu: {


### PR DESCRIPTION
## Summary
- Forward the current `beta` fixes into `nightly`.
- Bring the explicit Wi-Fi mode selector to the nightly channel.
- Preserve channel ancestry for future promotions.

## Validation
- GitHub comparison: 2 commits across 4 files.
- Verified that `nightly` and `beta` merge cleanly with `git merge-tree`.