### PR TITLE
Add Auto Tare and Retraction Distance settings

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2,10 +2,10 @@ import Api, {
   regionType,
   APIError,
   BrightnessRequest,
-  DeviceInfo,
   ManufacturingSettings,
   ManufacturingMenuItems
 } from '@meticulous-home/espresso-api';
+import { DialDeviceInfo } from '../types';
 
 export const API_URL =
   import.meta.env.VITE_SERVER_URL || 'http://localhost:8080';
@@ -31,14 +31,14 @@ export const getOSStatus = async () => {
   }
 };
 
-export async function getDeviceInfo(): Promise<DeviceInfo> {
+export async function getDeviceInfo(): Promise<DialDeviceInfo> {
   try {
     const response = await api.getDeviceInfo();
     const data = response.data;
     if (data && 'error' in data) {
       throw new Error((data as APIError).error);
     }
-    return data as DeviceInfo;
+    return data as DialDeviceInfo;
   } catch (error) {
     if (error.response) {
       console.error('Error fetching device Info: ', error.response.data);

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,14 +1,15 @@
 import { APIError, Settings } from '@meticulous-home/espresso-api';
+import { DialSettings } from '../types';
 import { api } from './api';
 
-export async function getSettings(): Promise<Settings> {
+export async function getSettings(): Promise<DialSettings> {
   try {
     const response = await api.getSettings();
     const data = response.data;
     if (data && 'error' in data) {
       throw new Error((data as APIError).error);
     }
-    return data as Settings;
+    return data as DialSettings;
   } catch (error) {
     if (error.response) {
       console.error('Error getting Settings: ', error.response.data);
@@ -23,15 +24,15 @@ export async function getSettings(): Promise<Settings> {
 }
 
 export async function updateSettings(
-  update: Partial<Settings>
-): Promise<Settings> {
+  update: Partial<DialSettings>
+): Promise<DialSettings> {
   try {
-    const response = await api.updateSetting(update);
+    const response = await api.updateSetting(update as Partial<Settings>);
     const data = response.data;
     if (data && 'error' in data) {
       throw new Error((data as APIError).error);
     }
-    return data as Settings;
+    return data as DialSettings;
   } catch (error) {
     if (error.response) {
       console.error('Error updating settings: ', error.response.data);

--- a/src/components/Settings/Advanced/DeviceInfoScreen.tsx
+++ b/src/components/Settings/Advanced/DeviceInfoScreen.tsx
@@ -41,10 +41,12 @@ export const DeviceInfoScreen = () => {
 
     const { repository_info, ...basicData } = deviceInfo as ExtendedDeviceInfo;
 
-    const basicInfo = Object.entries(basicData).map(([key, value]) => ({
-      key,
-      label: `${key}: ${typeof value === 'boolean' ? `${value ? 'ENABLED' : 'DISABLED'}` : (value ?? 'UNSET')}`
-    }));
+    const basicInfo = Object.entries(basicData)
+      .filter(([key]) => key !== 'tare_behavior_supported')
+      .map(([key, value]) => ({
+        key,
+        label: `${key}: ${typeof value === 'boolean' ? `${value ? 'ENABLED' : 'DISABLED'}` : (value ?? 'UNSET')}`
+      }));
 
     const keysToFilter = ['backend', 'dial', 'firmware'];
 

--- a/src/components/Settings/Advanced/RetractionVolume.tsx
+++ b/src/components/Settings/Advanced/RetractionVolume.tsx
@@ -69,7 +69,7 @@ export const RetractionSettingGauge: React.FC = () => {
         );
       }
     },
-    Boolean(globalSettings)
+    !globalSettings
   );
 
   if (!globalSettings) {

--- a/src/components/Settings/Advanced/RetractionVolume.tsx
+++ b/src/components/Settings/Advanced/RetractionVolume.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSettings, useUpdateSettings } from '../../../hooks/useSettings';
 import { Gauge } from '../../SettingNumerical/Gauge';
 import { useHandleGestures } from '../../../hooks/useHandleGestures';
@@ -9,14 +9,15 @@ import {
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 
 import { useDimScreen } from '../../../hooks/useDimScreen';
-
-const MIN_VOLUME = 100; // ml
-const MAX_VOLUME = 150; // ml
-const INTERVAL = 1; // 1 ml interval
-
-const cylinder_radius = 26.5; //mm
-
-const pi_r_squared = Math.PI * cylinder_radius * cylinder_radius;
+import { LoadingScreen } from '../../LoadingScreen/LoadingScreen';
+import {
+  RETRACTION_DEFAULT_VOLUME_ML,
+  RETRACTION_MAX_VOLUME_ML,
+  RETRACTION_MIN_VOLUME_ML,
+  RETRACTION_VOLUME_STEP_ML,
+  retractionMmToVolumeMl,
+  volumeMlToRetractionMm
+} from '../../../utils/retraction';
 
 export const RetractionSettingGauge: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -25,36 +26,62 @@ export const RetractionSettingGauge: React.FC = () => {
   const updateSettings = useUpdateSettings();
 
   const [localRetractionVolume, setLocalRetractionVolume] = useState(
-    Math.round((pi_r_squared * globalSettings.partial_retraction) / 1000.0)
+    globalSettings
+      ? retractionMmToVolumeMl(globalSettings.partial_retraction)
+      : RETRACTION_DEFAULT_VOLUME_ML
   );
+  const initializedFromSettings = useRef(Boolean(globalSettings));
+
+  useEffect(() => {
+    if (!initializedFromSettings.current && globalSettings) {
+      setLocalRetractionVolume(
+        retractionMmToVolumeMl(globalSettings.partial_retraction)
+      );
+      initializedFromSettings.current = true;
+    }
+  }, [globalSettings]);
 
   useDimScreen();
 
-  useHandleGestures({
-    left() {
-      const newValue = Math.max(localRetractionVolume - INTERVAL, MIN_VOLUME);
-      setLocalRetractionVolume(newValue);
+  useHandleGestures(
+    {
+      left() {
+        const newValue = Math.max(
+          localRetractionVolume - RETRACTION_VOLUME_STEP_ML,
+          RETRACTION_MIN_VOLUME_ML
+        );
+        setLocalRetractionVolume(newValue);
+      },
+      right() {
+        const newValue = Math.min(
+          localRetractionVolume + RETRACTION_VOLUME_STEP_ML,
+          RETRACTION_MAX_VOLUME_ML
+        );
+        setLocalRetractionVolume(newValue);
+      },
+      pressDown() {
+        updateSettings.mutate({
+          partial_retraction: volumeMlToRetractionMm(localRetractionVolume)
+        });
+        dispatch(setScreen(prevScreen));
+        dispatch(
+          setBubbleDisplay({ visible: true, component: 'brewSettings' })
+        );
+      }
     },
-    right() {
-      const newValue = Math.min(localRetractionVolume + INTERVAL, MAX_VOLUME);
-      setLocalRetractionVolume(newValue);
-    },
-    pressDown() {
-      updateSettings.mutate({
-        partial_retraction:
-          Math.round((localRetractionVolume * 1000 * 100) / pi_r_squared) / 100
-      });
-      dispatch(setScreen(prevScreen));
-      dispatch(setBubbleDisplay({ visible: true, component: 'brewSettings' }));
-    }
-  });
+    Boolean(globalSettings)
+  );
+
+  if (!globalSettings) {
+    return <LoadingScreen />;
+  }
 
   return (
     <div className="gauge-container">
       <Gauge
         value={localRetractionVolume}
-        maxValue={MAX_VOLUME}
-        minValue={MIN_VOLUME}
+        maxValue={RETRACTION_MAX_VOLUME_ML}
+        minValue={RETRACTION_MIN_VOLUME_ML}
         precision={0}
         unit="volume"
       />

--- a/src/components/Settings/BrewSettings.tsx
+++ b/src/components/Settings/BrewSettings.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { SettingsKey } from '@meticulous-home/espresso-api';
+import type { Settings } from '@meticulous-home/espresso-api';
 
 import '../PressetSettings/pressetSettings.css';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
@@ -17,10 +18,9 @@ import Styled, {
   MARQUEE_MIN_TEXT_LENGTH
 } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
-import type { Settings } from '@meticulous-home/espresso-api';
-
-const cylinder_radius = 26.5; //ml
-const pi_r_squared = Math.PI * cylinder_radius * cylinder_radius;
+import type { DialSettings } from '../../types';
+import { retractionMmToVolumeMl } from '../../utils/retraction';
+import { useDeviceInfo } from '../../hooks/useDeviceOSStatus';
 
 const initialSettings: SettingsItem[] = [
   {
@@ -37,11 +37,18 @@ const initialSettings: SettingsItem[] = [
   },
   {
     key: 'shot_volume',
-    label: 'Shot volume',
+    label: 'Retraction distance',
     getLabel: (settings: Settings) =>
-      ((settings.partial_retraction * pi_r_squared) / 1000.0)
-        .toFixed()
-        .toString() + ' ml',
+      `${retractionMmToVolumeMl(settings.partial_retraction)} mL`,
+    visible: true
+  },
+  {
+    key: 'tare_behavior',
+    label: 'Auto Tare',
+    getLabel: (settings: Settings) =>
+      (settings as DialSettings).tare_behavior === 'before_retraction'
+        ? 'Before retraction'
+        : 'After retraction',
     visible: true
   },
   {
@@ -61,6 +68,7 @@ export function BrewSettings(): JSX.Element {
   const [activeIndex, setActiveIndex] = useState(0);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const { data: globalSettings, isSuccess } = useSettings();
+  const { data: deviceInfo } = useDeviceInfo({ refetchInterval: 10000 });
   const updateSettings = useUpdateSettings();
 
   const updatedSettings = useMemo(() => {
@@ -71,11 +79,14 @@ export function BrewSettings(): JSX.Element {
     }
     return initialSettings.map((item) => ({
       ...item,
-      label: item.getLabel
-        ? `${item.label}: ${item.getLabel(globalSettings)}`
-        : item.label
+      label:
+        item.key === 'tare_behavior' && !deviceInfo?.tare_behavior_supported
+          ? `${item.label}: Unavailable`
+          : item.getLabel
+            ? `${item.label}: ${item.getLabel(globalSettings)}`
+            : item.label
     }));
-  }, [globalSettings, isSuccess]);
+  }, [deviceInfo?.tare_behavior_supported, globalSettings, isSuccess]);
 
   useHandleGestures(
     {
@@ -98,6 +109,18 @@ export function BrewSettings(): JSX.Element {
             break;
           case 'shot_volume':
             dispatch(setScreen('retraction_volume'));
+            dispatch(
+              setBubbleDisplay({
+                visible: false,
+                component: null
+              })
+            );
+            break;
+          case 'tare_behavior':
+            if (!deviceInfo?.tare_behavior_supported) {
+              break;
+            }
+            dispatch(setScreen('tare_behavior'));
             dispatch(
               setBubbleDisplay({
                 visible: false,

--- a/src/components/Settings/TareBehavior.tsx
+++ b/src/components/Settings/TareBehavior.tsx
@@ -72,7 +72,7 @@ export const TareBehaviorSetting = () => {
         updateSettings.mutate({ tare_behavior: selected });
       }
     },
-    !bubbleDisplay.interceptsGesture
+    bubbleDisplay.interceptsGesture || !globalSettings
   );
 
   const optionPositionOuter = useMemo(

--- a/src/components/Settings/TareBehavior.tsx
+++ b/src/components/Settings/TareBehavior.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import { useSettings, useUpdateSettings } from '../../hooks/useSettings';
+import Styled, {
+  MenuAnnotation,
+  VIEWPORT_HEIGHT
+} from '../../styles/utils/mixins';
+import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
+import type { TareBehavior } from '../../types';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../store/features/screens/screens-slice';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+
+type TareBehaviorOption = {
+  key: TareBehavior | 'back';
+  label: string;
+};
+
+const options: TareBehaviorOption[] = [
+  { key: 'after_retraction', label: 'After retraction' },
+  { key: 'before_retraction', label: 'Before retraction' },
+  { key: 'back', label: 'Back' }
+];
+
+export const TareBehaviorSetting = () => {
+  const dispatch = useAppDispatch();
+  const prevScreen = useAppSelector((state) => state.screen.prev);
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
+  const { data: globalSettings } = useSettings();
+  const updateSettings = useUpdateSettings();
+  const [activeIndex, setActiveIndex] = useState(() => {
+    const selected = options.findIndex(
+      (option) => option.key === globalSettings?.tare_behavior
+    );
+    return selected >= 0 ? selected : 0;
+  });
+  const initializedFromSettings = useRef(Boolean(globalSettings));
+
+  useEffect(() => {
+    if (!initializedFromSettings.current && globalSettings) {
+      const selected = options.findIndex(
+        (option) => option.key === globalSettings.tare_behavior
+      );
+      setActiveIndex(selected >= 0 ? selected : 0);
+      initializedFromSettings.current = true;
+    }
+  }, [globalSettings]);
+
+  useHandleGestures(
+    {
+      left() {
+        setActiveIndex((previous) => Math.max(previous - 1, 0));
+      },
+      right() {
+        setActiveIndex((previous) =>
+          Math.min(previous + 1, options.length - 1)
+        );
+      },
+      pressDown() {
+        const selected = options[activeIndex].key;
+        if (selected === 'back') {
+          dispatch(setScreen(prevScreen));
+          dispatch(
+            setBubbleDisplay({ visible: true, component: 'brewSettings' })
+          );
+          return;
+        }
+
+        updateSettings.mutate({ tare_behavior: selected });
+      }
+    },
+    !bubbleDisplay.interceptsGesture
+  );
+
+  const optionPositionOuter = useMemo(
+    () =>
+      calculateOptionPosition({
+        activeOptionIdx: activeIndex,
+        settings: options
+      }),
+    [activeIndex]
+  );
+
+  const optionPositionInner = useMemo(
+    () =>
+      calculateOptionPosition({
+        activeOptionIdx: activeIndex,
+        adjustmentFn: (position) => position - VIEWPORT_HEIGHT / 2,
+        settings: options
+      }),
+    [activeIndex]
+  );
+
+  const renderOption = (option: TareBehaviorOption, inner = false) => {
+    const isCurrent = globalSettings?.tare_behavior === option.key;
+    return (
+      <Styled.SelectedOption key={option.key}>
+        <span>{option.label}</span>
+        {isCurrent && (
+          <MenuAnnotation $marginRigth={inner ? undefined : '1.2rem'}>
+            current
+          </MenuAnnotation>
+        )}
+      </Styled.SelectedOption>
+    );
+  };
+
+  return (
+    <Styled.SettingsContainer>
+      <Styled.Viewport>
+        <Styled.OptionsContainer $translateY={optionPositionOuter}>
+          {options.map((option) => renderOption(option))}
+        </Styled.OptionsContainer>
+        <Styled.ActiveIndicator>
+          <Styled.OptionsContainer
+            $translateY={optionPositionInner}
+            $isInner={true}
+          >
+            {options.map((option) => renderOption(option, true))}
+          </Styled.OptionsContainer>
+        </Styled.ActiveIndicator>
+      </Styled.Viewport>
+    </Styled.SettingsContainer>
+  );
+};

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -57,6 +57,7 @@ export type ScreenType =
   | 'brewComplete'
   | 'factoryReset'
   | 'retraction_volume'
+  | 'tare_behavior'
   | 'manufacturingSettings'
   | 'displayAlignment'
   | 'masterCalibrationLock'

--- a/src/hooks/useDeviceOSStatus.tsx
+++ b/src/hooks/useDeviceOSStatus.tsx
@@ -21,11 +21,11 @@ export const useOSStatus = () => {
   });
 };
 
-export const useDeviceInfo = () => {
+export const useDeviceInfo = (options?: { refetchInterval?: number }) => {
   return useQuery({
     queryKey: [DEVICE_INFO],
     queryFn: () => getDeviceInfo(),
     staleTime: 0,
-    refetchInterval: 2 * 60 * 60 * 1000 // Every 2 hours
+    refetchInterval: options?.refetchInterval ?? 2 * 60 * 60 * 1000 // Every 2 hours
   });
 };

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -54,6 +54,7 @@ import {
 import { FactoryReset } from '../components/Settings/Advanced/FactoryReset';
 import { Manufacturing } from '../components/Settings/Advanced/Manufacturing';
 import { RetractionSettingGauge } from '../components/Settings/Advanced/RetractionVolume';
+import { TareBehaviorSetting } from '../components/Settings/TareBehavior';
 import { useProfileContext } from '../context/ProfileContext';
 import { DisplayAlignment } from '../components/Settings/Advanced/DisplayAlignment';
 import {
@@ -193,10 +194,16 @@ export const routes: Record<ScreenType, Route> = {
   retraction_volume: {
     component: RetractionSettingGauge,
     title: 'retraction',
-    bottomTitle: 'shot volume',
+    bottomTitle: 'distance',
     props: {
       type: 'retraction_volume'
     },
+    bottomStatusHidden: true,
+    parent: 'brewSettings'
+  },
+  tare_behavior: {
+    component: TareBehaviorSetting,
+    title: 'auto tare',
     bottomStatusHidden: true,
     parent: 'brewSettings'
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,15 @@
 import { VariableType } from '@meticulous-home/espresso-profile';
-import { StatusData, Settings } from '@meticulous-home/espresso-api';
+import {
+  DeviceInfo,
+  StatusData,
+  Settings
+} from '@meticulous-home/espresso-api';
+
+export type TareBehavior = 'after_retraction' | 'before_retraction';
+export type DialSettings = Settings & { tare_behavior: TareBehavior };
+export type DialDeviceInfo = DeviceInfo & {
+  tare_behavior_supported?: boolean;
+};
 
 export type GestureType =
   | 'right'

--- a/src/utils/retraction.ts
+++ b/src/utils/retraction.ts
@@ -1,0 +1,13 @@
+export const PISTON_RADIUS_MM = 26.5;
+export const RETRACTION_MIN_VOLUME_ML = 80;
+export const RETRACTION_DEFAULT_VOLUME_ML = 100;
+export const RETRACTION_MAX_VOLUME_ML = 150;
+export const RETRACTION_VOLUME_STEP_ML = 1;
+
+const PISTON_AREA_MM2 = Math.PI * PISTON_RADIUS_MM * PISTON_RADIUS_MM;
+
+export const retractionMmToVolumeMl = (distanceMm: number): number =>
+  Math.round((PISTON_AREA_MM2 * distanceMm) / 1000);
+
+export const volumeMlToRetractionMm = (volumeMl: number): number =>
+  Math.round((volumeMl * 1000 * 100) / PISTON_AREA_MM2) / 100;


### PR DESCRIPTION
## Summary

Add two Brew Settings controls:

- **Auto Tare**
  - After retraction
  - Before retraction
  - current-selection annotation
  - unavailable state when connected firmware lacks capability support
- **Retraction Distance**
  - replaces the previous Brew/Shot Volume label
  - displays volume in mL
  - supports 80–150 mL in 1 mL increments
  - defaults to 100 mL while settings are loading
  - converts volume to piston distance using the existing 26.5 mm cylinder radius

## Behavior

`After retraction` preserves the original machine workflow. In `Before retraction` mode, liquid that falls into the cup during the initial piston retraction remains part of shot weight, so the shot can begin with positive weight at time zero.

The Auto Tare screen is capability-gated using `tare_behavior_supported` from Device Info.

## Freeze root cause and fix

The first pilot build passed loaded settings directly into the second `useHandleGestures` argument on Retraction Distance. That argument means “ignore gestures,” so all input was discarded once settings loaded. The new Auto Tare screen had the inverse bubble guard and could fail for the same reason.

The final commit corrects both guards:

- Retraction Distance ignores input only until settings exist.
- Auto Tare ignores input only while an overlay intercepts gestures or settings are unavailable.

No backend request was issued during the observed freeze, and the Dial process remained healthy.

## Validation

- `npm run types`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- native ARM64 Tauri release build
- generated production-asset assertions for both gesture guards and the 80 mL minimum / 100 mL default
- installed Dial checksum and service readiness verified on machine serial 003312

## Companion PRs

- Firmware: https://github.com/MeticulousHome/EspressoFirmware/pull/498
- Backend: https://github.com/MeticulousHome/meticulous-backend/pull/391
- Dial: https://github.com/MeticulousHome/meticulous-dial/pull/575
- TypeScript API: https://github.com/MeticulousHome/meticulous-typescript-api/pull/49