### PR TITLE
Add machine serial to Sentry events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,8 @@ const SentryRuntimeMetadata = () => {
       return;
     }
 
+    Sentry.setTag('serial', deviceInfo.serial);
+
     if (deviceInfo.image_version) {
       Sentry.setTag('build-version', deviceInfo.image_version);
     }


### PR DESCRIPTION
## Summary
- Add the machine serial as a searchable Sentry tag on automatic Dial events.
- Read the serial from the existing device-info response, alongside the current build version and channel tags.
- Match the Backend Sentry contract while preserving the existing automatic-event privacy sanitizer.

## Root cause
Dial's runtime Sentry metadata only set `build-version` and `build-channel`. The sanitizer already preserves a `serial` tag, but Dial never added it.

## Validation
- `npm run types`
- `npm run lint`
- `npm run build`
- `npx prettier --config .prettierrc src/App.tsx --check`
- The repository pre-commit hook's repo-wide Prettier check still reports existing formatting drift in 145 files; the changed file passes the focused check.