### PR TITLE
Integrate reliable Community upload pairing

### DIFF
--- a/Dockerfile.arm64-cross
+++ b/Dockerfile.arm64-cross
@@ -38,5 +38,4 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     PKG_CONFIG_ALLOW_CROSS=1
 WORKDIR /app/src-tauri
 
-CMD bash -c "/root/.cargo/bin/cargo tauri build --target aarch64-unknown-linux-gnu --bundles deb --verbose;\
-    chown -R $(stat -c '%u:%g' /app) /app/;"
+CMD ["bash", "-ec", "cd /app; npm ci --ignore-scripts; cd /app/src-tauri; /root/.cargo/bin/cargo tauri build --target aarch64-unknown-linux-gnu --bundles deb --verbose; owner_group=$(stat -c '%u:%g' /app); chown -R \"$owner_group\" /app/dist /app/src-tauri/target"]

--- a/Dockerfile.arm64-qemu
+++ b/Dockerfile.arm64-qemu
@@ -19,5 +19,4 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN $HOME/.cargo/bin/cargo install tauri-cli --git https://github.com/tauri-apps/tauri
 WORKDIR /app/src-tauri
 
-CMD bash -c "/root/.cargo/bin/cargo tauri build --target aarch64-unknown-linux-gnu --bundles deb --verbose;\
-    chown -R $(stat -c '%u:%g' /app) /app/;"
+CMD ["bash", "-ec", "cd /app; npm ci --ignore-scripts; cd /app/src-tauri; /root/.cargo/bin/cargo tauri build --target aarch64-unknown-linux-gnu --bundles deb --verbose; owner_group=$(stat -c '%u:%g' /app); chown -R \"$owner_group\" /app/dist /app/src-tauri/target"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meticulous-dial",
-  "version": "1.103.0",
+  "version": "1.103.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meticulous-dial",
-      "version": "1.103.0",
+      "version": "1.103.1",
       "license": "MIT",
       "dependencies": {
         "@meticulous-home/espresso-api": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meticulous-dial",
   "productName": "meticulous-dial",
-  "version": "1.103.0",
+  "version": "1.103.1",
   "description": "My Electron application description",
   "main": ".webpack/main",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "tauri": "VITE_SERVER_URL=\"${SERVER_URL}\" tauri",
     "docker:arm64-qemu": "docker build . -t rust_native_compile/arm64 -f Dockerfile.arm64-qemu",
     "docker:arm64-cross": "docker build . -t rust_cross_compile_trixie/arm64 -f Dockerfile.arm64-cross",
-    "package:arm64-qemu": "docker run --platform linux/arm64/v8 --rm -v `pwd`:/app rust_native_compile/arm64",
-    "package:arm64-cross": "docker run --rm -v `pwd`:/app rust_cross_compile_trixie/arm64"
+    "package:arm64-qemu": "docker run --platform linux/arm64/v8 --rm -v `pwd`:/app -v /app/node_modules rust_native_compile/arm64",
+    "package:arm64-cross": "docker run --rm -v `pwd`:/app -v /app/node_modules rust_cross_compile_trixie/arm64"
   },
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "meticulous-dial"
-version = "0.1.0"
+version = "1.103.0"
 dependencies = [
  "base64 0.22.1",
  "byte-unit",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -260,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +561,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +601,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -646,6 +669,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -735,6 +767,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +825,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -941,6 +1010,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1385,8 +1486,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1408,10 +1511,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1690,6 +1796,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2122,6 +2244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,15 +2316,22 @@ dependencies = [
 name = "meticulous-dial"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "byte-unit",
+ "ed25519-dalek",
  "log",
+ "rand_core 0.6.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2769,6 +2904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +3097,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,7 +3190,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -3001,6 +3202,17 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3042,6 +3254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,6 +3275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3145,6 +3372,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3175,6 +3442,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3248,6 +3529,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3477,6 +3793,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,7 +3896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3586,6 +3914,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3683,6 +4020,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +4089,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3900,7 +4253,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4292,6 +4645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,6 +4965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4860,6 +5229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,6 +5292,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5143,6 +5531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5705,6 +6102,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "meticulous-dial"
-version = "1.103.0"
+version = "1.103.1"
 dependencies = [
  "base64 0.22.1",
  "byte-unit",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,3 +26,10 @@ serde_yaml = "0.9"
 tauri-plugin-log = "2.7.1"
 byte-unit = "5.2.0"
 log = "0.4.28"
+base64 = "0.22"
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+sha2 = "0.10"
+url = "2"
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meticulous-dial"
-version = "0.1.0"
+version = "1.103.0"
 description = "Meticulous on-machine Dial Application"
 authors = ["Johanna Schander <mimoja@meticuloushome.com>", "mimoja <coffee@mimoja.de>"]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meticulous-dial"
-version = "1.103.0"
+version = "1.103.1"
 description = "Meticulous on-machine Dial Application"
 authors = ["Johanna Schander <mimoja@meticuloushome.com>", "mimoja <coffee@mimoja.de>"]
 edition = "2024"

--- a/src-tauri/src/community_upload.rs
+++ b/src-tauri/src/community_upload.rs
@@ -26,6 +26,7 @@ const DEFAULT_COMMUNITY_BASE: &str = "https://community.meticuloushome.com";
 const DEFAULT_MACHINE_BASE: &str = "http://localhost:8080";
 const MAX_SHOT_BODY_BYTES: usize = 2 * 1024 * 1024;
 const ENROLLMENT_TTL_SECONDS: i64 = 10 * 60;
+const ENROLLMENT_EXCHANGE_GRACE_SECONDS: i64 = 5 * 60;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -383,19 +384,17 @@ impl CommunityUploadService {
     }
 
     fn expire_local_enrollment(&self) {
-        let expired = {
-            let state = self
-                .inner
-                .state
-                .lock()
-                .expect("community state lock poisoned");
-            state
-                .persistent
-                .enrollment
-                .as_ref()
-                .is_some_and(|value| value.issued_at + ENROLLMENT_TTL_SECONDS < unix_seconds())
-                && state.persistent.key_id.is_none()
-        };
+        let expired =
+            {
+                let state = self
+                    .inner
+                    .state
+                    .lock()
+                    .expect("community state lock poisoned");
+                state.persistent.enrollment.as_ref().is_some_and(|value| {
+                    enrollment_exchange_expired(value.issued_at, unix_seconds())
+                }) && state.persistent.key_id.is_none()
+            };
         if expired {
             let _ = self.mutate_persistent(|state| {
                 state.enrollment = None;
@@ -1432,6 +1431,10 @@ fn unix_seconds() -> i64 {
         .as_secs() as i64
 }
 
+fn enrollment_exchange_expired(issued_at: i64, now: i64) -> bool {
+    issued_at + ENROLLMENT_TTL_SECONDS + ENROLLMENT_EXCHANGE_GRACE_SECONDS <= now
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1499,6 +1502,23 @@ mod tests {
             idempotency_key(vector.installation_id, "shot-vector-001"),
             vector.request.idempotency_key,
         );
+    }
+
+    #[test]
+    fn keeps_an_expired_display_challenge_for_the_bounded_exchange_grace() {
+        let issued_at = 1_000;
+        assert!(!enrollment_exchange_expired(
+            issued_at,
+            issued_at + ENROLLMENT_TTL_SECONDS,
+        ));
+        assert!(!enrollment_exchange_expired(
+            issued_at,
+            issued_at + ENROLLMENT_TTL_SECONDS + ENROLLMENT_EXCHANGE_GRACE_SECONDS - 1,
+        ));
+        assert!(enrollment_exchange_expired(
+            issued_at,
+            issued_at + ENROLLMENT_TTL_SECONDS + ENROLLMENT_EXCHANGE_GRACE_SECONDS,
+        ));
     }
 
     #[test]

--- a/src-tauri/src/community_upload.rs
+++ b/src-tauri/src/community_upload.rs
@@ -1,0 +1,1554 @@
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use ed25519_dalek::{Signer, SigningKey};
+use rand_core::{OsRng, RngCore};
+use reqwest::blocking::{Client, Response};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, RETRY_AFTER};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use url::Url;
+use uuid::Uuid;
+
+const CONTRACT_VERSION: u8 = 1;
+const AUDIENCE: &str = "meticulous-community";
+const EXCHANGE_PATH: &str = "/api/machine-uploads/v1/enrollments/exchange";
+const TOKEN_PATH: &str = "/api/machine-uploads/v1/token";
+const SHOT_PATH: &str = "/api/machine-uploads/v1/shots";
+const REVOKE_PATH: &str = "/api/machine-uploads/v1/installations/current";
+const DEFAULT_COMMUNITY_BASE: &str = "https://community.meticuloushome.com";
+const DEFAULT_MACHINE_BASE: &str = "http://localhost:8080";
+const MAX_SHOT_BODY_BYTES: usize = 2 * 1024 * 1024;
+const ENROLLMENT_TTL_SECONDS: i64 = 10 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EnrollmentState {
+    challenge: String,
+    issued_at: i64,
+    machine_serial: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueuedShot {
+    id: Uuid,
+    source_shot_id: String,
+    history_path: String,
+    body_file: String,
+    attempt_count: u32,
+    next_attempt_at: i64,
+    last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistentState {
+    installation_id: Uuid,
+    private_seed: String,
+    public_key: String,
+    enrollment: Option<EnrollmentState>,
+    authorization_id: Option<Uuid>,
+    key_id: Option<Uuid>,
+    key_version: Option<u32>,
+    paused: bool,
+    history_baselined: bool,
+    history_cursor: Option<String>,
+    queue: Vec<QueuedShot>,
+    last_success_at: Option<i64>,
+    last_error: Option<String>,
+    last_retry_at: Option<i64>,
+}
+
+#[derive(Default)]
+struct VolatileState {
+    access_token: Option<String>,
+    access_token_expires_at: i64,
+    clock_offset_seconds: i64,
+    worker_not_before: i64,
+    worker_failure_count: u32,
+}
+
+struct RuntimeState {
+    persistent: PersistentState,
+    volatile: VolatileState,
+}
+
+#[derive(Clone)]
+pub struct CommunityUploadService {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    state: Mutex<RuntimeState>,
+    state_path: PathBuf,
+    queue_dir: PathBuf,
+    community_base: Url,
+    machine_base: Url,
+    client: Client,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityUploadStatus {
+    state: &'static str,
+    connected: bool,
+    paused: bool,
+    pending_count: usize,
+    last_success_at: Option<i64>,
+    last_error: Option<String>,
+    last_retry_at: Option<i64>,
+    enrollment_expires_at: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityEnrollment {
+    qr_url: String,
+    expires_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExchangeResponse {
+    access_token: String,
+    authorization_id: Uuid,
+    key_id: Uuid,
+    key_version: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenResponse {
+    access_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryEntry {
+    name: Option<String>,
+    url: Option<String>,
+    file: Option<String>,
+}
+
+#[derive(Debug)]
+struct RequestFailure {
+    category: String,
+    retry_after_seconds: Option<i64>,
+    permanent: bool,
+}
+
+impl std::fmt::Display for RequestFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.category)
+    }
+}
+
+impl std::error::Error for RequestFailure {}
+
+impl CommunityUploadService {
+    pub fn new() -> Result<Self, String> {
+        let default_config = if cfg!(debug_assertions) {
+            env::temp_dir().join("meticulous-dial-config")
+        } else {
+            PathBuf::from("/meticulous-user/config")
+        };
+        let root = env::var("CONFIG_PATH")
+            .map(PathBuf::from)
+            .unwrap_or(default_config)
+            .join("community-upload");
+        let queue_dir = root.join("queue");
+        create_private_dir(&root).map_err(safe_error)?;
+        create_private_dir(&queue_dir).map_err(safe_error)?;
+        let state_path = root.join("state.json");
+        let persistent = load_or_create_state(&state_path).map_err(safe_error)?;
+        remove_orphaned_queue_files(&queue_dir, &persistent.queue).map_err(safe_error)?;
+
+        let community_base = Url::parse(
+            &env::var("COMMUNITY_API_BASE").unwrap_or_else(|_| DEFAULT_COMMUNITY_BASE.to_string()),
+        )
+        .map_err(|_| "Invalid COMMUNITY_API_BASE".to_string())?;
+        let machine_base = Url::parse(
+            &env::var("MACHINE_API_BASE").unwrap_or_else(|_| DEFAULT_MACHINE_BASE.to_string()),
+        )
+        .map_err(|_| "Invalid MACHINE_API_BASE".to_string())?;
+        if !matches!(community_base.scheme(), "https" | "http") {
+            return Err("Unsupported Community API scheme".to_string());
+        }
+        if !matches!(machine_base.scheme(), "https" | "http") {
+            return Err("Unsupported machine API scheme".to_string());
+        }
+
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(15))
+            .user_agent("meticulous-dial-community-upload-v1")
+            .build()
+            .map_err(safe_error)?;
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                state: Mutex::new(RuntimeState {
+                    persistent,
+                    volatile: VolatileState::default(),
+                }),
+                state_path,
+                queue_dir,
+                community_base,
+                machine_base,
+                client,
+            }),
+        })
+    }
+
+    pub fn start(&self) {
+        let service = self.clone();
+        thread::spawn(move || {
+            loop {
+                if service.worker_is_ready() {
+                    match service.worker_tick() {
+                        Ok(()) => service.clear_worker_failure_count(),
+                        Err(error) => service.record_worker_failure(&error),
+                    }
+                }
+                thread::sleep(Duration::from_millis(500));
+            }
+        });
+    }
+
+    pub fn status(&self) -> CommunityUploadStatus {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .expect("community state lock poisoned");
+        let connected = state.persistent.key_id.is_some() && state.persistent.key_version.is_some();
+        CommunityUploadStatus {
+            state: if connected && state.persistent.paused {
+                "upload_paused"
+            } else if connected {
+                "connected"
+            } else {
+                "not_connected"
+            },
+            connected,
+            paused: state.persistent.paused,
+            pending_count: state.persistent.queue.len(),
+            last_success_at: state.persistent.last_success_at,
+            last_error: state.persistent.last_error.clone(),
+            last_retry_at: state.persistent.last_retry_at,
+            enrollment_expires_at: state
+                .persistent
+                .enrollment
+                .as_ref()
+                .map(|enrollment| enrollment.issued_at + ENROLLMENT_TTL_SECONDS),
+        }
+    }
+
+    pub fn begin_enrollment(
+        &self,
+        machine_serial: Option<String>,
+    ) -> Result<CommunityEnrollment, String> {
+        let serial = machine_serial
+            .map(|value| value.trim().chars().take(128).collect::<String>())
+            .filter(|value| !value.is_empty());
+        let issued_at = unix_seconds();
+        let mut challenge_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut challenge_bytes);
+        let enrollment = EnrollmentState {
+            challenge: URL_SAFE_NO_PAD.encode(challenge_bytes),
+            issued_at,
+            machine_serial: serial,
+        };
+
+        let (installation_id, public_key) = self.mutate_persistent(|state| {
+            if state.key_id.is_some() {
+                return Err("Community backup is already connected".to_string());
+            }
+            state.enrollment = Some(enrollment.clone());
+            state.last_error = None;
+            Ok((state.installation_id, state.public_key.clone()))
+        })?;
+
+        let payload = json!({
+            "kind": "meticulous-community-enrollment",
+            "contractVersion": CONTRACT_VERSION,
+            "installationId": installation_id,
+            "challenge": enrollment.challenge,
+            "publicKey": public_key,
+            "issuedAt": enrollment.issued_at,
+            "machineSerial": enrollment.machine_serial,
+        });
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).map_err(safe_error)?);
+        let mut qr_url = self.inner.community_base.clone();
+        qr_url.set_path("/my-setup/machine/connect");
+        qr_url.set_query(Some(&format!("enrollment={encoded}")));
+        Ok(CommunityEnrollment {
+            qr_url: qr_url.to_string(),
+            expires_at: issued_at + ENROLLMENT_TTL_SECONDS,
+        })
+    }
+
+    pub fn set_paused(&self, paused: bool) -> Result<(), String> {
+        self.mutate_persistent(|state| {
+            if state.key_id.is_none() {
+                return Err("Community backup is not connected".to_string());
+            }
+            state.paused = paused;
+            state.last_error = None;
+            Ok(())
+        })
+    }
+
+    pub fn disconnect(&self) -> Result<(), String> {
+        let connected = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| "Community state unavailable".to_string())?;
+            state.persistent.key_id.is_some()
+        };
+        if connected {
+            self.revoke_current().map_err(|failure| {
+                self.record_retry(&failure.category, failure.retry_after_seconds.unwrap_or(5));
+                "Could not disconnect from Community. Check the internet connection and try again."
+                    .to_string()
+            })?;
+        }
+
+        self.factory_reset_local()
+    }
+
+    pub fn factory_reset_local(&self) -> Result<(), String> {
+        let queue_files = self.mutate_persistent(|state| {
+            let files = state
+                .queue
+                .iter()
+                .map(|item| item.body_file.clone())
+                .collect::<Vec<_>>();
+            *state = fresh_state()?;
+            Ok(files)
+        })?;
+        for file in queue_files {
+            let _ = fs::remove_file(self.inner.queue_dir.join(file));
+        }
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| "Community state unavailable".to_string())?;
+        state.volatile = VolatileState::default();
+        Ok(())
+    }
+
+    fn worker_tick(&self) -> Result<(), RequestFailure> {
+        self.expire_local_enrollment();
+        let snapshot = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            (
+                state.persistent.enrollment.clone(),
+                state.persistent.key_id,
+                state.persistent.paused,
+            )
+        };
+
+        if snapshot.1.is_none() {
+            if snapshot.0.is_some() {
+                self.try_exchange()?;
+            }
+            return Ok(());
+        }
+        if snapshot.2 {
+            return Ok(());
+        }
+
+        self.observe_new_shots()?;
+        self.upload_next_shot()?;
+        Ok(())
+    }
+
+    fn expire_local_enrollment(&self) {
+        let expired = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .expect("community state lock poisoned");
+            state
+                .persistent
+                .enrollment
+                .as_ref()
+                .is_some_and(|value| value.issued_at + ENROLLMENT_TTL_SECONDS < unix_seconds())
+                && state.persistent.key_id.is_none()
+        };
+        if expired {
+            let _ = self.mutate_persistent(|state| {
+                state.enrollment = None;
+                state.last_error = Some("pairing_code_expired".to_string());
+                Ok(())
+            });
+        }
+    }
+
+    fn try_exchange(&self) -> Result<(), RequestFailure> {
+        let (installation_id, private_seed, enrollment, timestamp) = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            let enrollment = state
+                .persistent
+                .enrollment
+                .clone()
+                .ok_or_else(|| temporary("enrollment_missing"))?;
+            (
+                state.persistent.installation_id,
+                state.persistent.private_seed.clone(),
+                enrollment,
+                unix_seconds() + state.volatile.clock_offset_seconds,
+            )
+        };
+        let body = serde_json::to_vec(&json!({
+            "contractVersion": CONTRACT_VERSION,
+            "installationId": installation_id,
+            "challenge": enrollment.challenge,
+        }))
+        .map_err(|_| permanent("invalid_exchange_body"))?;
+        let headers = enrollment_headers(
+            installation_id,
+            &private_seed,
+            timestamp,
+            EXCHANGE_PATH,
+            &body,
+        )?;
+        let response = self
+            .inner
+            .client
+            .post(self.community_url(EXCHANGE_PATH))
+            .header(CONTENT_TYPE, "application/json")
+            .headers(headers)
+            .body(body)
+            .send()
+            .map_err(|_| temporary("exchange_network"))?;
+        self.update_server_clock(&response);
+        if response.status().as_u16() == 202 {
+            let retry_after = response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<i64>().ok())
+                .unwrap_or(2);
+            self.schedule_worker_after(retry_after);
+            return Ok(());
+        }
+        if !response.status().is_success() {
+            let failure = response_failure(response, "exchange_failed");
+            if failure.permanent {
+                self.mutate_persistent_failure(|state| {
+                    state.enrollment = None;
+                    state.last_error = Some(failure.category.clone());
+                    state.last_retry_at = None;
+                    Ok(())
+                })?;
+            }
+            return Err(failure);
+        }
+        let exchanged = response
+            .json::<ExchangeResponse>()
+            .map_err(|_| temporary("exchange_response_invalid"))?;
+        self.mutate_persistent_failure(|state| {
+            state.authorization_id = Some(exchanged.authorization_id);
+            state.key_id = Some(exchanged.key_id);
+            state.key_version = Some(exchanged.key_version);
+            state.enrollment = None;
+            state.paused = false;
+            state.history_baselined = false;
+            state.history_cursor = None;
+            state.last_error = None;
+            Ok(())
+        })?;
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| temporary("state_unavailable"))?;
+        state.volatile.access_token = Some(exchanged.access_token);
+        state.volatile.access_token_expires_at = unix_seconds() + 240;
+        Ok(())
+    }
+
+    fn observe_new_shots(&self) -> Result<(), RequestFailure> {
+        let (baselined, cursor) = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            (
+                state.persistent.history_baselined,
+                state.persistent.history_cursor.clone(),
+            )
+        };
+        let latest = self.fetch_last_history_path()?;
+        if !baselined {
+            self.mutate_persistent_failure(|state| {
+                state.history_baselined = true;
+                state.history_cursor = latest;
+                Ok(())
+            })?;
+            return Ok(());
+        }
+        let Some(latest_path) = latest else {
+            return Ok(());
+        };
+        if cursor.as_ref().is_some_and(|value| value >= &latest_path) {
+            return Ok(());
+        }
+
+        let paths = self.fetch_history_paths()?;
+        for path in paths {
+            let current_cursor = {
+                self.inner
+                    .state
+                    .lock()
+                    .map_err(|_| temporary("state_unavailable"))?
+                    .persistent
+                    .history_cursor
+                    .clone()
+            };
+            if current_cursor.as_ref().is_some_and(|value| value >= &path) {
+                continue;
+            }
+            match self.queue_history_path(&path) {
+                Ok(()) => {}
+                Err(failure) if failure.permanent => {
+                    self.skip_history_path(&path, &failure.category)?;
+                }
+                Err(failure) => return Err(failure),
+            }
+        }
+        Ok(())
+    }
+
+    fn fetch_last_history_path(&self) -> Result<Option<String>, RequestFailure> {
+        let response = self
+            .inner
+            .client
+            .get(self.machine_url("/api/v1/history/last"))
+            .send()
+            .map_err(|_| temporary("machine_history_unavailable"))?;
+        if response.status().as_u16() == 404 || response.status().as_u16() == 204 {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(temporary("machine_history_unavailable"));
+        }
+        let value = response
+            .json::<Value>()
+            .map_err(|_| temporary("machine_history_invalid"))?;
+        value
+            .get("file")
+            .and_then(Value::as_str)
+            .map(normalize_history_path)
+            .transpose()
+    }
+
+    fn fetch_history_paths(&self) -> Result<Vec<String>, RequestFailure> {
+        let dates = self.fetch_history_entries("/api/v1/history/files/")?;
+        let mut paths = Vec::new();
+        for date in dates {
+            let Some(date_name) = date.name.or(date.url) else {
+                continue;
+            };
+            let date_name = normalize_history_segment(&date_name)?;
+            let entries =
+                self.fetch_history_entries(&format!("/api/v1/history/files/{date_name}"))?;
+            for entry in entries {
+                let Some(file_name) = entry.url.or(entry.name).or(entry.file) else {
+                    continue;
+                };
+                let file_name = normalize_history_segment(&file_name)?;
+                if file_name.contains(".shot.json") {
+                    paths.push(format!("{date_name}/{file_name}"));
+                }
+            }
+        }
+        paths.sort();
+        paths.dedup();
+        Ok(paths)
+    }
+
+    fn fetch_history_entries(&self, path: &str) -> Result<Vec<HistoryEntry>, RequestFailure> {
+        let response = self
+            .inner
+            .client
+            .get(self.machine_url(path))
+            .send()
+            .map_err(|_| temporary("machine_history_unavailable"))?;
+        if !response.status().is_success() {
+            return Err(temporary("machine_history_unavailable"));
+        }
+        response
+            .json::<Vec<HistoryEntry>>()
+            .map_err(|_| temporary("machine_history_invalid"))
+    }
+
+    fn queue_history_path(&self, history_path: &str) -> Result<(), RequestFailure> {
+        let response = self
+            .inner
+            .client
+            .get(self.machine_history_file_url(history_path)?)
+            .send()
+            .map_err(|_| temporary("shot_file_pending"))?;
+        if !response.status().is_success() {
+            return Err(temporary("shot_file_pending"));
+        }
+        let declared = response.content_length().unwrap_or(0);
+        if declared as usize > MAX_SHOT_BODY_BYTES {
+            return Err(permanent("shot_file_too_large"));
+        }
+        let mut raw = Vec::new();
+        response
+            .take((MAX_SHOT_BODY_BYTES + 1) as u64)
+            .read_to_end(&mut raw)
+            .map_err(|_| temporary("shot_file_pending"))?;
+        if raw.len() > MAX_SHOT_BODY_BYTES {
+            return Err(permanent("shot_file_too_large"));
+        }
+        let parsed =
+            serde_json::from_slice::<Value>(&raw).map_err(|_| temporary("shot_file_pending"))?;
+        let source_shot_id = parsed
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty() && value.len() <= 256)
+            .ok_or_else(|| permanent("shot_id_invalid"))?
+            .to_string();
+        if !parsed.get("data").is_some_and(Value::is_array) {
+            return Err(permanent("shot_data_invalid"));
+        }
+        let mut body = Vec::with_capacity(raw.len() + 32);
+        body.extend_from_slice(b"{\"contractVersion\":1,\"shot\":");
+        body.extend_from_slice(&raw);
+        body.push(b'}');
+        if body.len() > MAX_SHOT_BODY_BYTES {
+            return Err(permanent("shot_file_too_large"));
+        }
+
+        let id = Uuid::new_v4();
+        let body_file = format!("{id}.json");
+        let body_path = self.inner.queue_dir.join(&body_file);
+        write_private_file_atomic(&body_path, &body)
+            .map_err(|_| temporary("queue_write_failed"))?;
+        let queued = QueuedShot {
+            id,
+            source_shot_id,
+            history_path: history_path.to_string(),
+            body_file: body_file.clone(),
+            attempt_count: 0,
+            next_attempt_at: unix_seconds(),
+            last_error: None,
+        };
+        if let Err(error) = self.mutate_persistent_failure(|state| {
+            state.queue.push(queued);
+            state.history_cursor = Some(history_path.to_string());
+            state.last_error = None;
+            Ok(())
+        }) {
+            let _ = fs::remove_file(body_path);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn upload_next_shot(&self) -> Result<(), RequestFailure> {
+        let queued = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            state
+                .persistent
+                .queue
+                .iter()
+                .find(|item| item.next_attempt_at <= unix_seconds())
+                .cloned()
+        };
+        let Some(queued) = queued else {
+            return Ok(());
+        };
+        let body_path = self.inner.queue_dir.join(&queued.body_file);
+        let body = match fs::read(&body_path) {
+            Ok(body) => body,
+            Err(_) => {
+                self.drop_queue_item(queued.id, "queued_body_missing")?;
+                return Err(permanent("queued_body_missing"));
+            }
+        };
+        if body.len() > MAX_SHOT_BODY_BYTES {
+            self.drop_queue_item(queued.id, "queued_body_too_large")?;
+            let _ = fs::remove_file(&body_path);
+            return Err(permanent("queued_body_too_large"));
+        }
+        let token = self.ensure_access_token()?;
+        let (installation_id, key_id, key_version, private_seed, timestamp) = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            (
+                state.persistent.installation_id,
+                state
+                    .persistent
+                    .key_id
+                    .ok_or_else(|| permanent("key_missing"))?,
+                state
+                    .persistent
+                    .key_version
+                    .ok_or_else(|| permanent("key_missing"))?,
+                state.persistent.private_seed.clone(),
+                unix_seconds() + state.volatile.clock_offset_seconds,
+            )
+        };
+        let mut headers = signed_headers(
+            key_id,
+            key_version,
+            &private_seed,
+            timestamp,
+            "POST",
+            SHOT_PATH,
+            &body,
+        )?;
+        headers.insert(
+            "x-meticulous-idempotency-key",
+            header_value(&idempotency_key(installation_id, &queued.source_shot_id))?,
+        );
+        let response = self
+            .inner
+            .client
+            .post(self.community_url(SHOT_PATH))
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .headers(headers)
+            .body(body)
+            .send()
+            .map_err(|_| temporary("upload_network"))?;
+        self.update_server_clock(&response);
+        if response.status().is_success() {
+            self.complete_queue_item(queued.id, &body_path)?;
+            return Ok(());
+        }
+        let failure = response_failure(response, "upload_failed");
+        if failure.category == "invalid_access" || failure.category == "expired_request" {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            state.volatile.access_token = None;
+            state.volatile.access_token_expires_at = 0;
+        }
+        if authorization_is_retired(&failure.category) {
+            self.retire_local_authorization(&failure.category)?;
+            return Err(failure);
+        }
+        self.defer_queue_item(&queued, &failure)?;
+        Err(failure)
+    }
+
+    fn ensure_access_token(&self) -> Result<String, RequestFailure> {
+        {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            if state.volatile.access_token_expires_at > unix_seconds() + 20
+                && let Some(token) = &state.volatile.access_token
+            {
+                return Ok(token.clone());
+            }
+        }
+        let (key_id, key_version, private_seed, timestamp) = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            (
+                state
+                    .persistent
+                    .key_id
+                    .ok_or_else(|| permanent("key_missing"))?,
+                state
+                    .persistent
+                    .key_version
+                    .ok_or_else(|| permanent("key_missing"))?,
+                state.persistent.private_seed.clone(),
+                unix_seconds() + state.volatile.clock_offset_seconds,
+            )
+        };
+        let body = b"{\"contractVersion\":1}".to_vec();
+        let headers = signed_headers(
+            key_id,
+            key_version,
+            &private_seed,
+            timestamp,
+            "POST",
+            TOKEN_PATH,
+            &body,
+        )?;
+        let response = self
+            .inner
+            .client
+            .post(self.community_url(TOKEN_PATH))
+            .header(CONTENT_TYPE, "application/json")
+            .headers(headers)
+            .body(body)
+            .send()
+            .map_err(|_| temporary("token_network"))?;
+        self.update_server_clock(&response);
+        if !response.status().is_success() {
+            let failure = response_failure(response, "token_failed");
+            if authorization_is_retired(&failure.category) {
+                self.retire_local_authorization(&failure.category)?;
+            }
+            return Err(failure);
+        }
+        let token = response
+            .json::<TokenResponse>()
+            .map_err(|_| temporary("token_response_invalid"))?
+            .access_token;
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| temporary("state_unavailable"))?;
+        state.volatile.access_token = Some(token.clone());
+        state.volatile.access_token_expires_at = unix_seconds() + 240;
+        Ok(token)
+    }
+
+    fn revoke_current(&self) -> Result<(), RequestFailure> {
+        let token = self.ensure_access_token()?;
+        let (key_id, key_version, private_seed, timestamp) = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| temporary("state_unavailable"))?;
+            (
+                state
+                    .persistent
+                    .key_id
+                    .ok_or_else(|| permanent("key_missing"))?,
+                state
+                    .persistent
+                    .key_version
+                    .ok_or_else(|| permanent("key_missing"))?,
+                state.persistent.private_seed.clone(),
+                unix_seconds() + state.volatile.clock_offset_seconds,
+            )
+        };
+        let body = b"{\"contractVersion\":1}".to_vec();
+        let headers = signed_headers(
+            key_id,
+            key_version,
+            &private_seed,
+            timestamp,
+            "DELETE",
+            REVOKE_PATH,
+            &body,
+        )?;
+        let response = self
+            .inner
+            .client
+            .delete(self.community_url(REVOKE_PATH))
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .headers(headers)
+            .body(body)
+            .send()
+            .map_err(|_| temporary("disconnect_network"))?;
+        self.update_server_clock(&response);
+        if !response.status().is_success() {
+            let failure = response_failure(response, "disconnect_failed");
+            if authorization_is_retired(&failure.category) {
+                return Ok(());
+            }
+            return Err(failure);
+        }
+        Ok(())
+    }
+
+    fn complete_queue_item(&self, id: Uuid, body_path: &Path) -> Result<(), RequestFailure> {
+        self.mutate_persistent_failure(|state| {
+            state.queue.retain(|item| item.id != id);
+            state.last_success_at = Some(unix_seconds());
+            state.last_error = None;
+            state.last_retry_at = None;
+            Ok(())
+        })?;
+        let _ = fs::remove_file(body_path);
+        Ok(())
+    }
+
+    fn defer_queue_item(
+        &self,
+        queued: &QueuedShot,
+        failure: &RequestFailure,
+    ) -> Result<(), RequestFailure> {
+        self.mutate_persistent_failure(|state| {
+            if let Some(item) = state.queue.iter_mut().find(|item| item.id == queued.id) {
+                item.attempt_count = item.attempt_count.saturating_add(1);
+                item.last_error = Some(failure.category.clone());
+                let backoff = failure
+                    .retry_after_seconds
+                    .unwrap_or_else(|| (2_i64.pow(item.attempt_count.min(8))).min(300));
+                item.next_attempt_at = if failure.permanent {
+                    i64::MAX
+                } else {
+                    unix_seconds() + backoff
+                };
+            }
+            state.last_error = Some(failure.category.clone());
+            state.last_retry_at = Some(unix_seconds());
+            Ok(())
+        })
+    }
+
+    fn skip_history_path(&self, history_path: &str, category: &str) -> Result<(), RequestFailure> {
+        self.mutate_persistent_failure(|state| {
+            state.history_cursor = Some(history_path.to_string());
+            state.last_error = Some(safe_category(category));
+            state.last_retry_at = None;
+            Ok(())
+        })
+    }
+
+    fn drop_queue_item(&self, id: Uuid, category: &str) -> Result<(), RequestFailure> {
+        self.mutate_persistent_failure(|state| {
+            state.queue.retain(|item| item.id != id);
+            state.last_error = Some(safe_category(category));
+            state.last_retry_at = None;
+            Ok(())
+        })
+    }
+
+    fn retire_local_authorization(&self, category: &str) -> Result<(), RequestFailure> {
+        self.mutate_persistent_failure(|state| {
+            rotate_identity_preserving_queue(state)?;
+            state.authorization_id = None;
+            state.key_id = None;
+            state.key_version = None;
+            state.enrollment = None;
+            state.paused = false;
+            state.last_error = Some(safe_category(category));
+            state.last_retry_at = None;
+            Ok(())
+        })?;
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| temporary("state_unavailable"))?;
+        state.volatile.access_token = None;
+        state.volatile.access_token_expires_at = 0;
+        Ok(())
+    }
+
+    fn worker_is_ready(&self) -> bool {
+        self.inner
+            .state
+            .lock()
+            .map(|state| state.volatile.worker_not_before <= unix_seconds())
+            .unwrap_or(false)
+    }
+
+    fn schedule_worker_after(&self, delay_seconds: i64) {
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.volatile.worker_not_before = unix_seconds() + delay_seconds.max(1);
+        }
+    }
+
+    fn clear_worker_failure_count(&self) {
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.volatile.worker_failure_count = 0;
+        }
+    }
+
+    fn record_worker_failure(&self, failure: &RequestFailure) {
+        let delay = {
+            let mut state = match self.inner.state.lock() {
+                Ok(state) => state,
+                Err(_) => return,
+            };
+            state.volatile.worker_failure_count =
+                state.volatile.worker_failure_count.saturating_add(1);
+            let backoff = (2_i64.pow(state.volatile.worker_failure_count.min(5))).min(30);
+            let delay = failure.retry_after_seconds.unwrap_or(backoff).max(1);
+            state.volatile.worker_not_before = unix_seconds() + delay;
+            delay
+        };
+        self.record_retry(&failure.category, delay);
+    }
+
+    fn record_retry(&self, category: &str, delay_seconds: i64) {
+        let _ = self.mutate_persistent(|state| {
+            state.last_error = Some(safe_category(category));
+            state.last_retry_at = Some(unix_seconds() + delay_seconds.max(1));
+            Ok(())
+        });
+    }
+
+    fn update_server_clock(&self, response: &Response) {
+        let Some(server_time) = response
+            .headers()
+            .get("x-meticulous-server-time")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<i64>().ok())
+        else {
+            return;
+        };
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.volatile.clock_offset_seconds = server_time - unix_seconds();
+        }
+    }
+
+    fn community_url(&self, path: &str) -> Url {
+        let mut url = self.inner.community_base.clone();
+        url.set_path(path);
+        url.set_query(None);
+        url
+    }
+
+    fn machine_url(&self, path: &str) -> Url {
+        let mut url = self.inner.machine_base.clone();
+        url.set_path(path);
+        url.set_query(None);
+        url
+    }
+
+    fn machine_history_file_url(&self, history_path: &str) -> Result<Url, RequestFailure> {
+        let normalized = normalize_history_path(history_path)?;
+        let mut url = self.inner.machine_base.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| permanent("machine_url_invalid"))?;
+            segments.clear();
+            for segment in ["api", "v1", "history", "files"] {
+                segments.push(segment);
+            }
+            for segment in normalized.split('/') {
+                segments.push(segment);
+            }
+        }
+        Ok(url)
+    }
+
+    fn mutate_persistent<T>(
+        &self,
+        mutate: impl FnOnce(&mut PersistentState) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let mut runtime = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| "Community state unavailable".to_string())?;
+        let mut next = runtime.persistent.clone();
+        let result = mutate(&mut next)?;
+        persist_state(&self.inner.state_path, &next).map_err(safe_error)?;
+        runtime.persistent = next;
+        Ok(result)
+    }
+
+    fn mutate_persistent_failure<T>(
+        &self,
+        mutate: impl FnOnce(&mut PersistentState) -> Result<T, String>,
+    ) -> Result<T, RequestFailure> {
+        self.mutate_persistent(mutate)
+            .map_err(|_| temporary("state_persist_failed"))
+    }
+}
+
+fn fresh_state() -> Result<PersistentState, String> {
+    let mut seed = [0u8; 32];
+    OsRng.fill_bytes(&mut seed);
+    let signing_key = SigningKey::from_bytes(&seed);
+    Ok(PersistentState {
+        installation_id: Uuid::new_v4(),
+        private_seed: URL_SAFE_NO_PAD.encode(seed),
+        public_key: URL_SAFE_NO_PAD.encode(signing_key.verifying_key().to_bytes()),
+        enrollment: None,
+        authorization_id: None,
+        key_id: None,
+        key_version: None,
+        paused: false,
+        history_baselined: false,
+        history_cursor: None,
+        queue: Vec::new(),
+        last_success_at: None,
+        last_error: None,
+        last_retry_at: None,
+    })
+}
+
+fn rotate_identity_preserving_queue(state: &mut PersistentState) -> Result<(), String> {
+    let fresh = fresh_state()?;
+    state.installation_id = fresh.installation_id;
+    state.private_seed = fresh.private_seed;
+    state.public_key = fresh.public_key;
+    Ok(())
+}
+
+fn load_or_create_state(path: &Path) -> Result<PersistentState, Box<dyn std::error::Error>> {
+    if path.exists() {
+        let bytes = fs::read(path)?;
+        let state = serde_json::from_slice::<PersistentState>(&bytes)?;
+        validate_state(&state)?;
+        return Ok(state);
+    }
+    let state = fresh_state().map_err(std::io::Error::other)?;
+    persist_state(path, &state)?;
+    Ok(state)
+}
+
+fn validate_state(state: &PersistentState) -> Result<(), std::io::Error> {
+    let seed = URL_SAFE_NO_PAD
+        .decode(&state.private_seed)
+        .map_err(std::io::Error::other)?;
+    let seed: [u8; 32] = seed
+        .try_into()
+        .map_err(|_| std::io::Error::other("Invalid Community key seed"))?;
+    let expected = SigningKey::from_bytes(&seed).verifying_key().to_bytes();
+    if URL_SAFE_NO_PAD.encode(expected) != state.public_key {
+        return Err(std::io::Error::other("Community key state is inconsistent"));
+    }
+    Ok(())
+}
+
+fn persist_state(path: &Path, state: &PersistentState) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = serde_json::to_vec(state)?;
+    write_private_file_atomic(path, &bytes)?;
+    Ok(())
+}
+
+fn write_private_file_atomic(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("Missing parent directory"))?;
+    create_private_dir(parent)?;
+    let temporary_path = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("state"),
+        Uuid::new_v4(),
+    ));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary_path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    fs::rename(&temporary_path, path)?;
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn create_private_dir(path: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+fn remove_orphaned_queue_files(
+    queue_dir: &Path,
+    queue: &[QueuedShot],
+) -> Result<(), std::io::Error> {
+    let expected = queue
+        .iter()
+        .map(|item| item.body_file.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    for entry in fs::read_dir(queue_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if entry.file_type()?.is_file() && !expected.contains(name.as_ref()) {
+            fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn signed_headers(
+    key_id: Uuid,
+    key_version: u32,
+    private_seed: &str,
+    timestamp: i64,
+    method: &str,
+    path: &str,
+    body: &[u8],
+) -> Result<reqwest::header::HeaderMap, RequestFailure> {
+    let nonce = random_nonce();
+    let request_id = Uuid::new_v4();
+    let digest = sha256_hex(body);
+    let canonical = format!(
+        "meticulous-machine-request-v1\nmethod:{}\npath:{}\naudience:{}\nkey-id:{}\nkey-version:{}\ntimestamp:{}\nnonce:{}\nrequest-id:{}\nbody-sha256:{}\n",
+        method.to_uppercase(),
+        path,
+        AUDIENCE,
+        key_id.to_string().to_lowercase(),
+        key_version,
+        timestamp,
+        nonce,
+        request_id.to_string().to_lowercase(),
+        digest,
+    );
+    let signature = sign_message(private_seed, canonical.as_bytes())?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("x-meticulous-key-id", header_value(&key_id.to_string())?);
+    headers.insert(
+        "x-meticulous-key-version",
+        header_value(&key_version.to_string())?,
+    );
+    headers.insert(
+        "x-meticulous-timestamp",
+        header_value(&timestamp.to_string())?,
+    );
+    headers.insert("x-meticulous-nonce", header_value(&nonce)?);
+    headers.insert(
+        "x-meticulous-request-id",
+        header_value(&request_id.to_string())?,
+    );
+    headers.insert("x-meticulous-signature", header_value(&signature)?);
+    Ok(headers)
+}
+
+fn enrollment_headers(
+    installation_id: Uuid,
+    private_seed: &str,
+    timestamp: i64,
+    path: &str,
+    body: &[u8],
+) -> Result<reqwest::header::HeaderMap, RequestFailure> {
+    let nonce = random_nonce();
+    let request_id = Uuid::new_v4();
+    let digest = sha256_hex(body);
+    let canonical = format!(
+        "meticulous-enrollment-exchange-v1\nmethod:POST\npath:{}\naudience:{}\ninstallation-id:{}\ntimestamp:{}\nnonce:{}\nrequest-id:{}\nbody-sha256:{}\n",
+        path,
+        AUDIENCE,
+        installation_id.to_string().to_lowercase(),
+        timestamp,
+        nonce,
+        request_id.to_string().to_lowercase(),
+        digest,
+    );
+    let signature = sign_message(private_seed, canonical.as_bytes())?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "x-meticulous-installation-id",
+        header_value(&installation_id.to_string())?,
+    );
+    headers.insert(
+        "x-meticulous-timestamp",
+        header_value(&timestamp.to_string())?,
+    );
+    headers.insert("x-meticulous-nonce", header_value(&nonce)?);
+    headers.insert(
+        "x-meticulous-request-id",
+        header_value(&request_id.to_string())?,
+    );
+    headers.insert("x-meticulous-signature", header_value(&signature)?);
+    Ok(headers)
+}
+
+fn sign_message(private_seed: &str, message: &[u8]) -> Result<String, RequestFailure> {
+    let seed = URL_SAFE_NO_PAD
+        .decode(private_seed)
+        .map_err(|_| permanent("private_key_invalid"))?;
+    let seed: [u8; 32] = seed
+        .try_into()
+        .map_err(|_| permanent("private_key_invalid"))?;
+    let signature = SigningKey::from_bytes(&seed).sign(message);
+    Ok(URL_SAFE_NO_PAD.encode(signature.to_bytes()))
+}
+
+fn response_failure(response: Response, fallback: &str) -> RequestFailure {
+    let status = response.status();
+    let retry_after_seconds = response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<i64>().ok());
+    let category = response
+        .json::<ErrorResponse>()
+        .ok()
+        .and_then(|value| value.error)
+        .map(|value| safe_category(&value))
+        .unwrap_or_else(|| fallback.to_string());
+    RequestFailure {
+        permanent: failure_is_permanent(status.as_u16(), &category),
+        category,
+        retry_after_seconds,
+    }
+}
+
+fn failure_is_permanent(status: u16, category: &str) -> bool {
+    if authorization_is_retired(category) {
+        return true;
+    }
+    if status == 409 {
+        return category != "replayed_request";
+    }
+    (400..500).contains(&status) && !matches!(status, 401 | 408 | 429)
+}
+
+fn authorization_is_retired(category: &str) -> bool {
+    matches!(
+        category,
+        "not_authorized" | "retired_key" | "retired_or_revoked_access"
+    )
+}
+
+fn normalize_history_path(value: &str) -> Result<String, RequestFailure> {
+    let normalized = value.trim().trim_start_matches('/');
+    let segments = normalized
+        .split('/')
+        .map(normalize_history_segment)
+        .collect::<Result<Vec<_>, _>>()?;
+    if segments.len() != 2 {
+        return Err(permanent("history_path_invalid"));
+    }
+    Ok(segments.join("/"))
+}
+
+fn normalize_history_segment(value: &str) -> Result<String, RequestFailure> {
+    let value = value.trim();
+    if value.is_empty()
+        || value == "."
+        || value == ".."
+        || value.contains('/')
+        || value.contains('\\')
+        || value.len() > 255
+    {
+        return Err(permanent("history_path_invalid"));
+    }
+    Ok(value.to_string())
+}
+
+fn idempotency_key(installation_id: Uuid, source_shot_id: &str) -> String {
+    sha256_hex(
+        format!(
+            "meticulous-machine-shot-idempotency-v1\n{}\n{}\n",
+            installation_id.to_string().to_lowercase(),
+            source_shot_id,
+        )
+        .as_bytes(),
+    )
+}
+
+fn random_nonce() -> String {
+    let mut bytes = [0u8; 24];
+    OsRng.fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+fn header_value(value: &str) -> Result<reqwest::header::HeaderValue, RequestFailure> {
+    reqwest::header::HeaderValue::from_str(value).map_err(|_| permanent("header_invalid"))
+}
+
+fn temporary(category: &str) -> RequestFailure {
+    RequestFailure {
+        category: safe_category(category),
+        retry_after_seconds: None,
+        permanent: false,
+    }
+}
+
+fn permanent(category: &str) -> RequestFailure {
+    RequestFailure {
+        category: safe_category(category),
+        retry_after_seconds: None,
+        permanent: true,
+    }
+}
+
+fn safe_category(value: &str) -> String {
+    let filtered = value
+        .chars()
+        .filter(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || *character == '_'
+        })
+        .take(64)
+        .collect::<String>();
+    if filtered.is_empty() {
+        "unknown".to_string()
+    } else {
+        filtered
+    }
+}
+
+fn safe_error(error: impl std::fmt::Display) -> String {
+    let _ = error;
+    "Community upload storage unavailable".to_string()
+}
+
+fn unix_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VECTOR: &str = include_str!("../test-vectors/machine-upload-v1.json");
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Vector {
+        installation_id: Uuid,
+        key_id: Uuid,
+        key_version: u32,
+        private_seed: String,
+        public_key: String,
+        request: VectorRequest,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct VectorRequest {
+        method: String,
+        path: String,
+        timestamp: i64,
+        nonce: String,
+        request_id: Uuid,
+        body: String,
+        body_sha256: String,
+        canonical: String,
+        signature: String,
+        idempotency_key: String,
+    }
+
+    #[test]
+    fn matches_community_cross_language_vector() {
+        let vector: Vector = serde_json::from_str(VECTOR).unwrap();
+        let seed = URL_SAFE_NO_PAD.decode(&vector.private_seed).unwrap();
+        let seed: [u8; 32] = seed.try_into().unwrap();
+        let signing_key = SigningKey::from_bytes(&seed);
+        assert_eq!(
+            URL_SAFE_NO_PAD.encode(signing_key.verifying_key().to_bytes()),
+            vector.public_key,
+        );
+        assert_eq!(
+            sha256_hex(vector.request.body.as_bytes()),
+            vector.request.body_sha256
+        );
+        let canonical = format!(
+            "meticulous-machine-request-v1\nmethod:{}\npath:{}\naudience:{}\nkey-id:{}\nkey-version:{}\ntimestamp:{}\nnonce:{}\nrequest-id:{}\nbody-sha256:{}\n",
+            vector.request.method,
+            vector.request.path,
+            AUDIENCE,
+            vector.key_id,
+            vector.key_version,
+            vector.request.timestamp,
+            vector.request.nonce,
+            vector.request.request_id,
+            vector.request.body_sha256,
+        );
+        assert_eq!(canonical, vector.request.canonical);
+        assert_eq!(
+            URL_SAFE_NO_PAD.encode(signing_key.sign(canonical.as_bytes()).to_bytes()),
+            vector.request.signature,
+        );
+        assert_eq!(
+            idempotency_key(vector.installation_id, "shot-vector-001"),
+            vector.request.idempotency_key,
+        );
+    }
+
+    #[test]
+    fn wraps_raw_shot_without_reserializing_it() {
+        let raw =
+            br#" {"id":"shot-1","data":[{"unknown":true}],"profile":{"future":{"kept":true}}} "#;
+        let mut body = Vec::new();
+        body.extend_from_slice(b"{\"contractVersion\":1,\"shot\":");
+        body.extend_from_slice(raw);
+        body.push(b'}');
+        assert!(body.windows(raw.len()).any(|window| window == raw));
+        let parsed: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["shot"]["profile"]["future"]["kept"], true);
+    }
+
+    #[test]
+    fn rejects_history_path_traversal() {
+        assert!(normalize_history_path("2026-08-15/shot.json.zst").is_ok());
+        assert!(normalize_history_path("../config/secret").is_err());
+        assert!(normalize_history_path("2026-08-15/../../secret").is_err());
+    }
+
+    #[test]
+    fn classifies_idempotency_conflicts_as_permanent() {
+        assert!(failure_is_permanent(409, "idempotency_payload_mismatch"));
+        assert!(!failure_is_permanent(409, "replayed_request"));
+        assert!(failure_is_permanent(401, "retired_or_revoked_access"));
+        assert!(!failure_is_permanent(401, "expired_request"));
+    }
+
+    #[test]
+    fn rotates_revoked_identity_without_losing_queued_shots() {
+        let mut state = fresh_state().expect("fresh state");
+        let prior_installation = state.installation_id;
+        let prior_public_key = state.public_key.clone();
+        state.queue.push(QueuedShot {
+            id: Uuid::new_v4(),
+            source_shot_id: "queued-shot".to_string(),
+            history_path: "2026-08-15/queued.shot.json".to_string(),
+            body_file: "queued.json".to_string(),
+            attempt_count: 2,
+            next_attempt_at: 123,
+            last_error: Some("retired_key".to_string()),
+        });
+
+        rotate_identity_preserving_queue(&mut state).expect("identity rotation");
+
+        assert_ne!(state.installation_id, prior_installation);
+        assert_ne!(state.public_key, prior_public_key);
+        assert_eq!(state.queue.len(), 1);
+        assert_eq!(state.queue[0].source_shot_id, "queued-shot");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,13 @@ use std::fs;
 use std::process::Command;
 use tauri::AppHandle;
 use tauri::Manager;
+use tauri::State;
 
+mod community_upload;
 mod config;
 mod profiles;
+
+use community_upload::{CommunityEnrollment, CommunityUploadService, CommunityUploadStatus};
 
 const DIAL_READY_MARKER: &str = "/run/meticulous-dial-ready";
 const DIAL_HOME_READY_MARKER: &str = "/run/meticulous-dial-home-ready";
@@ -46,6 +50,40 @@ fn get_profiles() -> Result<Vec<serde_json::Value>, String> {
         );
     }
     profiles
+}
+
+#[tauri::command]
+fn community_upload_status(service: State<'_, CommunityUploadService>) -> CommunityUploadStatus {
+    service.status()
+}
+
+#[tauri::command]
+fn community_begin_enrollment(
+    service: State<'_, CommunityUploadService>,
+    machine_serial: Option<String>,
+) -> Result<CommunityEnrollment, String> {
+    service.begin_enrollment(machine_serial)
+}
+
+#[tauri::command]
+fn community_set_upload_paused(
+    service: State<'_, CommunityUploadService>,
+    paused: bool,
+) -> Result<(), String> {
+    service.set_paused(paused)
+}
+
+#[tauri::command]
+async fn community_disconnect(service: State<'_, CommunityUploadService>) -> Result<(), String> {
+    let service = service.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || service.disconnect())
+        .await
+        .map_err(|_| "Community disconnect task failed".to_string())?
+}
+
+#[tauri::command]
+fn community_factory_reset_local(service: State<'_, CommunityUploadService>) -> Result<(), String> {
+    service.factory_reset_local()
 }
 
 fn parse_mem() -> Option<u64> {
@@ -104,10 +142,14 @@ fn show_mem() {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let community_upload =
+        CommunityUploadService::new().expect("failed to initialize Community upload service");
+    community_upload.start();
     std::thread::spawn(|| {
         show_mem();
     });
     tauri::Builder::default()
+        .manage(community_upload)
         .setup(|_app| {
             #[cfg(debug_assertions)]
             {
@@ -130,7 +172,16 @@ pub fn run() {
                 )) // add the terminal (stdout) as log target
                 .build(),
         )
-        .invoke_handler(tauri::generate_handler![ready, home_ready, get_profiles])
+        .invoke_handler(tauri::generate_handler![
+            ready,
+            home_ready,
+            get_profiles,
+            community_upload_status,
+            community_begin_enrollment,
+            community_set_upload_paused,
+            community_disconnect,
+            community_factory_reset_local,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "meticulous-dial",
-  "version": "1.103.0",
+  "version": "1.103.1",
   "identifier": "com.meticulous-dial.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "meticulous-dial",
-  "version": "0.1.0",
+  "version": "1.103.0",
   "identifier": "com.meticulous-dial.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/test-vectors/machine-upload-v1.json
+++ b/src-tauri/test-vectors/machine-upload-v1.json
@@ -1,0 +1,22 @@
+{
+  "contractVersion": 1,
+  "caseId": "ed25519-shot-request-001",
+  "installationId": "11111111-1111-4111-8111-111111111111",
+  "keyId": "22222222-2222-4222-8222-222222222222",
+  "keyVersion": 3,
+  "privateSeed": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
+  "publicKey": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+  "request": {
+    "method": "POST",
+    "path": "/api/machine-uploads/v1/shots",
+    "audience": "meticulous-community",
+    "timestamp": 1786700000,
+    "nonce": "AAECAwQFBgcICQoLDA0ODw",
+    "requestId": "33333333-3333-4333-8333-333333333333",
+    "body": "{\"contractVersion\":1,\"shot\":{\"id\":\"shot-vector-001\",\"time\":1720000000,\"profile_name\":\"Vector\",\"profile\":{\"name\":\"Vector\",\"unknown_future_field\":{\"kept\":true}},\"data\":[{\"time\":0,\"shot\":{\"pressure\":0,\"flow\":0,\"weight\":0}}]}}",
+    "bodySha256": "41dbe46dcd37cbbabb31c326adb363bbcf0070e6fd827a4a0a652d155e071306",
+    "canonical": "meticulous-machine-request-v1\nmethod:POST\npath:/api/machine-uploads/v1/shots\naudience:meticulous-community\nkey-id:22222222-2222-4222-8222-222222222222\nkey-version:3\ntimestamp:1786700000\nnonce:AAECAwQFBgcICQoLDA0ODw\nrequest-id:33333333-3333-4333-8333-333333333333\nbody-sha256:41dbe46dcd37cbbabb31c326adb363bbcf0070e6fd827a4a0a652d155e071306\n",
+    "signature": "fvIdgP7NOYaZDZOU57WfAlklhte9QGw0gExZPBpPJ_1pSyvTwQseEjRTfc-dd_ltPz_o6A_63q4Zm-itVvbADw",
+    "idempotencyKey": "0d688498617229c54549f26102e48d69ba7ec01fb6922c406f6412f802096875"
+  }
+}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -6,6 +6,7 @@ import Api, {
   ManufacturingMenuItems
 } from '@meticulous-home/espresso-api';
 import { DialDeviceInfo } from '../types';
+import { invoke } from '@tauri-apps/api/core';
 
 export const API_URL =
   import.meta.env.VITE_SERVER_URL || 'http://localhost:8080';
@@ -143,6 +144,9 @@ export const updateManufacturingSettings = async (
 // The API package doesn't expose this endpoint
 export const factoryReset = async () => {
   try {
+    if ('__TAURI_INTERNALS__' in window) {
+      await invoke('community_factory_reset_local');
+    }
     const server = API_URL;
     const url = server + `/api/v1/machine/factory_reset?confirm=true`;
 

--- a/src/components/Settings/Community/Community.css
+++ b/src/components/Settings/Community/Community.css
@@ -1,0 +1,80 @@
+.community-screen {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 44px 68px 54px;
+  color: #e7e7e7;
+  text-align: center;
+}
+
+.community-screen h2 {
+  margin: 0;
+  font-family: 'ABC Diatype';
+  font-size: 24px;
+  font-weight: 400;
+}
+
+.community-copy {
+  max-width: 340px;
+  margin: 0;
+  color: #e7e7e7b3;
+  font-family: 'ABC Diatype';
+  font-size: 15px;
+  line-height: 1.25;
+}
+
+.community-qr {
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px;
+}
+
+.community-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+}
+
+.community-action {
+  min-width: 118px;
+  border: 1px solid #e7e7e755;
+  border-radius: 999px;
+  padding: 7px 12px;
+  color: #e7e7e7a6;
+  font-family: 'ABC Diatype';
+  font-size: 15px;
+}
+
+.community-action.active {
+  border-color: #e7e7e7;
+  background: #e7e7e7;
+  color: #171717;
+}
+
+.community-status-grid {
+  width: 300px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px 16px;
+  text-align: left;
+  font-family: 'ABC Diatype';
+  font-size: 15px;
+}
+
+.community-status-grid span:nth-child(odd) {
+  color: #e7e7e799;
+}
+
+.community-error {
+  max-width: 320px;
+  color: #ff7b70;
+  font-family: 'ABC Diatype';
+  font-size: 14px;
+  line-height: 1.25;
+}

--- a/src/components/Settings/Community/Community.css
+++ b/src/components/Settings/Community/Community.css
@@ -1,6 +1,7 @@
 .community-screen {
   --community-optical-offset-x: -16px;
   --community-optical-offset-y: 0px;
+  --community-qr-offset-x: 12px;
   box-sizing: border-box;
   position: absolute;
   top: 50%;
@@ -63,6 +64,7 @@
   border-radius: 8px;
   background: #fff;
   padding: 8px;
+  transform: translateX(var(--community-qr-offset-x));
 }
 
 .community-qr svg {
@@ -83,6 +85,7 @@
   font-family: 'ABC Diatype';
   font-size: 15px;
   line-height: 1.2;
+  transform: translateX(var(--community-qr-offset-x));
 }
 
 .community-actions {

--- a/src/components/Settings/Community/Community.css
+++ b/src/components/Settings/Community/Community.css
@@ -1,54 +1,126 @@
 .community-screen {
+  --community-optical-offset-x: -16px;
+  --community-optical-offset-y: 0px;
   box-sizing: border-box;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 330px;
+  height: 350px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 44px 68px 54px;
+  gap: 8px;
+  padding: 6px 4px;
+  transform: translate(
+    calc(-50% + var(--community-optical-offset-x)),
+    calc(-50% + var(--community-optical-offset-y))
+  );
   color: #e7e7e7;
+  font-family: 'ABC Diatype';
   text-align: center;
 }
 
 .community-screen h2 {
+  max-width: 310px;
   margin: 0;
   font-family: 'ABC Diatype';
   font-size: 24px;
   font-weight: 400;
+  line-height: 1.1;
+}
+
+.community-screen-connect {
+  gap: 6px;
+}
+
+.community-screen-dialog {
+  gap: 14px;
 }
 
 .community-copy {
-  max-width: 340px;
+  max-width: 294px;
   margin: 0;
   color: #e7e7e7b3;
   font-family: 'ABC Diatype';
   font-size: 15px;
-  line-height: 1.25;
+  line-height: 1.2;
+}
+
+.community-expiry,
+.community-gesture-hint {
+  margin: 0;
+  color: #e7e7e799;
+  font-family: 'ABC Diatype';
+  font-size: 13px;
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
 }
 
 .community-qr {
+  display: flex;
   border-radius: 8px;
   background: #fff;
-  padding: 10px;
+  padding: 8px;
 }
 
-.community-actions {
+.community-qr svg {
+  display: block;
+}
+
+.community-qr-placeholder {
+  box-sizing: border-box;
+  width: 192px;
+  height: 192px;
   display: flex;
-  gap: 8px;
   align-items: center;
   justify-content: center;
-}
-
-.community-action {
-  min-width: 118px;
   border: 1px solid #e7e7e755;
-  border-radius: 999px;
-  padding: 7px 12px;
+  border-radius: 8px;
+  padding: 24px;
   color: #e7e7e7a6;
   font-family: 'ABC Diatype';
   font-size: 15px;
+  line-height: 1.2;
+}
+
+.community-actions {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 6px;
+}
+
+.community-actions-single {
+  width: 132px;
+}
+
+.community-actions-two {
+  width: 270px;
+}
+
+.community-actions-three {
+  width: 324px;
+}
+
+.community-action {
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 36px;
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #e7e7e755;
+  border-radius: 999px;
+  padding: 7px 5px;
+  color: #e7e7e7a6;
+  font-family: 'ABC Diatype';
+  font-size: 13px;
+  line-height: 1.05;
 }
 
 .community-action.active {
@@ -58,23 +130,50 @@
 }
 
 .community-status-grid {
-  width: 300px;
+  box-sizing: border-box;
+  width: 310px;
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 8px 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr);
+  gap: 9px 14px;
+  border: 1px solid #e7e7e72e;
+  border-radius: 10px;
+  padding: 14px 16px;
   text-align: left;
   font-family: 'ABC Diatype';
   font-size: 15px;
+  line-height: 1.1;
+}
+
+.community-status-grid span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .community-status-grid span:nth-child(odd) {
   color: #e7e7e799;
 }
 
+.community-success-mark {
+  width: 46px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #7beebf;
+  border-radius: 50%;
+  color: #7beebf;
+  font-size: 25px;
+  line-height: 1;
+}
+
 .community-error {
-  max-width: 320px;
+  max-width: 294px;
+  margin: 0;
   color: #ff7b70;
   font-family: 'ABC Diatype';
-  font-size: 14px;
-  line-height: 1.25;
+  font-size: 12px;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
 }

--- a/src/components/Settings/Community/Community.tsx
+++ b/src/components/Settings/Community/Community.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import QRCode from 'react-qr-code';
 import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
 import { useHandleGestures } from '../../../hooks/useHandleGestures';
@@ -12,11 +12,7 @@ import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
 import { useAppDispatch } from '../../store/hooks';
 import './Community.css';
 
-const COMMUNITY_APP_URL =
-  import.meta.env.VITE_COMMUNITY_APP_URL ||
-  'https://community.meticuloushome.com';
-
-type ScreenMode = 'overview' | 'pairing' | 'connected-success' | 'disconnect';
+type ScreenMode = 'overview' | 'connected-success' | 'disconnect';
 
 function formatTimestamp(value: number | null | undefined): string {
   if (!value) return 'Not yet';
@@ -31,18 +27,30 @@ function readableError(value: string | null | undefined): string {
   return value.replace(/_/g, ' ');
 }
 
+function secondsRemaining(
+  expiresAt: number | null,
+  now: number
+): string | null {
+  if (!expiresAt) return null;
+  const seconds = Math.max(expiresAt - now, 0);
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`;
+}
+
 export function CommunitySettings(): JSX.Element {
   const dispatch = useAppDispatch();
   const statusQuery = useCommunityUploadStatus();
   const beginEnrollment = useBeginCommunityEnrollment();
   const setPaused = useSetCommunityUploadPaused();
   const disconnect = useDisconnectCommunity();
-  const { data: deviceInfo } = useDeviceInfo();
+  const { data: deviceInfo, isPending: deviceInfoPending } = useDeviceInfo();
   const [mode, setMode] = useState<ScreenMode>('overview');
   const [activeAction, setActiveAction] = useState(0);
   const [pairingUrl, setPairingUrl] = useState<string | null>(null);
   const [pairingExpiresAt, setPairingExpiresAt] = useState<number | null>(null);
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  const enrollmentAttempted = useRef(false);
+  const enrollmentInFlight = useRef(false);
+  const pairingWasActive = useRef(false);
 
   const status = statusQuery.data;
   const connected = status?.connected === true;
@@ -54,6 +62,49 @@ export function CommunitySettings(): JSX.Element {
     disconnect.error ||
     statusQuery.error;
 
+  const startEnrollment = useCallback(async () => {
+    if (enrollmentInFlight.current || connected) return;
+
+    enrollmentAttempted.current = true;
+    enrollmentInFlight.current = true;
+    pairingWasActive.current = true;
+    beginEnrollment.reset();
+    setPairingUrl(null);
+    setPairingExpiresAt(null);
+
+    try {
+      const enrollment = await beginEnrollment.mutateAsync(deviceInfo?.serial);
+      setPairingUrl(enrollment.qrUrl);
+      setPairingExpiresAt(enrollment.expiresAt);
+      setNow(Math.floor(Date.now() / 1000));
+    } catch {
+      // The mutation exposes its user-facing error below.
+    } finally {
+      enrollmentInFlight.current = false;
+    }
+  }, [beginEnrollment, connected, deviceInfo?.serial]);
+
+  useEffect(() => {
+    if (
+      statusQuery.isPending ||
+      deviceInfoPending ||
+      connected ||
+      pairingUrl ||
+      beginEnrollment.isPending ||
+      enrollmentAttempted.current
+    ) {
+      return;
+    }
+    void startEnrollment();
+  }, [
+    beginEnrollment.isPending,
+    connected,
+    deviceInfoPending,
+    pairingUrl,
+    startEnrollment,
+    statusQuery.isPending
+  ]);
+
   useEffect(() => {
     if (!pairingExpiresAt) return;
     const interval = window.setInterval(
@@ -64,53 +115,58 @@ export function CommunitySettings(): JSX.Element {
   }, [pairingExpiresAt]);
 
   useEffect(() => {
-    if (connected && mode === 'pairing') {
+    if (connected && pairingWasActive.current) {
+      pairingWasActive.current = false;
       setMode('connected-success');
       setPairingUrl(null);
       setPairingExpiresAt(null);
       setActiveAction(0);
     }
-  }, [connected, mode]);
+  }, [connected]);
+
+  useEffect(() => {
+    if (
+      connected ||
+      !pairingExpiresAt ||
+      now < pairingExpiresAt ||
+      beginEnrollment.isPending
+    ) {
+      return;
+    }
+
+    enrollmentAttempted.current = false;
+    setPairingUrl(null);
+    setPairingExpiresAt(null);
+    beginEnrollment.reset();
+  }, [beginEnrollment, connected, now, pairingExpiresAt]);
 
   const actions = useMemo(() => {
-    if (!connected) return ['Connect', 'Back'];
+    if (!connected) {
+      return beginEnrollment.isError ? ['Try again', 'Back'] : ['Back'];
+    }
     return [
       'Back',
       status?.paused ? 'Resume uploads' : 'Pause uploads',
       'Disconnect'
     ];
-  }, [connected, status?.paused]);
+  }, [beginEnrollment.isError, connected, status?.paused]);
 
   const goBack = () => {
     dispatch(setBubbleDisplay({ visible: true, component: 'settings' }));
   };
 
-  const begin = async () => {
-    const enrollment = await beginEnrollment.mutateAsync(deviceInfo?.serial);
-    setPairingUrl(enrollment.qrUrl);
-    setPairingExpiresAt(enrollment.expiresAt);
-    setNow(Math.floor(Date.now() / 1000));
-    setMode('pairing');
-    setActiveAction(0);
-  };
-
   useHandleGestures({
     left() {
-      if (mode === 'pairing' || mode === 'connected-success') return;
+      if (mode === 'connected-success') return;
       setActiveAction((previous) => Math.max(previous - 1, 0));
     },
     right() {
-      if (mode === 'pairing' || mode === 'connected-success') return;
+      if (mode === 'connected-success') return;
       const max = mode === 'disconnect' ? 1 : actions.length - 1;
       setActiveAction((previous) => Math.min(previous + 1, max));
     },
     pressDown() {
       if (busy) return;
-      if (mode === 'pairing') {
-        setMode('overview');
-        setActiveAction(0);
-        return;
-      }
       if (mode === 'connected-success') {
         setMode('overview');
         setActiveAction(0);
@@ -120,6 +176,7 @@ export function CommunitySettings(): JSX.Element {
       if (mode === 'disconnect') {
         if (activeAction === 0) {
           setMode('overview');
+          setActiveAction(0);
           return;
         }
         void disconnect.mutateAsync().then(() => {
@@ -128,9 +185,15 @@ export function CommunitySettings(): JSX.Element {
         });
         return;
       }
+
       const action = actions[activeAction];
-      if (action === 'Connect') {
-        void begin();
+      if (action === 'Try again') {
+        enrollmentAttempted.current = false;
+        pairingWasActive.current = true;
+        setPairingUrl(null);
+        setPairingExpiresAt(null);
+        beginEnrollment.reset();
+        setActiveAction(0);
       } else if (action === 'Pause uploads') {
         void setPaused.mutateAsync(true);
       } else if (action === 'Resume uploads') {
@@ -144,40 +207,21 @@ export function CommunitySettings(): JSX.Element {
     }
   });
 
-  if (mode === 'pairing' && pairingUrl) {
-    const secondsLeft = Math.max((pairingExpiresAt ?? now) - now, 0);
-    return (
-      <div className="community-screen">
-        <h2>Connect to Community</h2>
-        <p className="community-copy">
-          In the Community app, open My Machine and scan this security code.
-        </p>
-        <div className="community-qr">
-          <QRCode value={pairingUrl} width={210} height={210} />
-        </div>
-        <p className="community-copy">
-          Code expires in {Math.floor(secondsLeft / 60)}:
-          {String(secondsLeft % 60).padStart(2, '0')}. Press to go back.
-        </p>
-      </div>
-    );
-  }
-
   if (mode === 'disconnect') {
     return (
-      <div className="community-screen">
+      <div className="community-screen community-screen-dialog">
         <h2>Disconnect Community?</h2>
         <p className="community-copy">
-          Future uploads will stop. Shots already stored in Community will
-          remain in your account.
+          New brews will stop uploading. Brews already in Community will remain
+          in your account.
         </p>
-        <div className="community-actions">
+        <div className="community-actions community-actions-two">
           {['Cancel', 'Disconnect'].map((label, index) => (
             <div
               className={`community-action ${activeAction === index ? 'active' : ''}`}
               key={label}
             >
-              {label}
+              {busy && activeAction === index ? 'Working...' : label}
             </div>
           ))}
         </div>
@@ -188,49 +232,72 @@ export function CommunitySettings(): JSX.Element {
 
   if (mode === 'connected-success') {
     return (
-      <div className="community-screen">
+      <div className="community-screen community-screen-dialog">
+        <div className="community-success-mark" aria-hidden="true">
+          ✓
+        </div>
         <h2>Connected to Community</h2>
         <p className="community-copy">
-          New shots will be uploaded privately to your account.
+          New brews will upload privately to your account.
         </p>
-        <div className="community-actions">
+        <div className="community-actions community-actions-single">
           <div className="community-action active">Done</div>
         </div>
       </div>
     );
   }
 
-  return (
-    <div className="community-screen">
-      <h2>Community</h2>
-      {!connected ? (
-        <>
-          <p className="community-copy">
-            Back up your Profiles and Brews to Meticulous Community. New shots
-            are uploaded privately to your account.
-          </p>
+  if (!connected) {
+    const timeLeft = secondsRemaining(pairingExpiresAt, now);
+    return (
+      <div className="community-screen community-screen-connect">
+        <h2>Connect to Community</h2>
+        <p className="community-copy">Scan this secure code with your phone.</p>
+        {pairingUrl ? (
           <div className="community-qr">
-            <QRCode value={COMMUNITY_APP_URL} width={160} height={160} />
+            <QRCode value={pairingUrl} width={176} height={176} />
           </div>
-          <p className="community-copy">
-            Scan to get the Community app. If you already have it, select
-            Connect.
-          </p>
-        </>
-      ) : (
-        <div className="community-status-grid">
-          <span>Status</span>
-          <span>{status.paused ? 'Upload paused' : 'Connected'}</span>
-          <span>Last upload</span>
-          <span>{formatTimestamp(status.lastSuccessAt)}</span>
-          <span>Pending</span>
-          <span>{status.pendingCount}</span>
-          <span>Retry state</span>
-          <span>{readableError(status.lastError)}</span>
+        ) : (
+          <div className="community-qr-placeholder" role="status">
+            {beginEnrollment.isError
+              ? 'Could not create a secure code'
+              : 'Creating secure code...'}
+          </div>
+        )}
+        <p className="community-expiry">
+          {timeLeft ? `Code expires in ${timeLeft}` : 'Keep this screen open'}
+        </p>
+        <div
+          className={`community-actions ${actions.length === 1 ? 'community-actions-single' : 'community-actions-two'}`}
+        >
+          {actions.map((label, index) => (
+            <div
+              className={`community-action ${activeAction === index ? 'active' : ''}`}
+              key={label}
+            >
+              {busy && activeAction === index ? 'Working...' : label}
+            </div>
+          ))}
         </div>
-      )}
+        {error ? <p className="community-error">{String(error)}</p> : null}
+      </div>
+    );
+  }
 
-      <div className="community-actions">
+  return (
+    <div className="community-screen community-screen-overview">
+      <h2>Community</h2>
+      <div className="community-status-grid">
+        <span>Status</span>
+        <span>{status.paused ? 'Upload paused' : 'Connected'}</span>
+        <span>Last upload</span>
+        <span>{formatTimestamp(status.lastSuccessAt)}</span>
+        <span>Waiting</span>
+        <span>{status.pendingCount}</span>
+        <span>Last error</span>
+        <span>{readableError(status.lastError)}</span>
+      </div>
+      <div className="community-actions community-actions-three">
         {actions.map((label, index) => (
           <div
             className={`community-action ${activeAction === index ? 'active' : ''}`}
@@ -240,6 +307,7 @@ export function CommunitySettings(): JSX.Element {
           </div>
         ))}
       </div>
+      <p className="community-gesture-hint">Turn to choose, press to select</p>
       {error ? <p className="community-error">{String(error)}</p> : null}
     </div>
   );

--- a/src/components/Settings/Community/Community.tsx
+++ b/src/components/Settings/Community/Community.tsx
@@ -54,6 +54,7 @@ export function CommunitySettings(): JSX.Element {
 
   const status = statusQuery.data;
   const connected = status?.connected === true;
+  const pairingExpired = Boolean(pairingExpiresAt && now >= pairingExpiresAt);
   const busy =
     beginEnrollment.isPending || setPaused.isPending || disconnect.isPending;
   const error =
@@ -78,7 +79,7 @@ export function CommunitySettings(): JSX.Element {
       setPairingExpiresAt(enrollment.expiresAt);
       setNow(Math.floor(Date.now() / 1000));
     } catch {
-      // The mutation exposes its user-facing error below.
+      // The mutation exposes a safe user-facing error below.
     } finally {
       enrollmentInFlight.current = false;
     }
@@ -106,13 +107,13 @@ export function CommunitySettings(): JSX.Element {
   ]);
 
   useEffect(() => {
-    if (!pairingExpiresAt) return;
+    if (!pairingExpiresAt || pairingExpired) return;
     const interval = window.setInterval(
       () => setNow(Math.floor(Date.now() / 1000)),
       1000
     );
     return () => window.clearInterval(interval);
-  }, [pairingExpiresAt]);
+  }, [pairingExpired, pairingExpiresAt]);
 
   useEffect(() => {
     if (connected && pairingWasActive.current) {
@@ -124,32 +125,18 @@ export function CommunitySettings(): JSX.Element {
     }
   }, [connected]);
 
-  useEffect(() => {
-    if (
-      connected ||
-      !pairingExpiresAt ||
-      now < pairingExpiresAt ||
-      beginEnrollment.isPending
-    ) {
-      return;
-    }
-
-    enrollmentAttempted.current = false;
-    setPairingUrl(null);
-    setPairingExpiresAt(null);
-    beginEnrollment.reset();
-  }, [beginEnrollment, connected, now, pairingExpiresAt]);
-
   const actions = useMemo(() => {
     if (!connected) {
-      return beginEnrollment.isError ? ['Try again', 'Back'] : ['Back'];
+      return beginEnrollment.isError || pairingExpired
+        ? ['Try again', 'Back']
+        : ['Back'];
     }
     return [
       'Back',
       status?.paused ? 'Resume uploads' : 'Pause uploads',
       'Disconnect'
     ];
-  }, [beginEnrollment.isError, connected, status?.paused]);
+  }, [beginEnrollment.isError, connected, pairingExpired, status?.paused]);
 
   const goBack = () => {
     dispatch(setBubbleDisplay({ visible: true, component: 'settings' }));
@@ -252,20 +239,28 @@ export function CommunitySettings(): JSX.Element {
     return (
       <div className="community-screen community-screen-connect">
         <h2>Connect to Community</h2>
-        <p className="community-copy">Scan this secure code with your phone.</p>
-        {pairingUrl ? (
+        <p className="community-copy">
+          Scan with your phone to open or install Community.
+        </p>
+        {pairingUrl && !pairingExpired ? (
           <div className="community-qr">
             <QRCode value={pairingUrl} width={176} height={176} />
           </div>
         ) : (
           <div className="community-qr-placeholder" role="status">
-            {beginEnrollment.isError
-              ? 'Could not create a secure code'
-              : 'Creating secure code...'}
+            {pairingExpired
+              ? 'Secure code expired'
+              : beginEnrollment.isError
+                ? 'Could not create a secure code'
+                : 'Creating secure code...'}
           </div>
         )}
         <p className="community-expiry">
-          {timeLeft ? `Code expires in ${timeLeft}` : 'Keep this screen open'}
+          {pairingExpired
+            ? 'Choose Try again for a new code'
+            : timeLeft
+              ? `Code expires in ${timeLeft}`
+              : 'Keep this screen open'}
         </p>
         <div
           className={`community-actions ${actions.length === 1 ? 'community-actions-single' : 'community-actions-two'}`}

--- a/src/components/Settings/Community/Community.tsx
+++ b/src/components/Settings/Community/Community.tsx
@@ -16,7 +16,7 @@ const COMMUNITY_APP_URL =
   import.meta.env.VITE_COMMUNITY_APP_URL ||
   'https://community.meticuloushome.com';
 
-type ScreenMode = 'overview' | 'pairing' | 'disconnect';
+type ScreenMode = 'overview' | 'pairing' | 'connected-success' | 'disconnect';
 
 function formatTimestamp(value: number | null | undefined): string {
   if (!value) return 'Not yet';
@@ -64,20 +64,20 @@ export function CommunitySettings(): JSX.Element {
   }, [pairingExpiresAt]);
 
   useEffect(() => {
-    if (connected) {
-      setMode('overview');
+    if (connected && mode === 'pairing') {
+      setMode('connected-success');
       setPairingUrl(null);
       setPairingExpiresAt(null);
       setActiveAction(0);
     }
-  }, [connected]);
+  }, [connected, mode]);
 
   const actions = useMemo(() => {
     if (!connected) return ['Connect', 'Back'];
     return [
+      'Back',
       status?.paused ? 'Resume uploads' : 'Pause uploads',
-      'Disconnect',
-      'Back'
+      'Disconnect'
     ];
   }, [connected, status?.paused]);
 
@@ -96,11 +96,11 @@ export function CommunitySettings(): JSX.Element {
 
   useHandleGestures({
     left() {
-      if (mode === 'pairing') return;
+      if (mode === 'pairing' || mode === 'connected-success') return;
       setActiveAction((previous) => Math.max(previous - 1, 0));
     },
     right() {
-      if (mode === 'pairing') return;
+      if (mode === 'pairing' || mode === 'connected-success') return;
       const max = mode === 'disconnect' ? 1 : actions.length - 1;
       setActiveAction((previous) => Math.min(previous + 1, max));
     },
@@ -109,6 +109,12 @@ export function CommunitySettings(): JSX.Element {
       if (mode === 'pairing') {
         setMode('overview');
         setActiveAction(0);
+        return;
+      }
+      if (mode === 'connected-success') {
+        setMode('overview');
+        setActiveAction(0);
+        goBack();
         return;
       }
       if (mode === 'disconnect') {
@@ -176,6 +182,20 @@ export function CommunitySettings(): JSX.Element {
           ))}
         </div>
         {error ? <p className="community-error">{String(error)}</p> : null}
+      </div>
+    );
+  }
+
+  if (mode === 'connected-success') {
+    return (
+      <div className="community-screen">
+        <h2>Connected to Community</h2>
+        <p className="community-copy">
+          New shots will be uploaded privately to your account.
+        </p>
+        <div className="community-actions">
+          <div className="community-action active">Done</div>
+        </div>
       </div>
     );
   }

--- a/src/components/Settings/Community/Community.tsx
+++ b/src/components/Settings/Community/Community.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useMemo, useState } from 'react';
+import QRCode from 'react-qr-code';
+import { useDeviceInfo } from '../../../hooks/useDeviceOSStatus';
+import { useHandleGestures } from '../../../hooks/useHandleGestures';
+import {
+  useBeginCommunityEnrollment,
+  useCommunityUploadStatus,
+  useDisconnectCommunity,
+  useSetCommunityUploadPaused
+} from '../../../hooks/useCommunityUpload';
+import { setBubbleDisplay } from '../../store/features/screens/screens-slice';
+import { useAppDispatch } from '../../store/hooks';
+import './Community.css';
+
+const COMMUNITY_APP_URL =
+  import.meta.env.VITE_COMMUNITY_APP_URL ||
+  'https://community.meticuloushome.com';
+
+type ScreenMode = 'overview' | 'pairing' | 'disconnect';
+
+function formatTimestamp(value: number | null | undefined): string {
+  if (!value) return 'Not yet';
+  return new Date(value * 1000).toLocaleString([], {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function readableError(value: string | null | undefined): string {
+  if (!value) return 'None';
+  return value.replace(/_/g, ' ');
+}
+
+export function CommunitySettings(): JSX.Element {
+  const dispatch = useAppDispatch();
+  const statusQuery = useCommunityUploadStatus();
+  const beginEnrollment = useBeginCommunityEnrollment();
+  const setPaused = useSetCommunityUploadPaused();
+  const disconnect = useDisconnectCommunity();
+  const { data: deviceInfo } = useDeviceInfo();
+  const [mode, setMode] = useState<ScreenMode>('overview');
+  const [activeAction, setActiveAction] = useState(0);
+  const [pairingUrl, setPairingUrl] = useState<string | null>(null);
+  const [pairingExpiresAt, setPairingExpiresAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  const status = statusQuery.data;
+  const connected = status?.connected === true;
+  const busy =
+    beginEnrollment.isPending || setPaused.isPending || disconnect.isPending;
+  const error =
+    beginEnrollment.error ||
+    setPaused.error ||
+    disconnect.error ||
+    statusQuery.error;
+
+  useEffect(() => {
+    if (!pairingExpiresAt) return;
+    const interval = window.setInterval(
+      () => setNow(Math.floor(Date.now() / 1000)),
+      1000
+    );
+    return () => window.clearInterval(interval);
+  }, [pairingExpiresAt]);
+
+  useEffect(() => {
+    if (connected) {
+      setMode('overview');
+      setPairingUrl(null);
+      setPairingExpiresAt(null);
+      setActiveAction(0);
+    }
+  }, [connected]);
+
+  const actions = useMemo(() => {
+    if (!connected) return ['Connect', 'Back'];
+    return [
+      status?.paused ? 'Resume uploads' : 'Pause uploads',
+      'Disconnect',
+      'Back'
+    ];
+  }, [connected, status?.paused]);
+
+  const goBack = () => {
+    dispatch(setBubbleDisplay({ visible: true, component: 'settings' }));
+  };
+
+  const begin = async () => {
+    const enrollment = await beginEnrollment.mutateAsync(deviceInfo?.serial);
+    setPairingUrl(enrollment.qrUrl);
+    setPairingExpiresAt(enrollment.expiresAt);
+    setNow(Math.floor(Date.now() / 1000));
+    setMode('pairing');
+    setActiveAction(0);
+  };
+
+  useHandleGestures({
+    left() {
+      if (mode === 'pairing') return;
+      setActiveAction((previous) => Math.max(previous - 1, 0));
+    },
+    right() {
+      if (mode === 'pairing') return;
+      const max = mode === 'disconnect' ? 1 : actions.length - 1;
+      setActiveAction((previous) => Math.min(previous + 1, max));
+    },
+    pressDown() {
+      if (busy) return;
+      if (mode === 'pairing') {
+        setMode('overview');
+        setActiveAction(0);
+        return;
+      }
+      if (mode === 'disconnect') {
+        if (activeAction === 0) {
+          setMode('overview');
+          return;
+        }
+        void disconnect.mutateAsync().then(() => {
+          setMode('overview');
+          setActiveAction(0);
+        });
+        return;
+      }
+      const action = actions[activeAction];
+      if (action === 'Connect') {
+        void begin();
+      } else if (action === 'Pause uploads') {
+        void setPaused.mutateAsync(true);
+      } else if (action === 'Resume uploads') {
+        void setPaused.mutateAsync(false);
+      } else if (action === 'Disconnect') {
+        setMode('disconnect');
+        setActiveAction(0);
+      } else if (action === 'Back') {
+        goBack();
+      }
+    }
+  });
+
+  if (mode === 'pairing' && pairingUrl) {
+    const secondsLeft = Math.max((pairingExpiresAt ?? now) - now, 0);
+    return (
+      <div className="community-screen">
+        <h2>Connect to Community</h2>
+        <p className="community-copy">
+          In the Community app, open My Machine and scan this security code.
+        </p>
+        <div className="community-qr">
+          <QRCode value={pairingUrl} width={210} height={210} />
+        </div>
+        <p className="community-copy">
+          Code expires in {Math.floor(secondsLeft / 60)}:
+          {String(secondsLeft % 60).padStart(2, '0')}. Press to go back.
+        </p>
+      </div>
+    );
+  }
+
+  if (mode === 'disconnect') {
+    return (
+      <div className="community-screen">
+        <h2>Disconnect Community?</h2>
+        <p className="community-copy">
+          Future uploads will stop. Shots already stored in Community will
+          remain in your account.
+        </p>
+        <div className="community-actions">
+          {['Cancel', 'Disconnect'].map((label, index) => (
+            <div
+              className={`community-action ${activeAction === index ? 'active' : ''}`}
+              key={label}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+        {error ? <p className="community-error">{String(error)}</p> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="community-screen">
+      <h2>Community</h2>
+      {!connected ? (
+        <>
+          <p className="community-copy">
+            Back up your Profiles and Brews to Meticulous Community. New shots
+            are uploaded privately to your account.
+          </p>
+          <div className="community-qr">
+            <QRCode value={COMMUNITY_APP_URL} width={160} height={160} />
+          </div>
+          <p className="community-copy">
+            Scan to get the Community app. If you already have it, select
+            Connect.
+          </p>
+        </>
+      ) : (
+        <div className="community-status-grid">
+          <span>Status</span>
+          <span>{status.paused ? 'Upload paused' : 'Connected'}</span>
+          <span>Last upload</span>
+          <span>{formatTimestamp(status.lastSuccessAt)}</span>
+          <span>Pending</span>
+          <span>{status.pendingCount}</span>
+          <span>Retry state</span>
+          <span>{readableError(status.lastError)}</span>
+        </div>
+      )}
+
+      <div className="community-actions">
+        {actions.map((label, index) => (
+          <div
+            className={`community-action ${activeAction === index ? 'active' : ''}`}
+            key={label}
+          >
+            {busy && activeAction === index ? 'Working...' : label}
+          </div>
+        ))}
+      </div>
+      {error ? <p className="community-error">{String(error)}</p> : null}
+    </div>
+  );
+}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -15,11 +15,17 @@ import type { SettingsItem } from '../../types';
 import Styled, { VIEWPORT_HEIGHT } from '../../styles/utils/mixins';
 import { calculateOptionPosition } from '../../styles/utils/calculateOptionPosition';
 import type { Settings } from '@meticulous-home/espresso-api';
+import { useCommunityUploadStatus } from '../../hooks/useCommunityUpload';
 
 const initialSettings: SettingsItem[] = [
   {
     key: 'device_info',
     label: 'Device Info',
+    visible: true
+  },
+  {
+    key: 'community',
+    label: 'Community',
     visible: true
   },
   {
@@ -59,6 +65,7 @@ export function Settings(): JSX.Element {
   const [activeIndex, setActiveIndex] = useState(0);
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const updateSettings = useUpdateSettings();
+  const communityStatus = useCommunityUploadStatus();
 
   const updatedSettings = useMemo(() => {
     if (!isSuccess) {
@@ -68,11 +75,20 @@ export function Settings(): JSX.Element {
     }
     return initialSettings.map((item) => ({
       ...item,
-      label: item.getLabel
-        ? `${item.label}: ${item.getLabel(globalSettings)}`
-        : item.label
+      label:
+        item.key === 'community'
+          ? `Community: ${
+              communityStatus.data?.state === 'connected'
+                ? 'Connected'
+                : communityStatus.data?.state === 'upload_paused'
+                  ? 'Upload paused'
+                  : 'Not connected'
+            }`
+          : item.getLabel
+            ? `${item.label}: ${item.getLabel(globalSettings)}`
+            : item.label
     }));
-  }, [globalSettings, isSuccess]);
+  }, [communityStatus.data?.state, globalSettings, isSuccess]);
 
   useHandleGestures(
     {
@@ -95,6 +111,12 @@ export function Settings(): JSX.Element {
           case 'advanced': {
             dispatch(
               setBubbleDisplay({ visible: true, component: 'advancedSettings' })
+            );
+            break;
+          }
+          case 'community': {
+            dispatch(
+              setBubbleDisplay({ visible: true, component: 'community' })
             );
             break;
           }

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -17,6 +17,7 @@ export type ScreenType =
   | 'dose'
   | 'output'
   | 'settings'
+  | 'community'
   | 'timeDate'
   | 'timeZoneConfig'
   | 'notifications'

--- a/src/hooks/useCommunityUpload.ts
+++ b/src/hooks/useCommunityUpload.ts
@@ -1,0 +1,71 @@
+import { invoke } from '@tauri-apps/api/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const COMMUNITY_UPLOAD_STATUS_QUERY_KEY = 'community-upload-status';
+
+export type CommunityConnectionState =
+  | 'not_connected'
+  | 'connected'
+  | 'upload_paused';
+
+export interface CommunityUploadStatus {
+  state: CommunityConnectionState;
+  connected: boolean;
+  paused: boolean;
+  pendingCount: number;
+  lastSuccessAt: number | null;
+  lastError: string | null;
+  lastRetryAt: number | null;
+  enrollmentExpiresAt: number | null;
+}
+
+export interface CommunityEnrollment {
+  qrUrl: string;
+  expiresAt: number;
+}
+
+export function useCommunityUploadStatus() {
+  return useQuery({
+    queryKey: [COMMUNITY_UPLOAD_STATUS_QUERY_KEY],
+    queryFn: () => invoke<CommunityUploadStatus>('community_upload_status'),
+    refetchInterval: 1000,
+    retry: false
+  });
+}
+
+export function useBeginCommunityEnrollment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (machineSerial?: string) =>
+      invoke<CommunityEnrollment>('community_begin_enrollment', {
+        machineSerial: machineSerial || null
+      }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: [COMMUNITY_UPLOAD_STATUS_QUERY_KEY]
+      })
+  });
+}
+
+export function useSetCommunityUploadPaused() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (paused: boolean) =>
+      invoke<void>('community_set_upload_paused', { paused }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: [COMMUNITY_UPLOAD_STATUS_QUERY_KEY]
+      })
+  });
+}
+
+export function useDisconnectCommunity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => invoke<void>('community_disconnect'),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: [COMMUNITY_UPLOAD_STATUS_QUERY_KEY]
+      })
+  });
+}

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -62,6 +62,7 @@ import {
   UnlockMasterCalibration
 } from '../components/UnlockScreen/UnlockScreen';
 import { InfoQRCode } from '../components/Settings/Advanced/InfoQrCode';
+import { CommunitySettings } from '../components/Settings/Community/Community';
 
 interface Route {
   component: ComponentType;
@@ -150,6 +151,11 @@ export const routes: Record<ScreenType, Route> = {
   settings: {
     component: Settings,
     title: 'settings',
+    bottomStatusHidden: true
+  },
+  community: {
+    component: CommunitySettings,
+    title: 'Community',
     bottomStatusHidden: true
   },
   profileHome: {

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -66,7 +66,7 @@ export const dataTypes: Record<DataTypeKey | ExtraSettingType, DataType> = {
     maxValue: 12,
     axisLabelStep: 2,
     unit: 'bar',
-    color: colorDataBlueLight,
+    color: colorDataGreenLight,
     precision: 1
   },
   flow: {
@@ -75,7 +75,7 @@ export const dataTypes: Record<DataTypeKey | ExtraSettingType, DataType> = {
     maxValue: 12,
     axisLabelStep: 2,
     unit: 'ml/s',
-    color: colorDataGreenLight,
+    color: colorDataBlueLight,
     precision: 1
   }
 };


### PR DESCRIPTION
## What changed

- combines the physical-display Community redesign with hardened enrollment behavior
- makes Back the safe default after connection and keeps Pause and Disconnect explicit
- shows QR expiration and retry states without silently replacing the code
- shifts the secure QR code 12 pixels right for the physical display
- retains the signed upload queue and enrollment exchange grace period
- releases the integrated Dial package as version 1.103.1

## Why

This combines both Dial-side implementations so the near-real-time upload flow and the revised one-QR onboarding ship together. The latest adjustment centers the QR code on the offset physical display.

## Validation

- installed version 1.103.1 on a physical Meticulous and confirmed the service remained ready
- frontend lint passed
- frontend production build passed
- six Community upload Rust tests passed
- ARM64 Debian package built and checksum verified
- installer validation passed
- all Community states were inspected against the physical Dial display

This remains a draft until physical-machine testing and feedback are complete.
