### PR TITLE
Add first-class Free Pour and repeatable pour-over profiles

### DIFF
--- a/scripts/collect-free-pour-logs.sh
+++ b/scripts/collect-free-pour-logs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TARGET="${TARGET:-root@192.168.10.142}"
+SINCE="${SINCE:-30 minutes ago}"
+OUTPUT_DIR="${1:-free-pour-logs-$(date -u +%Y%m%dT%H%M%SZ)}"
+CONTROL_PATH="/tmp/md-freepour-logs-%C"
+
+SSH_OPTIONS=(
+  -o ConnectTimeout=10
+  -o StrictHostKeyChecking=accept-new
+  -o ControlMaster=auto
+  -o ControlPersist=120
+  -o ControlPath="${CONTROL_PATH}"
+)
+
+close_connection() {
+  ssh "${SSH_OPTIONS[@]}" -O exit "${TARGET}" >/dev/null 2>&1 || true
+}
+trap close_connection EXIT
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "Collecting Free Pour logs from ${TARGET} since '${SINCE}'..."
+
+ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
+  journalctl -u meticulous-dial.service --since "${SINCE}" \
+  --no-pager -o short-iso-precise > "${OUTPUT_DIR}/meticulous-dial.log"
+
+ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
+  journalctl -u meticulous-backend.service --since "${SINCE}" \
+  --no-pager -o short-iso-precise > "${OUTPUT_DIR}/meticulous-backend.log"
+
+ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
+  journalctl -u meticulous-dial.service -u meticulous-backend.service \
+  --since "${SINCE}" --no-pager -o short-iso-precise \
+  > "${OUTPUT_DIR}/combined.log"
+
+ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
+  systemctl show meticulous-dial.service meticulous-backend.service \
+  --property=Id,ActiveState,SubState,MainPID,NRestarts,ExecMainStartTimestamp \
+  > "${OUTPUT_DIR}/service-status.txt"
+
+echo "Logs saved to ${OUTPUT_DIR}"

--- a/scripts/collect-free-pour-logs.sh
+++ b/scripts/collect-free-pour-logs.sh
@@ -6,6 +6,7 @@ TARGET="${TARGET:-root@192.168.10.142}"
 SINCE="${SINCE:-30 minutes ago}"
 OUTPUT_DIR="${1:-free-pour-logs-$(date -u +%Y%m%dT%H%M%SZ)}"
 CONTROL_PATH="/tmp/md-freepour-logs-%C"
+printf -v REMOTE_SINCE '%q' "${SINCE}"
 
 SSH_OPTIONS=(
   -o ConnectTimeout=10
@@ -25,21 +26,19 @@ mkdir -p "${OUTPUT_DIR}"
 echo "Collecting Free Pour logs from ${TARGET} since '${SINCE}'..."
 
 ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
-  journalctl -u meticulous-dial.service --since "${SINCE}" \
-  --no-pager -o short-iso-precise > "${OUTPUT_DIR}/meticulous-dial.log"
+  "journalctl -u meticulous-dial.service --since ${REMOTE_SINCE} --no-pager -o short-iso-precise" \
+  > "${OUTPUT_DIR}/meticulous-dial.log"
 
 ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
-  journalctl -u meticulous-backend.service --since "${SINCE}" \
-  --no-pager -o short-iso-precise > "${OUTPUT_DIR}/meticulous-backend.log"
+  "journalctl -u meticulous-backend.service --since ${REMOTE_SINCE} --no-pager -o short-iso-precise" \
+  > "${OUTPUT_DIR}/meticulous-backend.log"
 
 ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
-  journalctl -u meticulous-dial.service -u meticulous-backend.service \
-  --since "${SINCE}" --no-pager -o short-iso-precise \
+  "journalctl -u meticulous-dial.service -u meticulous-backend.service --since ${REMOTE_SINCE} --no-pager -o short-iso-precise" \
   > "${OUTPUT_DIR}/combined.log"
 
 ssh "${SSH_OPTIONS[@]}" "${TARGET}" \
-  systemctl show meticulous-dial.service meticulous-backend.service \
-  --property=Id,ActiveState,SubState,MainPID,NRestarts,ExecMainStartTimestamp \
+  "systemctl show meticulous-dial.service meticulous-backend.service --property=Id,ActiveState,SubState,MainPID,NRestarts,ExecMainStartTimestamp" \
   > "${OUTPUT_DIR}/service-status.txt"
 
 echo "Logs saved to ${OUTPUT_DIR}"

--- a/src/components/ProfileHomeScreen/CircleOverlay.tsx
+++ b/src/components/ProfileHomeScreen/CircleOverlay.tsx
@@ -29,10 +29,12 @@ const CircleText = styled.div`
 
 export function CircleOverlay({
   shouldAnimate,
-  onAnimationFinished
+  onAnimationFinished,
+  hoverState
 }: {
   shouldAnimate: boolean;
   onAnimationFinished?: () => void;
+  hoverState?: boolean;
 }) {
   // Circle configuration
   const stroke = 5;
@@ -60,6 +62,7 @@ export function CircleOverlay({
   }
 
   const { localHoverState } = useProfileContext();
+  const isHovered = hoverState ?? localHoverState;
 
   useEffect(() => {
     if (!isDrawn) {
@@ -77,7 +80,7 @@ export function CircleOverlay({
   // Reset the circle if we zoom out
   useEffect(() => {
     setWasLetGo(false);
-  }, [localHoverState]);
+  }, [isHovered]);
 
   return (
     <>
@@ -111,9 +114,7 @@ export function CircleOverlay({
       </svg>
       <CircleText
         className={
-          localHoverState && wasLetGo && !shouldAnimate
-            ? 'animateTextOpacityUp'
-            : ''
+          isHovered && wasLetGo && !shouldAnimate ? 'animateTextOpacityUp' : ''
         }
         onAnimationEnd={() => setWasLetGo(false)}
       >

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -23,6 +23,7 @@ import { loadProfileData, startProfile } from '../../api/profile';
 import { DownloadIcon } from './DownloadIcon';
 import { useSocket } from '../store/SocketManager';
 import { invoke } from '@tauri-apps/api/core';
+import { FreePourIcon } from '../../features/freePour/FreePourIcon';
 
 const CARD_GAP = 79;
 const CARD_SIZE = PROFILE_ENTRY_SIZE + CARD_GAP;
@@ -78,8 +79,8 @@ export const ProfileHomeScreen = () => {
   const profileState = useProfileContext();
 
   const {
-    localProfileIndex: activeOption,
-    setLocalProfileIndex: setActiveOption,
+    setLocalProfileIndex: setActiveProfileOption,
+    setHomeMode,
     profileStarting,
     setProfileStarting,
     localHoverState,
@@ -90,6 +91,10 @@ export const ProfileHomeScreen = () => {
 
   const [transitionDirection, setTransitionDirection] =
     useState<dialDirection>('none');
+  // Free Pour is intentionally the first/default home option. ProfileContext
+  // remains profile-only, keeping this mode independent from espresso uploads.
+  const [activeOption, setActiveOption] = useState(0);
+  const [homeHoverState, setHomeHoverState] = useState(false);
   const [isPressingDown, setIsPressingDown] = useState(false);
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
   const homeReadyReported = useRef(false);
@@ -106,8 +111,17 @@ export const ProfileHomeScreen = () => {
   };
 
   const animationFinished = async () => {
+    if (activeOption === 0) {
+      setIsPressingDown(false);
+      setHomeHoverState(false);
+      if (pressThroughTimer.current) clearTimeout(pressThroughTimer.current);
+      pressThroughTimer.current = null;
+      dispatch(setScreen('freePour'));
+      return;
+    }
+
     const loadAndStartProfile = async () => {
-      const profile = mergedProfiles?.[activeOption];
+      const profile = mergedProfiles?.[activeOption - 1];
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { isLast, temporary, ...cleanProfile } = profile;
@@ -159,34 +173,56 @@ export const ProfileHomeScreen = () => {
       });
     }
 
-    if (activeOption > mergedProfiles.length) {
-      setActiveOption(mergedProfiles.length);
+    if (activeOption > mergedProfiles.length + 1) {
+      setActiveOption(mergedProfiles.length + 1);
       return;
     }
 
     // We are never zoomed in on the new button
-    if (activeOption == mergedProfiles.length) {
-      setLocalHoverState(false);
+    if (activeOption == mergedProfiles.length + 1) {
+      setHomeHoverState(false);
       return;
     }
   }, [mergedProfiles, activeOption]);
 
+  useEffect(() => {
+    if (activeOption > 0 && activeOption <= mergedProfiles.length) {
+      setActiveProfileOption(activeOption - 1);
+      setHomeMode('espresso');
+    } else if (activeOption === 0) {
+      setHomeMode('free_pour');
+      setLocalHoverState(false);
+    } else {
+      setHomeMode('new');
+      setLocalHoverState(false);
+    }
+  }, [
+    activeOption,
+    mergedProfiles,
+    setActiveProfileOption,
+    setHomeMode,
+    localHoverState,
+    setLocalHoverState
+  ]);
+
   const rotateLeft = () => {
-    if (localHoverState) {
+    if (homeHoverState) {
+      setHomeHoverState(false);
       setLocalHoverState(false);
       return;
     }
-    if (activeOption !== mergedProfiles?.length) {
+    if (activeOption !== mergedProfiles?.length + 1) {
       setTransitionDirection('none');
       requestAnimationFrame(() => {
         setTransitionDirection('right');
       });
     }
-    setActiveOption((prev) => Math.min(prev + 1, mergedProfiles?.length || 0));
+    setActiveOption((prev) => Math.min(prev + 1, mergedProfiles.length + 1));
   };
 
   const rotateRight = () => {
-    if (localHoverState) {
+    if (homeHoverState) {
+      setHomeHoverState(false);
       setLocalHoverState(false);
       return;
     }
@@ -220,18 +256,29 @@ export const ProfileHomeScreen = () => {
       },
       pressDown() {
         // New profile button
-        if (activeOption == mergedProfiles?.length) {
+        if (activeOption == mergedProfiles?.length + 1) {
           if (!isOnline) return;
           if (limitedAccess) {
             dispatch(setScreen('unlock'));
             return;
           }
           dispatch(setScreen('defaultProfiles'));
+        } else if (activeOption === 0) {
+          if (!homeHoverState) {
+            setHomeHoverState(true);
+            setTransitionDirection('none');
+            pressThroughTimer.current = setTimeout(() => {
+              setIsPressingDown(true);
+            }, 300);
+          } else {
+            setIsPressingDown(true);
+          }
         } else {
-          if (!localHoverState) {
+          if (!homeHoverState) {
+            setHomeHoverState(true);
             setLocalHoverState(true);
             setTransitionDirection('none');
-            const profile = mergedProfiles?.[activeOption];
+            const profile = mergedProfiles?.[activeOption - 1];
             if (profile?.id) {
               socket.emit('profileHover', {
                 id: profile.id,
@@ -271,8 +318,22 @@ export const ProfileHomeScreen = () => {
             $translateX={CARD_PADDING - activeOption * CARD_SIZE}
             component={'div'}
           >
+            <ProfileEntry
+              key="free-pour"
+              title="Free Pour"
+              containerStyle={{ backgroundColor: '#23383f', color: '#78d6ff' }}
+              contentClassNames={
+                Math.abs(activeOption) < 2 &&
+                `animation-bounce-${transitionDirection}`
+              }
+              distanceToActive={-activeOption}
+              zoomedIn={homeHoverState}
+            >
+              <FreePourIcon />
+            </ProfileEntry>
             {mergedProfiles.map((profile, index) => {
-              const itemRef = getOrCreateRef(index.toString());
+              const carouselIndex = index + 1;
+              const itemRef = getOrCreateRef(carouselIndex.toString());
               const backgroundColor = profile.display?.accentColor
                 ? profile.display?.accentColor
                 : '#e0dcd0';
@@ -287,14 +348,14 @@ export const ProfileHomeScreen = () => {
                   <ProfileEntry
                     ref={itemRef}
                     contentClassNames={
-                      !localHoverState &&
-                      Math.abs(index - activeOption) < 2 &&
+                      !homeHoverState &&
+                      Math.abs(carouselIndex - activeOption) < 2 &&
                       `animation-bounce-${transitionDirection}`
                     }
                     containerStyle={{ backgroundColor, position: 'relative' }}
                     title={profile.name}
-                    distanceToActive={index - activeOption}
-                    zoomedIn={localHoverState}
+                    distanceToActive={carouselIndex - activeOption}
+                    zoomedIn={homeHoverState}
                   >
                     <ProfileImage profile={profile} />
                     {profile.isLast && (
@@ -309,11 +370,11 @@ export const ProfileHomeScreen = () => {
               key={'unlock_new'}
               title={limitedAccess ? 'unlock all features' : 'new'}
               contentClassNames={
-                Math.abs(mergedProfiles.length - activeOption) < 2 &&
+                Math.abs(mergedProfiles.length + 1 - activeOption) < 2 &&
                 `animation-bounce-${transitionDirection}`
               }
-              distanceToActive={mergedProfiles.length - activeOption}
-              zoomedIn={localHoverState}
+              distanceToActive={mergedProfiles.length + 1 - activeOption}
+              zoomedIn={homeHoverState}
             >
               {limitedAccess ? <DownloadIcon /> : <PlusIcon />}
             </ProfileEntry>
@@ -323,6 +384,7 @@ export const ProfileHomeScreen = () => {
       <CircleOverlay
         shouldAnimate={isPressingDown}
         onAnimationFinished={animationFinished}
+        hoverState={homeHoverState}
       />
     </>
   );

--- a/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
+++ b/src/components/ProfileHomeScreen/ProfileHomeScreen.tsx
@@ -24,6 +24,10 @@ import { DownloadIcon } from './DownloadIcon';
 import { useSocket } from '../store/SocketManager';
 import { invoke } from '@tauri-apps/api/core';
 import { FreePourIcon } from '../../features/freePour/FreePourIcon';
+import { logFreePourError } from '../../features/freePour/logging';
+import { createRepeatPourOverProfile } from '../../features/freePour/profile';
+import { getLatestFreePourOnlySession } from '../../features/freePour/storage';
+import { PourOverProfile } from '../../features/freePour/types';
 
 const CARD_GAP = 79;
 const CARD_SIZE = PROFILE_ENTRY_SIZE + CARD_GAP;
@@ -96,6 +100,8 @@ export const ProfileHomeScreen = () => {
   const [activeOption, setActiveOption] = useState(0);
   const [homeHoverState, setHomeHoverState] = useState(false);
   const [isPressingDown, setIsPressingDown] = useState(false);
+  const [repeatPourProfile, setRepeatPourProfile] =
+    useState<PourOverProfile | null>(null);
   const pressThroughTimer = useRef<NodeJS.Timeout | null>(null);
   const homeReadyReported = useRef(false);
 
@@ -110,6 +116,9 @@ export const ProfileHomeScreen = () => {
     return nodeRefs.current[id];
   };
 
+  const pourOverOptionCount = repeatPourProfile ? 2 : 1;
+  const newOptionIndex = mergedProfiles.length + pourOverOptionCount;
+
   const animationFinished = async () => {
     if (activeOption === 0) {
       setIsPressingDown(false);
@@ -120,8 +129,17 @@ export const ProfileHomeScreen = () => {
       return;
     }
 
+    if (repeatPourProfile && activeOption === 1) {
+      setIsPressingDown(false);
+      setHomeHoverState(false);
+      if (pressThroughTimer.current) clearTimeout(pressThroughTimer.current);
+      pressThroughTimer.current = null;
+      dispatch(setScreen('freePourRecipe'));
+      return;
+    }
+
     const loadAndStartProfile = async () => {
-      const profile = mergedProfiles?.[activeOption - 1];
+      const profile = mergedProfiles?.[activeOption - pourOverOptionCount];
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { isLast, temporary, ...cleanProfile } = profile;
@@ -153,6 +171,19 @@ export const ProfileHomeScreen = () => {
   };
 
   useEffect(() => {
+    getLatestFreePourOnlySession()
+      .then((session) =>
+        setRepeatPourProfile(
+          session ? createRepeatPourOverProfile(session) : null
+        )
+      )
+      .catch((error) => {
+        logFreePourError('repeat_profile_home_load_failed', error);
+        setRepeatPourProfile(null);
+      });
+  }, []);
+
+  useEffect(() => {
     requiresPurge.current = PistonPos && PistonPos < PISTON_ON_PURGE_POSITION;
   }, [PistonPos]);
 
@@ -173,24 +204,27 @@ export const ProfileHomeScreen = () => {
       });
     }
 
-    if (activeOption > mergedProfiles.length + 1) {
-      setActiveOption(mergedProfiles.length + 1);
+    if (activeOption > newOptionIndex) {
+      setActiveOption(newOptionIndex);
       return;
     }
 
     // We are never zoomed in on the new button
-    if (activeOption == mergedProfiles.length + 1) {
+    if (activeOption == newOptionIndex) {
       setHomeHoverState(false);
       return;
     }
-  }, [mergedProfiles, activeOption]);
+  }, [mergedProfiles, activeOption, newOptionIndex]);
 
   useEffect(() => {
-    if (activeOption > 0 && activeOption <= mergedProfiles.length) {
-      setActiveProfileOption(activeOption - 1);
+    if (activeOption >= pourOverOptionCount && activeOption < newOptionIndex) {
+      setActiveProfileOption(activeOption - pourOverOptionCount);
       setHomeMode('espresso');
     } else if (activeOption === 0) {
       setHomeMode('free_pour');
+      setLocalHoverState(false);
+    } else if (repeatPourProfile && activeOption === 1) {
+      setHomeMode('pour_over_profile');
       setLocalHoverState(false);
     } else {
       setHomeMode('new');
@@ -199,6 +233,9 @@ export const ProfileHomeScreen = () => {
   }, [
     activeOption,
     mergedProfiles,
+    newOptionIndex,
+    pourOverOptionCount,
+    repeatPourProfile,
     setActiveProfileOption,
     setHomeMode,
     localHoverState,
@@ -211,13 +248,13 @@ export const ProfileHomeScreen = () => {
       setLocalHoverState(false);
       return;
     }
-    if (activeOption !== mergedProfiles?.length + 1) {
+    if (activeOption !== newOptionIndex) {
       setTransitionDirection('none');
       requestAnimationFrame(() => {
         setTransitionDirection('right');
       });
     }
-    setActiveOption((prev) => Math.min(prev + 1, mergedProfiles.length + 1));
+    setActiveOption((prev) => Math.min(prev + 1, newOptionIndex));
   };
 
   const rotateRight = () => {
@@ -256,14 +293,17 @@ export const ProfileHomeScreen = () => {
       },
       pressDown() {
         // New profile button
-        if (activeOption == mergedProfiles?.length + 1) {
+        if (activeOption == newOptionIndex) {
           if (!isOnline) return;
           if (limitedAccess) {
             dispatch(setScreen('unlock'));
             return;
           }
           dispatch(setScreen('defaultProfiles'));
-        } else if (activeOption === 0) {
+        } else if (
+          activeOption === 0 ||
+          (repeatPourProfile && activeOption === 1)
+        ) {
           if (!homeHoverState) {
             setHomeHoverState(true);
             setTransitionDirection('none');
@@ -278,7 +318,8 @@ export const ProfileHomeScreen = () => {
             setHomeHoverState(true);
             setLocalHoverState(true);
             setTransitionDirection('none');
-            const profile = mergedProfiles?.[activeOption - 1];
+            const profile =
+              mergedProfiles?.[activeOption - pourOverOptionCount];
             if (profile?.id) {
               socket.emit('profileHover', {
                 id: profile.id,
@@ -331,8 +372,26 @@ export const ProfileHomeScreen = () => {
             >
               <FreePourIcon />
             </ProfileEntry>
+            {repeatPourProfile && (
+              <ProfileEntry
+                key="repeat-last-pour"
+                title={repeatPourProfile.name}
+                containerStyle={{
+                  backgroundColor: '#1f3340',
+                  color: '#78d6ff'
+                }}
+                contentClassNames={
+                  Math.abs(activeOption - 1) < 2 &&
+                  `animation-bounce-${transitionDirection}`
+                }
+                distanceToActive={1 - activeOption}
+                zoomedIn={homeHoverState}
+              >
+                <FreePourIcon />
+              </ProfileEntry>
+            )}
             {mergedProfiles.map((profile, index) => {
-              const carouselIndex = index + 1;
+              const carouselIndex = index + pourOverOptionCount;
               const itemRef = getOrCreateRef(carouselIndex.toString());
               const backgroundColor = profile.display?.accentColor
                 ? profile.display?.accentColor
@@ -370,10 +429,10 @@ export const ProfileHomeScreen = () => {
               key={'unlock_new'}
               title={limitedAccess ? 'unlock all features' : 'new'}
               contentClassNames={
-                Math.abs(mergedProfiles.length + 1 - activeOption) < 2 &&
+                Math.abs(newOptionIndex - activeOption) < 2 &&
                 `animation-bounce-${transitionDirection}`
               }
-              distanceToActive={mergedProfiles.length + 1 - activeOption}
+              distanceToActive={newOptionIndex - activeOption}
               zoomedIn={homeHoverState}
             >
               {limitedAccess ? <DownloadIcon /> : <PlusIcon />}

--- a/src/components/ProfileHomeScreen/ProfileTitle.tsx
+++ b/src/components/ProfileHomeScreen/ProfileTitle.tsx
@@ -44,7 +44,7 @@ export const getProfilesTitle = () => <TitleProfiles />;
 export const getActiveProfilesTitle = () => <TitleProfiles />;
 
 export const TitleProfiles = () => {
-  const { localHoverState, localProfile } = useProfileContext();
+  const { homeMode, localHoverState, localProfile } = useProfileContext();
   const currentScreen = useAppSelector((state) => state.screen.value);
   const isHomeScreen = currentScreen == 'profileHome';
   const titleRef = useRef<HTMLSpanElement>(null);
@@ -63,7 +63,10 @@ export const TitleProfiles = () => {
   const scroll = localHoverState && isHomeScreen;
   const marquee = (isHomeScreen && scroll) || !isHomeScreen;
 
-  let title = localProfile?.name || '';
+  let title =
+    isHomeScreen && homeMode === 'free_pour'
+      ? 'Free Pour'
+      : localProfile?.name || '';
   if (title.length > 40) {
     title = title.slice(0, 40) + '...';
   }

--- a/src/components/ProfileHomeScreen/ProfileTitle.tsx
+++ b/src/components/ProfileHomeScreen/ProfileTitle.tsx
@@ -66,7 +66,9 @@ export const TitleProfiles = () => {
   let title =
     isHomeScreen && homeMode === 'free_pour'
       ? 'Free Pour'
-      : localProfile?.name || '';
+      : isHomeScreen && homeMode === 'pour_over_profile'
+        ? 'Repeat Last Pour'
+        : localProfile?.name || '';
   if (title.length > 40) {
     title = title.slice(0, 40) + '...';
   }

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -241,7 +241,8 @@ export function QuickSettings(): JSX.Element {
         );
       },
       doubleClick() {
-        if (currentScreen !== 'freePour') return;
+        if (currentScreen !== 'freePour' && currentScreen !== 'freePourRecipe')
+          return;
         logFreePour('aborted', { source: 'double_press_context_menu' });
         dispatch(setScreen('profileHome'));
         dispatch(setBubbleDisplay({ visible: false, component: undefined }));
@@ -331,8 +332,15 @@ export function QuickSettings(): JSX.Element {
           }
           case 'last_free_pour': {
             dispatch(setScreen('freePourHistory'));
+            // The menu opens entries on pressDown. Keep the underlying chart
+            // blocked until the bubble finishes closing so the same physical
+            // press cannot resolve into a click that immediately exits it.
             dispatch(
-              setBubbleDisplay({ visible: false, component: undefined })
+              setBubbleDisplay({
+                visible: false,
+                component: undefined,
+                interceptsGesture: true
+              })
             );
             break;
           }
@@ -430,7 +438,8 @@ export function QuickSettings(): JSX.Element {
     currentScreen === 'profileHome' &&
     homeMode === 'espresso';
   const requiresFreePourContext =
-    currentScreen === 'profileHome' && homeMode === 'free_pour';
+    currentScreen === 'profileHome' &&
+    (homeMode === 'free_pour' || homeMode === 'pour_over_profile');
 
   useEffect(() => {
     const context: QuickSettingOption[] = profileContextSettings;
@@ -459,6 +468,7 @@ export function QuickSettings(): JSX.Element {
         setSettings(inBrewSettings);
         break;
       case 'freePour':
+      case 'freePourRecipe':
         setSettings(freePourInProgressSettings);
         break;
       default:

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -23,6 +23,7 @@ import { useProfileContext } from '../../context/ProfileContext';
 import { useDeletePreset } from '../../hooks/useProfiles';
 import { addSettingsToProfile } from '../../utils/profiles';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
+import { logFreePour } from '../../features/freePour/logging';
 
 export type QuickSettingOption = {
   key: string;
@@ -54,6 +55,23 @@ const freePourContextSettings: QuickSettingOption[] = [
   {
     key: 'last_free_pour',
     label: 'Last pour-over'
+  }
+];
+
+const freePourInProgressSettings: QuickSettingOption[] = [
+  {
+    key: 'resume_free_pour',
+    label: 'Resume Free Pour'
+  },
+  {
+    key: 'abort_free_pour',
+    label: 'Abort Free Pour',
+    longpress: true,
+    hasSeparator: true
+  },
+  {
+    key: 'exit',
+    label: 'Exit menu'
   }
 ];
 
@@ -188,9 +206,11 @@ export function QuickSettings(): JSX.Element {
 
   const handleAnimationEnd = () => {
     setHoldAnimation('finished');
-    if (localProfile?.temporary) return; //To prevent deleting an existing profile based on a temporary profile that has modifications.
     switch (settings[activeOption].key) {
       case 'delete': {
+        // Prevent deleting an existing profile based on a temporary profile
+        // that has modifications.
+        if (localProfile?.temporary) return;
         deletePresetMutation.mutate(localProfile?.id);
         dispatch(setScreen('profileHome'));
         dispatch(setBubbleDisplay({ visible: false, component: undefined }));
@@ -198,6 +218,12 @@ export function QuickSettings(): JSX.Element {
       }
       case 'abort_brew': {
         socket.emit('action', 'abort');
+        dispatch(setBubbleDisplay({ visible: false, component: undefined }));
+        break;
+      }
+      case 'abort_free_pour': {
+        logFreePour('aborted', { source: 'context_menu' });
+        dispatch(setScreen('profileHome'));
         dispatch(setBubbleDisplay({ visible: false, component: undefined }));
         break;
       }
@@ -213,6 +239,12 @@ export function QuickSettings(): JSX.Element {
             component: !bubbleDisplay.visible ? 'quick-settings' : null
           })
         );
+      },
+      doubleClick() {
+        if (currentScreen !== 'freePour') return;
+        logFreePour('aborted', { source: 'double_press_context_menu' });
+        dispatch(setScreen('profileHome'));
+        dispatch(setBubbleDisplay({ visible: false, component: undefined }));
       },
       left() {
         setActiveOption((prev) => Math.max(prev - 1, 0));
@@ -301,6 +333,19 @@ export function QuickSettings(): JSX.Element {
             dispatch(setScreen('freePourHistory'));
             dispatch(
               setBubbleDisplay({ visible: false, component: undefined })
+            );
+            break;
+          }
+          case 'resume_free_pour': {
+            logFreePour('context_closed', { action: 'resume' });
+            // Keep gestures intercepted during the close animation so the
+            // resolved click cannot leak through to the Free Pour screen.
+            dispatch(
+              setBubbleDisplay({
+                visible: false,
+                component: undefined,
+                interceptsGesture: true
+              })
             );
             break;
           }
@@ -412,6 +457,9 @@ export function QuickSettings(): JSX.Element {
         break;
       case 'barometer':
         setSettings(inBrewSettings);
+        break;
+      case 'freePour':
+        setSettings(freePourInProgressSettings);
         break;
       default:
         {

--- a/src/components/QuickSettings/QuickSettings.tsx
+++ b/src/components/QuickSettings/QuickSettings.tsx
@@ -50,6 +50,13 @@ const profileContextSettings: QuickSettingOption[] = [
   }
 ];
 
+const freePourContextSettings: QuickSettingOption[] = [
+  {
+    key: 'last_free_pour',
+    label: 'Last pour-over'
+  }
+];
+
 const prevScreenSetting: QuickSettingOption = {
   key: 'prevScreen',
   label: 'Back',
@@ -133,6 +140,7 @@ export function QuickSettings(): JSX.Element {
   const {
     profileQuery: { data: profiles },
     localProfile,
+    homeMode,
     detailProfileSelected: defaultProfileSelectedForDetails,
     setSettingsIndex: setProfileSettingsIndex,
     setSettingsProfile: setProfileSettings
@@ -289,6 +297,13 @@ export function QuickSettings(): JSX.Element {
             );
             break;
           }
+          case 'last_free_pour': {
+            dispatch(setScreen('freePourHistory'));
+            dispatch(
+              setBubbleDisplay({ visible: false, component: undefined })
+            );
+            break;
+          }
           case 'purge': {
             socket.emit('action', 'purge');
             dispatch(
@@ -366,7 +381,11 @@ export function QuickSettings(): JSX.Element {
   );
 
   const requiresProfileContext: boolean =
-    profiles?.length > 0 && currentScreen === 'profileHome';
+    profiles?.length > 0 &&
+    currentScreen === 'profileHome' &&
+    homeMode === 'espresso';
+  const requiresFreePourContext =
+    currentScreen === 'profileHome' && homeMode === 'free_pour';
 
   useEffect(() => {
     const context: QuickSettingOption[] = profileContextSettings;
@@ -401,13 +420,14 @@ export function QuickSettings(): JSX.Element {
             : context;
           setSettings([
             ...(requiresProfileContext ? newContext : []),
+            ...(requiresFreePourContext ? freePourContextSettings : []),
             ...(backAvailable ? [prevScreenSetting] : []),
             ...defaultSettings
           ]);
         }
         break;
     }
-  }, [currentScreen, osStatusInfo, osStatusVisible]);
+  }, [currentScreen, homeMode, osStatusInfo, osStatusVisible]);
 
   useEffect(() => {
     if (counterESGG >= 20) {

--- a/src/components/Scale/Scale.tsx
+++ b/src/components/Scale/Scale.tsx
@@ -20,7 +20,11 @@ export interface scaleState {
   size: 'small' | 'full' | undefined;
 }
 
-const noScalePopUpScreens: ScreenType[] = ['calibrateScale'];
+const noScalePopUpScreens: ScreenType[] = [
+  'calibrateScale',
+  'freePour',
+  'freePourHistory'
+];
 
 const Weight = () => {
   const weight = useAppSelector((state) => state.stats.sensors.w || 0);

--- a/src/components/Scale/Scale.tsx
+++ b/src/components/Scale/Scale.tsx
@@ -23,6 +23,7 @@ export interface scaleState {
 const noScalePopUpScreens: ScreenType[] = [
   'calibrateScale',
   'freePour',
+  'freePourRecipe',
   'freePourHistory'
 ];
 

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -56,6 +56,7 @@ export type ScreenType =
   | 'scrollDirections'
   | 'brewComplete'
   | 'freePour'
+  | 'freePourRecipe'
   | 'freePourHistory'
   | 'factoryReset'
   | 'retraction_volume'

--- a/src/components/store/features/screens/screens-slice.ts
+++ b/src/components/store/features/screens/screens-slice.ts
@@ -55,6 +55,8 @@ export type ScreenType =
   | 'shot_history'
   | 'scrollDirections'
   | 'brewComplete'
+  | 'freePour'
+  | 'freePourHistory'
   | 'factoryReset'
   | 'retraction_volume'
   | 'tare_behavior'

--- a/src/context/ProfileContext.tsx
+++ b/src/context/ProfileContext.tsx
@@ -53,9 +53,9 @@ type ProfileContextType = {
   onProfileHover: (type: string, profile_id: string) => void;
   mergedProfiles: ExtendedProfile[];
   limitedAccess: boolean;
-  homeMode: 'espresso' | 'free_pour' | 'new';
+  homeMode: 'espresso' | 'free_pour' | 'pour_over_profile' | 'new';
   setHomeMode: React.Dispatch<
-    React.SetStateAction<'espresso' | 'free_pour' | 'new'>
+    React.SetStateAction<'espresso' | 'free_pour' | 'pour_over_profile' | 'new'>
   >;
 };
 
@@ -89,9 +89,9 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
   const [profileIdToFind, setProfileIdToFind] = useState<string | null>(null);
   const [profileEvent, setProfileEvent] = useState<ProfileUpdate | null>(null);
   const [profileStarting, setProfileStarting] = useState(false);
-  const [homeMode, setHomeMode] = useState<'espresso' | 'free_pour' | 'new'>(
-    'espresso'
-  );
+  const [homeMode, setHomeMode] = useState<
+    'espresso' | 'free_pour' | 'pour_over_profile' | 'new'
+  >('espresso');
   const [settingsIndex, setSettingsIndex] = useState(0);
   const [settingsProfile, setSettingsProfile] = useState<
     (ExtendedProfile & { settings: IPresetSetting[] }) | null

--- a/src/context/ProfileContext.tsx
+++ b/src/context/ProfileContext.tsx
@@ -53,6 +53,10 @@ type ProfileContextType = {
   onProfileHover: (type: string, profile_id: string) => void;
   mergedProfiles: ExtendedProfile[];
   limitedAccess: boolean;
+  homeMode: 'espresso' | 'free_pour' | 'new';
+  setHomeMode: React.Dispatch<
+    React.SetStateAction<'espresso' | 'free_pour' | 'new'>
+  >;
 };
 
 export type ExtendedProfile = Profile & {
@@ -85,6 +89,9 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
   const [profileIdToFind, setProfileIdToFind] = useState<string | null>(null);
   const [profileEvent, setProfileEvent] = useState<ProfileUpdate | null>(null);
   const [profileStarting, setProfileStarting] = useState(false);
+  const [homeMode, setHomeMode] = useState<'espresso' | 'free_pour' | 'new'>(
+    'espresso'
+  );
   const [settingsIndex, setSettingsIndex] = useState(0);
   const [settingsProfile, setSettingsProfile] = useState<
     (ExtendedProfile & { settings: IPresetSetting[] }) | null
@@ -259,7 +266,9 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
     onProfileEvent,
     onProfileHover,
     mergedProfiles,
-    limitedAccess
+    limitedAccess,
+    homeMode,
+    setHomeMode
   };
 
   return (

--- a/src/features/freePour/FreePourHistoryScreen.tsx
+++ b/src/features/freePour/FreePourHistoryScreen.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import { LoadingScreen } from '../../components/LoadingScreen/LoadingScreen';
+import { setScreen } from '../../components/store/features/screens/screens-slice';
+import { useAppDispatch } from '../../components/store/hooks';
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import { clamp, formatBrewTime } from './format';
+import { getLatestFreePourSession } from './storage';
+import { FreePourSample, FreePourSession } from './types';
+import './free-pour-history.css';
+
+const CHART_LEFT = 68;
+const CHART_TOP = 108;
+const CHART_WIDTH = 344;
+const CHART_HEIGHT = 142;
+const SCROLL_STEP_MS = 5_000;
+
+const closestSample = (samples: FreePourSample[], timeMs: number) =>
+  samples.reduce((closest, sample) =>
+    Math.abs(sample.t - timeMs) < Math.abs(closest.t - timeMs)
+      ? sample
+      : closest
+  );
+
+const linePath = (
+  samples: FreePourSample[],
+  durationMs: number,
+  value: (sample: FreePourSample) => number,
+  maximum: number
+) =>
+  samples
+    .map((sample, index) => {
+      const x = CHART_LEFT + (sample.t / Math.max(1, durationMs)) * CHART_WIDTH;
+      const y =
+        CHART_TOP +
+        CHART_HEIGHT -
+        (clamp(value(sample), 0, maximum) / maximum) * CHART_HEIGHT;
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(' ');
+
+export const FreePourHistoryScreen = () => {
+  const dispatch = useAppDispatch();
+  const [session, setSession] = useState<FreePourSession | null | undefined>(
+    undefined
+  );
+  const [selectedTimeMs, setSelectedTimeMs] = useState(0);
+
+  useEffect(() => {
+    getLatestFreePourSession()
+      .then(setSession)
+      .catch((error) => {
+        console.error('Failed to read Free Pour history', error);
+        setSession(null);
+      });
+  }, []);
+
+  const durationMs = session?.measurements.durationMs ?? 0;
+  useHandleGestures(
+    {
+      left() {
+        setSelectedTimeMs((time) => Math.max(0, time - SCROLL_STEP_MS));
+      },
+      right() {
+        setSelectedTimeMs((time) =>
+          Math.min(durationMs, time + SCROLL_STEP_MS)
+        );
+      },
+      click() {
+        dispatch(setScreen('profileHome'));
+      },
+      pressDown() {
+        dispatch(setScreen('profileHome'));
+      },
+      context() {
+        dispatch(setScreen('profileHome'));
+      }
+    },
+    false
+  );
+
+  const chart = useMemo(() => {
+    if (!session || session.samples.length === 0) return null;
+    const maxWeight = Math.max(1, ...session.samples.map((sample) => sample.w));
+    return {
+      weightPath: linePath(
+        session.samples,
+        durationMs,
+        (sample) => sample.w,
+        maxWeight
+      ),
+      flowPath: linePath(session.samples, durationMs, (sample) => sample.f, 10),
+      selected: closestSample(session.samples, selectedTimeMs),
+      cursorX:
+        CHART_LEFT + (selectedTimeMs / Math.max(1, durationMs)) * CHART_WIDTH
+    };
+  }, [durationMs, selectedTimeMs, session]);
+
+  if (session === undefined) return <LoadingScreen />;
+  if (!session || !chart) {
+    return (
+      <div className="free-pour-history free-pour-history--empty">
+        <strong>NO FREE POUR HISTORY</strong>
+        <span>PRESS DIAL TO RETURN</span>
+      </div>
+    );
+  }
+
+  const selectedPour =
+    chart.selected.p ||
+    [...session.pours]
+      .reverse()
+      .find((pour) => pour.startTimeMs <= selectedTimeMs)?.number ||
+    1;
+
+  return (
+    <div className="free-pour-history">
+      <div className="free-pour-history-title">FREE POUR</div>
+      <div className="free-pour-history-subtitle">
+        {session.recipe.doseG}g DOSE ·{' '}
+        {Math.round(session.measurements.waterPouredG)}g WATER
+      </div>
+      <svg
+        width="480"
+        height="284"
+        className="free-pour-history-chart"
+        aria-label="Free Pour chart"
+      >
+        <line
+          x1={CHART_LEFT}
+          x2={CHART_LEFT + CHART_WIDTH}
+          y1={CHART_TOP + CHART_HEIGHT}
+          y2={CHART_TOP + CHART_HEIGHT}
+          className="free-pour-history-axis"
+        />
+        {[0, 0.5, 1].map((fraction) => (
+          <line
+            key={fraction}
+            x1={CHART_LEFT}
+            x2={CHART_LEFT + CHART_WIDTH}
+            y1={CHART_TOP + CHART_HEIGHT * fraction}
+            y2={CHART_TOP + CHART_HEIGHT * fraction}
+            className="free-pour-history-grid"
+          />
+        ))}
+        {session.pours.map((pour) => {
+          const x =
+            CHART_LEFT +
+            (pour.startTimeMs / Math.max(1, durationMs)) * CHART_WIDTH;
+          return (
+            <circle
+              key={pour.number}
+              cx={x}
+              cy={CHART_TOP + CHART_HEIGHT}
+              r="4"
+              className="free-pour-history-pour"
+            />
+          );
+        })}
+        <path d={chart.weightPath} className="free-pour-history-weight-line" />
+        <path d={chart.flowPath} className="free-pour-history-flow-line" />
+        <line
+          x1={chart.cursorX}
+          x2={chart.cursorX}
+          y1={CHART_TOP - 5}
+          y2={CHART_TOP + CHART_HEIGHT + 5}
+          className="free-pour-history-cursor"
+        />
+      </svg>
+      <div className="free-pour-history-values">
+        <div>
+          <span>POUR</span>
+          <strong>{selectedPour}</strong>
+        </div>
+        <div>
+          <span>TIME</span>
+          <strong>{formatBrewTime(selectedTimeMs)}</strong>
+        </div>
+        <div>
+          <span>WATER</span>
+          <strong>{Math.round(chart.selected.w)}g</strong>
+        </div>
+        <div>
+          <span>FLOW</span>
+          <strong>{Math.round(chart.selected.f)} g/s</strong>
+        </div>
+      </div>
+      <div className="free-pour-history-turn">TURN DIAL · 5 SEC</div>
+      <div className="free-pour-history-legend">
+        <span>
+          <i className="free-pour-history-legend-weight" />
+          WEIGHT
+        </span>
+        <span>
+          <i className="free-pour-history-legend-flow" />
+          FLOW
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/features/freePour/FreePourHistoryScreen.tsx
+++ b/src/features/freePour/FreePourHistoryScreen.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { LoadingScreen } from '../../components/LoadingScreen/LoadingScreen';
 import { setScreen } from '../../components/store/features/screens/screens-slice';
-import { useAppDispatch } from '../../components/store/hooks';
+import { useAppDispatch, useAppSelector } from '../../components/store/hooks';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { clamp, formatBrewTime } from './format';
 import { getLatestFreePourSession } from './storage';
 import { FreePourSample, FreePourSession } from './types';
+import { logFreePour, logFreePourError } from './logging';
 import './free-pour-history.css';
 
 const CHART_LEFT = 68;
@@ -40,6 +41,7 @@ const linePath = (
 
 export const FreePourHistoryScreen = () => {
   const dispatch = useAppDispatch();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const [session, setSession] = useState<FreePourSession | null | undefined>(
     undefined
   );
@@ -49,7 +51,7 @@ export const FreePourHistoryScreen = () => {
     getLatestFreePourSession()
       .then(setSession)
       .catch((error) => {
-        console.error('Failed to read Free Pour history', error);
+        logFreePourError('history_read_failed', error);
         setSession(null);
       });
   }, []);
@@ -66,16 +68,15 @@ export const FreePourHistoryScreen = () => {
         );
       },
       click() {
+        logFreePour('history_closed', { source: 'click' });
         dispatch(setScreen('profileHome'));
       },
-      pressDown() {
-        dispatch(setScreen('profileHome'));
-      },
-      context() {
+      doubleClick() {
+        logFreePour('history_closed', { source: 'double_press' });
         dispatch(setScreen('profileHome'));
       }
     },
-    false
+    bubbleDisplay.interceptsGesture
   );
 
   const chart = useMemo(() => {

--- a/src/features/freePour/FreePourHistoryScreen.tsx
+++ b/src/features/freePour/FreePourHistoryScreen.tsx
@@ -115,10 +115,15 @@ export const FreePourHistoryScreen = () => {
 
   return (
     <div className="free-pour-history">
-      <div className="free-pour-history-title">FREE POUR</div>
+      <div className="free-pour-history-title">
+        {session.recipe.profileName.toUpperCase()}
+      </div>
       <div className="free-pour-history-subtitle">
-        {session.recipe.doseG}g DOSE ·{' '}
-        {Math.round(session.measurements.waterPouredG)}g WATER
+        {session.recipe.doseG}g ·{' '}
+        {session.measurements.waterTemperatureC ??
+          session.recipe.temperatureC ??
+          92}
+        °C · {Math.round(session.measurements.waterPouredG)}g WATER
       </div>
       <svg
         width="480"

--- a/src/features/freePour/FreePourIcon.tsx
+++ b/src/features/freePour/FreePourIcon.tsx
@@ -1,0 +1,18 @@
+export const FreePourIcon = () => (
+  <svg width="126" height="126" viewBox="0 0 126 126" aria-hidden="true">
+    <g
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M30 35h66L81 79H45L30 35Z" />
+      <path d="M50 79h26v12H50zM39 103h48" />
+      <path
+        d="M43 48c13 7 27 7 40 0M55 25c0-8 9-9 9-17M71 25c0-7 8-8 8-14"
+        opacity=".72"
+      />
+    </g>
+  </svg>
+);

--- a/src/features/freePour/FreePourScreen.tsx
+++ b/src/features/freePour/FreePourScreen.tsx
@@ -41,13 +41,16 @@ const SAMPLE_INTERVAL_MS = 200;
 const MAX_POURS = 5;
 const TARE_CONFIRM_TOLERANCE_G = 0.6;
 const TARE_CONFIRM_TIMEOUT_MS = 5000;
+// Setup loads only need to clear scale noise. Do not assume a minimum server or
+// brewer weight: the incoming reading may include a tare offset from earlier use.
+const SETUP_LOAD_CHANGE_G = TARE_CONFIRM_TOLERANCE_G * 2;
 
 const isSetupStage = (stage: Stage): stage is SetupStage =>
   stage === 'server' || stage === 'brewer' || stage === 'coffee';
 
 const isValidSetupWeight = (stage: SetupStage, weight: number) => {
-  if (stage === 'server') return weight >= 20;
-  if (stage === 'brewer') return weight >= 10;
+  if (stage === 'server') return true;
+  if (stage === 'brewer') return weight >= SETUP_LOAD_CHANGE_G;
   return weight >= 5 && weight <= 40;
 };
 
@@ -197,8 +200,8 @@ export const FreePourScreen = () => {
   const [result, setResult] = useState<FreePourSession | null>(null);
   const [setupStatus, setSetupStatus] = useState<SetupStatus>('idle');
   const stable = useStableWeight(weight, stage);
-  const serverReady = stable && weight >= 20;
-  const brewerReady = stable && weight >= 10;
+  const serverReady = stable;
+  const brewerReady = stable && weight >= SETUP_LOAD_CHANGE_G;
   const coffeeReady = stable && weight >= 5 && weight <= 40;
 
   const stageRef = useRef(stage);
@@ -315,7 +318,7 @@ export const FreePourScreen = () => {
         pourTargets: []
       },
       measurements: {
-        emptyServerG: roundTo(serverWeight.current),
+        serverBaselineG: roundTo(serverWeight.current),
         brewerG: roundTo(brewerWeight.current),
         setupG: roundTo(setupWeight.current),
         waterPouredG,
@@ -759,7 +762,7 @@ export const FreePourScreen = () => {
               ? 'WAITING FOR ZERO'
               : setupStatus === 'tare-timeout'
                 ? 'TARE NOT CONFIRMED'
-                : weight < 10
+                : weight < SETUP_LOAD_CHANGE_G
                   ? 'PLACE BREWER ON SERVER'
                   : brewerReady
                     ? 'WEIGHT STABLE'
@@ -767,7 +770,7 @@ export const FreePourScreen = () => {
         </div>
         <div
           className={`free-pour-dose-action ${
-            setupStatus === 'idle' && weight < 10
+            setupStatus === 'idle' && weight < SETUP_LOAD_CHANGE_G
               ? 'free-pour-dose-action--disabled'
               : ''
           }`}
@@ -847,11 +850,9 @@ export const FreePourScreen = () => {
               ? 'WAITING FOR ZERO'
               : setupStatus === 'tare-timeout'
                 ? 'TARE NOT CONFIRMED'
-                : weight < 20
-                  ? 'PLACE EMPTY SERVER'
-                  : serverReady
-                    ? 'WEIGHT STABLE'
-                    : 'WAITING FOR STABLE WEIGHT'}
+                : serverReady
+                  ? 'WEIGHT STABLE'
+                  : 'WAITING FOR STABLE WEIGHT'}
         </div>
         <div className="free-pour-setup-action">
           {setupStatus === 'saving'

--- a/src/features/freePour/FreePourScreen.tsx
+++ b/src/features/freePour/FreePourScreen.tsx
@@ -1,0 +1,678 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useHandleGestures } from '../../hooks/useHandleGestures';
+import { useIdleTimer } from '../../hooks/useIdleTimer';
+import { Gauge } from '../../components/SettingNumerical/Gauge';
+import { useAppDispatch, useAppSelector } from '../../components/store/hooks';
+import { useSocket } from '../../components/store/SocketManager';
+import { setScreen } from '../../components/store/features/screens/screens-slice';
+import { colorDataBlueLight } from '../../constants/colors';
+import { clamp, formatBrewTime, roundTo } from './format';
+import { DetectorSample, PourDetector } from './pourDetector';
+import { saveFreePourSession } from './storage';
+import {
+  FREE_POUR_SCHEMA_VERSION,
+  FreePourCompletion,
+  FreePourPour,
+  FreePourSample,
+  FreePourSession
+} from './types';
+import './free-pour.css';
+
+type Stage =
+  | 'server'
+  | 'dose'
+  | 'recipe'
+  | 'ready'
+  | 'pouring'
+  | 'waiting'
+  | 'finish-requested'
+  | 'measuring'
+  | 'replace-server'
+  | 'result';
+
+const SAMPLE_INTERVAL_MS = 200;
+const MAX_POURS = 5;
+
+const stepForStage = (stage: Stage) => {
+  if (stage === 'server') return 1;
+  if (stage === 'dose') return 2;
+  if (stage === 'recipe') return 3;
+  if (stage === 'ready' || stage === 'pouring') return 4;
+  if (stage === 'waiting') return 5;
+  if (stage === 'finish-requested' || stage === 'measuring') return 6;
+  return 7;
+};
+
+const useStableWeight = (weight: number, resetKey: Stage) => {
+  const latestWeight = useRef(weight);
+  const readings = useRef<{ time: number; weight: number }[]>([]);
+  const [stable, setStable] = useState(false);
+  latestWeight.current = weight;
+
+  useEffect(() => {
+    readings.current = [];
+    setStable(false);
+  }, [resetKey]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const now = performance.now();
+      readings.current.push({ time: now, weight: latestWeight.current });
+      while (readings.current[0]?.time < now - 900) readings.current.shift();
+      const values = readings.current.map((reading) => reading.weight);
+      const range = values.length
+        ? Math.max(...values) - Math.min(...values)
+        : Infinity;
+      const duration = now - (readings.current[0]?.time ?? now);
+      const nextStable = duration >= 700 && range <= 0.6;
+      setStable((previous) =>
+        previous === nextStable ? previous : nextStable
+      );
+    }, 100);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  return stable;
+};
+
+const FlowMeter = ({ flow }: { flow: number }) => {
+  const displayedFlow = clamp(flow, 0, 10);
+  return (
+    <div className="free-pour-flow-meter">
+      <div className="free-pour-flow-title">
+        FLOW · <span>{Math.round(displayedFlow)} g/s</span>
+      </div>
+      <div className="free-pour-flow-segments">
+        {Array.from({ length: 10 }, (_, index) => (
+          <span className="free-pour-flow-segment" key={index}>
+            <i
+              style={{
+                width: `${clamp(displayedFlow - index, 0, 1) * 100}%`,
+                backgroundColor: colorDataBlueLight
+              }}
+            />
+          </span>
+        ))}
+      </div>
+      <div className="free-pour-flow-axis">
+        {Array.from({ length: 11 }, (_, index) => (
+          <span key={index}>{index}</span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const PourRail = ({
+  pours,
+  activePour,
+  waiting
+}: {
+  pours: FreePourPour[];
+  activePour: { number: number; startTimeMs: number } | null;
+  waiting: boolean;
+}) => {
+  const maxedOut = !activePour && pours.length >= MAX_POURS;
+  const completed = maxedOut ? pours.slice(-5) : pours.slice(-4);
+  const showOpenCenter = waiting && pours.length < MAX_POURS;
+  const centerNumber =
+    activePour?.number ?? Math.min(pours.length + 1, MAX_POURS);
+  return (
+    <div className="free-pour-rail" aria-label={`Pour ${centerNumber}`}>
+      <div
+        className={`free-pour-rail-line ${
+          maxedOut ? 'free-pour-rail-line--complete' : ''
+        }`}
+      />
+      {completed.map((pour, index) => {
+        const offset = maxedOut
+          ? (index - Math.floor(completed.length / 2)) * 52
+          : -(completed.length - index) * 52;
+        return (
+          <div
+            className="free-pour-rail-point free-pour-rail-point--past"
+            key={pour.number}
+            style={{ transform: `translateX(${offset}px)` }}
+          >
+            <span className="free-pour-dot free-pour-dot--past" />
+            <small>{formatBrewTime(pour.startTimeMs)}</small>
+          </div>
+        );
+      })}
+      {activePour && (
+        <div className="free-pour-rail-point">
+          <span className="free-pour-dot free-pour-dot--active" />
+          <small>{formatBrewTime(activePour.startTimeMs)}</small>
+        </div>
+      )}
+      {showOpenCenter && (
+        <div className="free-pour-rail-point">
+          <span className="free-pour-dot" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const FreePourScreen = () => {
+  const dispatch = useAppDispatch();
+  const socket = useSocket();
+  const { resetTimer } = useIdleTimer();
+  const weight = useAppSelector((state) => state.stats.sensors.w || 0);
+  const gravimetricFlow = useAppSelector((state) => state.stats.sensors.g || 0);
+  const [stage, setStage] = useState<Stage>('server');
+  const [doseG, setDoseG] = useState(15);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [pours, setPours] = useState<FreePourPour[]>([]);
+  const [activePourView, setActivePourView] = useState<{
+    number: number;
+    startTimeMs: number;
+  } | null>(null);
+  const [result, setResult] = useState<FreePourSession | null>(null);
+  const stable = useStableWeight(weight, stage);
+  const serverReady = stable && weight >= 20;
+  const setupReady = stable && weight >= 5;
+
+  const stageRef = useRef(stage);
+  const weightRef = useRef(weight);
+  const flowRef = useRef(gravimetricFlow);
+  const detector = useRef(new PourDetector());
+  const serverWeight = useRef(0);
+  const setupWeight = useRef(0);
+  const startedAtIso = useRef('');
+  const brewStartTime = useRef<number | null>(null);
+  const elapsedMsRef = useRef(0);
+  const lastStoredSampleTime = useRef(0);
+  const peakWaterWeight = useRef(0);
+  const samples = useRef<FreePourSample[]>([]);
+  const completedPours = useRef<FreePourPour[]>([]);
+  const activePour = useRef<{
+    number: number;
+    startTimeMs: number;
+    startWeightG: number;
+    peakWeightG: number;
+    peakFlowGps: number;
+  } | null>(null);
+  const completion = useRef<FreePourCompletion>('brewer_removed');
+  const finalizing = useRef(false);
+
+  stageRef.current = stage;
+  weightRef.current = weight;
+  flowRef.current = gravimetricFlow;
+
+  const updateStage = (next: Stage) => {
+    stageRef.current = next;
+    setStage(next);
+  };
+
+  const finishActivePour = (timeMs: number, endWeightG: number) => {
+    const current = activePour.current;
+    if (!current || brewStartTime.current === null) return;
+    const endTimeMs = Math.max(
+      current.startTimeMs,
+      timeMs - brewStartTime.current
+    );
+    const finalWeight = Math.max(
+      current.startWeightG,
+      endWeightG,
+      current.peakWeightG
+    );
+    const waterG = Math.max(0, finalWeight - current.startWeightG);
+    const durationSeconds = Math.max(
+      0.1,
+      (endTimeMs - current.startTimeMs) / 1000
+    );
+    const finished: FreePourPour = {
+      number: current.number,
+      startTimeMs: Math.round(current.startTimeMs),
+      endTimeMs: Math.round(endTimeMs),
+      startWeightG: roundTo(current.startWeightG),
+      endWeightG: roundTo(finalWeight),
+      waterG: roundTo(waterG),
+      averageFlowGps: roundTo(waterG / durationSeconds),
+      peakFlowGps: roundTo(current.peakFlowGps)
+    };
+    completedPours.current = [...completedPours.current, finished];
+    setPours(completedPours.current);
+    activePour.current = null;
+    setActivePourView(null);
+  };
+
+  const createSession = (beverageG: number | null) => {
+    const waterPouredG = Math.max(0, roundTo(peakWaterWeight.current));
+    const measuredBeverage =
+      beverageG === null ? null : Math.max(0, roundTo(beverageG));
+    const retainedG =
+      measuredBeverage === null
+        ? null
+        : Math.max(0, roundTo(waterPouredG - measuredBeverage));
+    const now = new Date();
+    const session: FreePourSession = {
+      schemaVersion: FREE_POUR_SCHEMA_VERSION,
+      id:
+        globalThis.crypto?.randomUUID?.() ??
+        `free-pour-${now.getTime()}-${Math.round(Math.random() * 100000)}`,
+      brewType: 'pour_over',
+      mode: 'free_pour',
+      name: 'Free Pour',
+      source: 'dial',
+      startedAt: startedAtIso.current || now.toISOString(),
+      completedAt: now.toISOString(),
+      recipe: {
+        profileId: null,
+        profileName: 'Free Pour',
+        doseG,
+        targetWaterG: null,
+        pourTargets: []
+      },
+      measurements: {
+        emptyServerG: roundTo(serverWeight.current),
+        setupG: roundTo(setupWeight.current),
+        waterPouredG,
+        beverageG: measuredBeverage,
+        retainedG,
+        durationMs: Math.round(elapsedMsRef.current),
+        status: measuredBeverage === null ? 'skipped' : 'measured'
+      },
+      pours: completedPours.current,
+      samples: samples.current,
+      completion: completion.current,
+      sync: { status: 'pending', attempts: 0 }
+    };
+    setResult(session);
+    updateStage('result');
+    saveFreePourSession(session).catch((error) => {
+      console.error('Failed to save Free Pour session', error);
+    });
+  };
+
+  const beginMeasurement = (timeMs: number) => {
+    if (finalizing.current) return;
+    finalizing.current = true;
+    if (activePour.current) finishActivePour(timeMs, peakWaterWeight.current);
+    detector.current.reset();
+    updateStage('measuring');
+  };
+
+  useEffect(() => {
+    const keepAwake = window.setInterval(resetTimer, 60_000);
+    return () => window.clearInterval(keepAwake);
+  }, [resetTimer]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const now = performance.now();
+      const currentStage = stageRef.current;
+      const currentWeight = weightRef.current;
+      const currentFlow = Math.max(0, flowRef.current);
+
+      if (
+        brewStartTime.current !== null &&
+        (currentStage === 'pouring' ||
+          currentStage === 'waiting' ||
+          currentStage === 'finish-requested')
+      ) {
+        const removalThreshold = Math.max(28, setupWeight.current * 0.18);
+        if (
+          peakWaterWeight.current >= 20 &&
+          currentWeight <= peakWaterWeight.current - removalThreshold
+        ) {
+          beginMeasurement(now);
+          return;
+        }
+      }
+
+      const timingActive =
+        currentStage === 'pouring' ||
+        currentStage === 'waiting' ||
+        currentStage === 'finish-requested';
+      if (brewStartTime.current !== null && timingActive) {
+        const nextElapsed = now - brewStartTime.current;
+        elapsedMsRef.current = nextElapsed;
+        setElapsedMs(nextElapsed);
+        peakWaterWeight.current = Math.max(
+          peakWaterWeight.current,
+          currentWeight
+        );
+        if (activePour.current) {
+          activePour.current.peakWeightG = Math.max(
+            activePour.current.peakWeightG,
+            currentWeight
+          );
+          activePour.current.peakFlowGps = Math.max(
+            activePour.current.peakFlowGps,
+            currentFlow
+          );
+        }
+        if (now - lastStoredSampleTime.current >= SAMPLE_INTERVAL_MS) {
+          lastStoredSampleTime.current = now;
+          samples.current.push({
+            t: Math.round(nextElapsed),
+            w: roundTo(Math.max(0, currentWeight)),
+            f: roundTo(currentFlow),
+            p: activePour.current?.number ?? 0
+          });
+        }
+      }
+
+      const brewingStage =
+        currentStage === 'ready' ||
+        currentStage === 'pouring' ||
+        currentStage === 'waiting';
+      if (brewingStage) {
+        const detectorSample: DetectorSample = {
+          timeMs: now,
+          weightG: currentWeight,
+          flowGps: currentFlow
+        };
+        const event = detector.current.process(detectorSample);
+        if (event?.type === 'pour-start') {
+          if (brewStartTime.current === null) {
+            brewStartTime.current = event.sample.timeMs;
+            startedAtIso.current = new Date(
+              Date.now() - (now - event.sample.timeMs)
+            ).toISOString();
+            peakWaterWeight.current = Math.max(0, event.sample.weightG);
+          }
+          const previousFifthPour =
+            completedPours.current.length >= MAX_POURS
+              ? completedPours.current[MAX_POURS - 1]
+              : null;
+          if (previousFifthPour) {
+            completedPours.current = completedPours.current.slice(0, -1);
+            setPours(completedPours.current);
+          }
+          const startTimeMs = previousFifthPour
+            ? previousFifthPour.startTimeMs
+            : event.sample.timeMs - brewStartTime.current;
+          const nextPour = previousFifthPour
+            ? {
+                number: MAX_POURS,
+                startTimeMs,
+                startWeightG: previousFifthPour.startWeightG,
+                peakWeightG: Math.max(
+                  previousFifthPour.endWeightG,
+                  event.sample.weightG
+                ),
+                peakFlowGps: Math.max(
+                  previousFifthPour.peakFlowGps,
+                  event.sample.flowGps
+                )
+              }
+            : {
+                number: completedPours.current.length + 1,
+                startTimeMs,
+                startWeightG: Math.max(0, event.sample.weightG),
+                peakWeightG: Math.max(0, event.sample.weightG),
+                peakFlowGps: Math.max(0, event.sample.flowGps)
+              };
+          activePour.current = nextPour;
+          setActivePourView({ number: nextPour.number, startTimeMs });
+          updateStage('pouring');
+        } else if (event?.type === 'pour-end' && activePour.current) {
+          finishActivePour(event.sample.timeMs, event.sample.weightG);
+          updateStage('waiting');
+        }
+      }
+    }, 100);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!stable || stage !== 'measuring') return;
+    const candidateBeverage = weight + setupWeight.current;
+    const water = peakWaterWeight.current;
+    const plausible =
+      candidateBeverage >= Math.max(8, water * 0.2) &&
+      candidateBeverage <= water + 8;
+    if (plausible) {
+      createSession(candidateBeverage);
+    } else if (candidateBeverage <= Math.max(5, water * 0.08)) {
+      finalizing.current = false;
+      updateStage('replace-server');
+    } else if (candidateBeverage > water + 8) {
+      // A transient bump can resemble a lift. Return to the live state once
+      // the full setup is stable on the scale again.
+      finalizing.current = false;
+      updateStage('waiting');
+    }
+  }, [stable, stage, weight]);
+
+  useEffect(() => {
+    if (!stable || stage !== 'replace-server') return;
+    const candidateBeverage = weight + setupWeight.current;
+    const water = peakWaterWeight.current;
+    if (
+      candidateBeverage >= Math.max(8, water * 0.2) &&
+      candidateBeverage <= water + 8
+    ) {
+      createSession(candidateBeverage);
+    }
+  }, [stable, stage, weight]);
+
+  useHandleGestures(
+    {
+      left() {
+        if (stageRef.current === 'dose')
+          setDoseG((value) => clamp(value - 1, 5, 40));
+      },
+      right() {
+        if (stageRef.current === 'dose')
+          setDoseG((value) => clamp(value + 1, 5, 40));
+      },
+      click() {
+        const currentStage = stageRef.current;
+        if (currentStage === 'server' && serverReady) {
+          serverWeight.current = weightRef.current;
+          socket.emit('action', 'tare');
+          updateStage('dose');
+          return;
+        }
+        if (currentStage === 'dose' && setupReady) {
+          setupWeight.current = weightRef.current;
+          socket.emit('action', 'tare');
+          window.setTimeout(() => updateStage('recipe'), 350);
+          return;
+        }
+        if (currentStage === 'recipe') {
+          updateStage('ready');
+          return;
+        }
+        if (currentStage === 'pouring' || currentStage === 'waiting') {
+          completion.current = 'dial_fallback';
+          updateStage('finish-requested');
+          return;
+        }
+        if (currentStage === 'replace-server') {
+          createSession(null);
+          return;
+        }
+        if (currentStage === 'result') {
+          dispatch(setScreen('freePourHistory'));
+        }
+      },
+      pressDown() {
+        if (stageRef.current === 'ready') return;
+      },
+      context() {
+        dispatch(setScreen('profileHome'));
+      }
+    },
+    false
+  );
+
+  const step = stepForStage(stage);
+  const liveFlow = Math.max(0, gravimetricFlow);
+  const roundedWeight = Math.max(0, Math.round(weight));
+  const liveState =
+    stage === 'ready' || stage === 'pouring' || stage === 'waiting';
+  const statusLabel =
+    stage === 'ready'
+      ? 'READY'
+      : stage === 'pouring'
+        ? `POUR ${activePourView?.number ?? 1}`
+        : stage === 'waiting'
+          ? pours.length >= MAX_POURS
+            ? 'DRAWDOWN'
+            : 'WAITING'
+          : '';
+  const railPours = useMemo(() => pours, [pours]);
+
+  if (stage === 'dose') {
+    return (
+      <div className="free-pour-screen free-pour-dose-screen">
+        <Gauge
+          value={doseG}
+          minValue={5}
+          maxValue={40}
+          precision={0}
+          unit="gram"
+        />
+        <div className="free-pour-step">2 OF 7</div>
+        <div className="free-pour-dose-title">SET COFFEE DOSE</div>
+        <div
+          className={`free-pour-dose-action ${
+            setupReady ? '' : 'free-pour-dose-action--disabled'
+          }`}
+        >
+          <span>PRESS DIAL TO SAVE</span>
+          <strong>DOSE + TARE</strong>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'server') {
+    return (
+      <div className="free-pour-screen free-pour-setup-screen">
+        <div className="free-pour-step">1 OF 7</div>
+        <div className="free-pour-kicker">EMPTY SERVER</div>
+        <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
+        <div className="free-pour-stability">
+          {weight < 20
+            ? 'PLACE EMPTY SERVER'
+            : serverReady
+              ? 'WEIGHT STABLE'
+              : 'WAITING FOR STABLE WEIGHT'}
+        </div>
+        <div className="free-pour-setup-action">PRESS DIAL TO SAVE + TARE</div>
+      </div>
+    );
+  }
+
+  if (stage === 'recipe') {
+    return (
+      <div className="free-pour-screen free-pour-recipe-screen">
+        <div className="free-pour-step">3 OF 7</div>
+        <div className="free-pour-name">FREE POUR</div>
+        <div className="free-pour-recipe-dose">{doseG}g</div>
+        <div className="free-pour-recipe-label">DOSE</div>
+        <div className="free-pour-recipe-ready">READY TO BREW</div>
+        <div className="free-pour-recipe-action">PRESS DIAL TO CONTINUE</div>
+      </div>
+    );
+  }
+
+  if (liveState) {
+    return (
+      <div className="free-pour-screen free-pour-live-screen">
+        <div className="free-pour-step">{step} OF 7</div>
+        <div className="free-pour-name">FREE POUR</div>
+        <div className="free-pour-timer">{formatBrewTime(elapsedMs)}</div>
+        <div className="free-pour-live-status">{statusLabel}</div>
+        <PourRail
+          pours={railPours}
+          activePour={activePourView}
+          waiting={stage === 'ready' || stage === 'waiting'}
+        />
+        <div className="free-pour-live-weight">{roundedWeight}g</div>
+        <FlowMeter flow={liveFlow} />
+        <div className="free-pour-live-instruction">
+          {stage === 'ready' ? (
+            'START POURING'
+          ) : stage === 'waiting' ? (
+            <>
+              {pours.length < MAX_POURS && <span>POUR AGAIN OR</span>}
+              <strong>LIFT BREWER TO FINISH</strong>
+            </>
+          ) : (
+            'POURING'
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'finish-requested') {
+    return (
+      <div className="free-pour-screen free-pour-message-screen">
+        <div className="free-pour-step">6 OF 7</div>
+        <div className="free-pour-message-main">LIFT BREWER</div>
+        <div className="free-pour-message-sub">KEEP SERVER ON SCALE</div>
+      </div>
+    );
+  }
+
+  if (stage === 'measuring') {
+    return (
+      <div className="free-pour-screen free-pour-message-screen">
+        <div className="free-pour-step">6 OF 7</div>
+        <div className="free-pour-message-main">
+          MEASURING
+          <br />
+          BREW WEIGHT
+        </div>
+        <div className="free-pour-message-sub">KEEP SERVER ON SCALE</div>
+        <div className="free-pour-stability free-pour-message-stability">
+          WEIGHT STABILIZING
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'replace-server') {
+    return (
+      <div className="free-pour-screen free-pour-message-screen">
+        <div className="free-pour-step">6 OF 7</div>
+        <div className="free-pour-message-main">SERVER REMOVED</div>
+        <div className="free-pour-message-sub">
+          PUT BACK SERVER ONLY
+          <br />
+          WE’LL MEASURE AUTOMATICALLY
+        </div>
+        <div className="free-pour-skip">
+          BEVERAGE MUST REMAIN · PRESS TO SKIP
+        </div>
+      </div>
+    );
+  }
+
+  const beverage = result?.measurements.beverageG;
+  return (
+    <div className="free-pour-screen free-pour-result-screen">
+      <div className="free-pour-step">7 OF 7</div>
+      <div className="free-pour-kicker">FREE POUR COMPLETE</div>
+      <div className="free-pour-result-value">
+        {beverage === null || beverage === undefined
+          ? '—'
+          : `${Math.round(beverage)}g`}
+      </div>
+      <div className="free-pour-result-label">BREWED</div>
+      <div className="free-pour-result-stats">
+        <div>
+          <span>WATER POURED</span>
+          <strong>{Math.round(result?.measurements.waterPouredG ?? 0)}g</strong>
+        </div>
+        <div>
+          <span>RETAINED</span>
+          <strong>
+            {result?.measurements.retainedG == null
+              ? '—'
+              : `${Math.round(result.measurements.retainedG)}g`}
+          </strong>
+        </div>
+      </div>
+      <div className="free-pour-result-action">PRESS TO REVIEW</div>
+    </div>
+  );
+};

--- a/src/features/freePour/FreePourScreen.tsx
+++ b/src/features/freePour/FreePourScreen.tsx
@@ -26,6 +26,10 @@ import {
   MAX_FREE_POUR_TEMPERATURE_C,
   MIN_FREE_POUR_TEMPERATURE_C
 } from './profile';
+import {
+  BrewerRemovalConfirmation,
+  updatePlausiblePeakWeight
+} from './brewWeightFilter';
 import './free-pour.css';
 
 type Stage =
@@ -149,11 +153,13 @@ const FlowMeter = ({ flow, target }: { flow: number; target?: number }) => {
 const TargetPourRail = ({
   targets,
   currentPour,
-  pouring
+  pouring,
+  cue
 }: {
   targets: PourOverPourTarget[];
   currentPour: number;
   pouring: boolean;
+  cue: 'idle' | 'countdown' | 'due';
 }) => {
   const visibleTargets = targets.slice(0, MAX_POURS);
   const middle = (visibleTargets.length - 1) / 2;
@@ -163,6 +169,12 @@ const TargetPourRail = ({
       {visibleTargets.map((target, index) => {
         const past = target.number < currentPour;
         const active = target.number === currentPour;
+        const cueClass =
+          active && cue === 'countdown'
+            ? 'free-pour-dot--cue'
+            : active && cue === 'due'
+              ? 'free-pour-dot--due'
+              : '';
         return (
           <div
             className="free-pour-rail-point"
@@ -175,7 +187,7 @@ const TargetPourRail = ({
                   ? 'free-pour-dot--past'
                   : active && pouring
                     ? 'free-pour-dot--active'
-                    : ''
+                    : cueClass
               }`}
             />
             <small>{formatBrewTime(target.startTimeMs)}</small>
@@ -277,7 +289,9 @@ export const FreePourScreen = ({
   const brewStartTime = useRef<number | null>(null);
   const elapsedMsRef = useRef(0);
   const lastStoredSampleTime = useRef(0);
+  const lastPeakFilterTime = useRef<number | null>(null);
   const peakWaterWeight = useRef(0);
+  const brewerRemoval = useRef(new BrewerRemovalConfirmation());
   const samples = useRef<FreePourSample[]>([]);
   const completedPours = useRef<FreePourPour[]>([]);
   const activePour = useRef<{
@@ -427,8 +441,14 @@ export const FreePourScreen = ({
   const beginMeasurement = (timeMs: number) => {
     if (finalizing.current) return;
     finalizing.current = true;
+    if (brewStartTime.current !== null) {
+      const finalElapsedMs = Math.max(0, timeMs - brewStartTime.current);
+      elapsedMsRef.current = finalElapsedMs;
+      setElapsedMs(finalElapsedMs);
+    }
     if (activePour.current) finishActivePour(timeMs, peakWaterWeight.current);
     detector.current.reset();
+    brewerRemoval.current.reset();
     logFreePour('brew_weight_measurement_started', {
       runId,
       elapsed_ms: Math.round(elapsedMsRef.current),
@@ -465,28 +485,6 @@ export const FreePourScreen = ({
       const currentWeight = weightRef.current;
       const currentFlow = Math.max(0, flowRef.current);
 
-      if (
-        brewStartTime.current !== null &&
-        (currentStage === 'pouring' ||
-          currentStage === 'waiting' ||
-          currentStage === 'finish-requested')
-      ) {
-        const removalThreshold = Math.max(28, setupWeight.current * 0.18);
-        if (
-          peakWaterWeight.current >= 20 &&
-          currentWeight <= peakWaterWeight.current - removalThreshold
-        ) {
-          logFreePour('brewer_removal_detected', {
-            runId,
-            scale_g: roundTo(currentWeight),
-            peak_water_g: roundTo(peakWaterWeight.current),
-            threshold_g: roundTo(removalThreshold)
-          });
-          beginMeasurement(now);
-          return;
-        }
-      }
-
       const timingActive =
         currentStage === 'pouring' ||
         currentStage === 'waiting' ||
@@ -495,14 +493,21 @@ export const FreePourScreen = ({
         const nextElapsed = now - brewStartTime.current;
         elapsedMsRef.current = nextElapsed;
         setElapsedMs(nextElapsed);
-        peakWaterWeight.current = Math.max(
+        const peakFilterElapsedMs =
+          lastPeakFilterTime.current === null
+            ? 100
+            : now - lastPeakFilterTime.current;
+        lastPeakFilterTime.current = now;
+        peakWaterWeight.current = updatePlausiblePeakWeight(
           peakWaterWeight.current,
-          currentWeight
+          currentWeight,
+          peakFilterElapsedMs
         );
         if (activePour.current) {
-          activePour.current.peakWeightG = Math.max(
+          activePour.current.peakWeightG = updatePlausiblePeakWeight(
             activePour.current.peakWeightG,
-            currentWeight
+            currentWeight,
+            peakFilterElapsedMs
           );
           activePour.current.peakFlowGps = Math.max(
             activePour.current.peakFlowGps,
@@ -518,6 +523,42 @@ export const FreePourScreen = ({
             p: activePour.current?.number ?? 0
           });
         }
+
+        const removalThreshold = Math.max(28, setupWeight.current * 0.18);
+        const belowRemovalThreshold =
+          peakWaterWeight.current >= 20 &&
+          currentWeight <= peakWaterWeight.current - removalThreshold;
+        const removalState = brewerRemoval.current.update(
+          belowRemovalThreshold,
+          now
+        );
+        if (removalState.type === 'started') {
+          logFreePour('brewer_removal_candidate_started', {
+            runId,
+            scale_g: roundTo(currentWeight),
+            peak_water_g: roundTo(peakWaterWeight.current),
+            threshold_g: roundTo(removalThreshold)
+          });
+        } else if (removalState.type === 'cancelled') {
+          logFreePour('brewer_removal_candidate_cancelled', {
+            runId,
+            held_ms: Math.round(removalState.heldMs),
+            scale_g: roundTo(currentWeight)
+          });
+        } else if (removalState.type === 'confirmed') {
+          logFreePour('brewer_removal_detected', {
+            runId,
+            held_ms: Math.round(removalState.heldMs),
+            scale_g: roundTo(currentWeight),
+            peak_water_g: roundTo(peakWaterWeight.current),
+            threshold_g: roundTo(removalThreshold)
+          });
+          beginMeasurement(removalState.startedAtMs);
+          return;
+        }
+      } else {
+        lastPeakFilterTime.current = null;
+        brewerRemoval.current.reset();
       }
 
       const brewingStage =
@@ -538,6 +579,8 @@ export const FreePourScreen = ({
               Date.now() - (now - event.sample.timeMs)
             ).toISOString();
             peakWaterWeight.current = Math.max(0, event.sample.weightG);
+            lastPeakFilterTime.current = event.sample.timeMs;
+            brewerRemoval.current.reset();
           }
           const previousFifthPour =
             completedPours.current.length >= MAX_POURS
@@ -582,7 +625,7 @@ export const FreePourScreen = ({
           setActivePourView({ number: nextPour.number, startTimeMs });
           updateStage('pouring');
         } else if (event?.type === 'pour-end' && activePour.current) {
-          finishActivePour(event.sample.timeMs, event.sample.weightG);
+          finishActivePour(event.sample.timeMs, activePour.current.peakWeightG);
           updateStage('waiting');
         }
       }
@@ -833,6 +876,17 @@ export const FreePourScreen = ({
   const activeTarget = profile?.pourTargets.find(
     (target) => target.number === currentTargetNumber
   );
+  const targetRemainingMs = activeTarget
+    ? activeTarget.startTimeMs - elapsedMs
+    : null;
+  const pourCue =
+    stage === 'waiting' && targetRemainingMs !== null
+      ? targetRemainingMs <= 0
+        ? 'due'
+        : targetRemainingMs <= 5000
+          ? 'countdown'
+          : 'idle'
+      : 'idle';
   const statusLabel =
     stage === 'ready'
       ? 'READY'
@@ -846,6 +900,18 @@ export const FreePourScreen = ({
             : 'WAITING'
           : '';
   const railPours = useMemo(() => pours, [pours]);
+
+  useEffect(() => {
+    if (!activeTarget || (pourCue !== 'countdown' && pourCue !== 'due')) return;
+    logFreePour(
+      pourCue === 'countdown' ? 'next_pour_cue_started' : 'next_pour_due',
+      {
+        runId,
+        pour: activeTarget.number,
+        target_start_ms: activeTarget.startTimeMs
+      }
+    );
+  }, [activeTarget?.number, pourCue, runId]);
 
   if (stage === 'temperature') {
     return (
@@ -1003,6 +1069,7 @@ export const FreePourScreen = ({
             targets={profile.pourTargets}
             currentPour={currentTargetNumber}
             pouring={stage === 'pouring'}
+            cue={pourCue}
           />
         ) : (
           <PourRail

--- a/src/features/freePour/FreePourScreen.tsx
+++ b/src/features/freePour/FreePourScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
-import { Gauge } from '../../components/SettingNumerical/Gauge';
 import { useAppDispatch, useAppSelector } from '../../components/store/hooks';
 import { useSocket } from '../../components/store/SocketManager';
 import { setScreen } from '../../components/store/features/screens/screens-slice';
@@ -20,7 +19,8 @@ import './free-pour.css';
 
 type Stage =
   | 'server'
-  | 'dose'
+  | 'brewer'
+  | 'coffee'
   | 'recipe'
   | 'ready'
   | 'pouring'
@@ -35,12 +35,13 @@ const MAX_POURS = 5;
 
 const stepForStage = (stage: Stage) => {
   if (stage === 'server') return 1;
-  if (stage === 'dose') return 2;
-  if (stage === 'recipe') return 3;
-  if (stage === 'ready' || stage === 'pouring') return 4;
-  if (stage === 'waiting') return 5;
-  if (stage === 'finish-requested' || stage === 'measuring') return 6;
-  return 7;
+  if (stage === 'brewer') return 2;
+  if (stage === 'coffee') return 3;
+  if (stage === 'recipe') return 4;
+  if (stage === 'ready' || stage === 'pouring') return 5;
+  if (stage === 'waiting') return 6;
+  if (stage === 'finish-requested' || stage === 'measuring') return 7;
+  return 8;
 };
 
 const useStableWeight = (weight: number, resetKey: Stage) => {
@@ -171,13 +172,15 @@ export const FreePourScreen = () => {
   const [result, setResult] = useState<FreePourSession | null>(null);
   const stable = useStableWeight(weight, stage);
   const serverReady = stable && weight >= 20;
-  const setupReady = stable && weight >= 5;
+  const brewerReady = stable && weight >= 10;
+  const coffeeReady = stable && weight >= 5 && weight <= 40;
 
   const stageRef = useRef(stage);
   const weightRef = useRef(weight);
   const flowRef = useRef(gravimetricFlow);
   const detector = useRef(new PourDetector());
   const serverWeight = useRef(0);
+  const brewerWeight = useRef(0);
   const setupWeight = useRef(0);
   const startedAtIso = useRef('');
   const brewStartTime = useRef<number | null>(null);
@@ -267,6 +270,7 @@ export const FreePourScreen = () => {
       },
       measurements: {
         emptyServerG: roundTo(serverWeight.current),
+        brewerG: roundTo(brewerWeight.current),
         setupG: roundTo(setupWeight.current),
         waterPouredG,
         beverageG: measuredBeverage,
@@ -452,26 +456,26 @@ export const FreePourScreen = () => {
 
   useHandleGestures(
     {
-      left() {
-        if (stageRef.current === 'dose')
-          setDoseG((value) => clamp(value - 1, 5, 40));
-      },
-      right() {
-        if (stageRef.current === 'dose')
-          setDoseG((value) => clamp(value + 1, 5, 40));
-      },
-      click() {
+      pressDown() {
         const currentStage = stageRef.current;
         if (currentStage === 'server' && serverReady) {
           serverWeight.current = weightRef.current;
           socket.emit('action', 'tare');
-          updateStage('dose');
+          updateStage('brewer');
           return;
         }
-        if (currentStage === 'dose' && setupReady) {
-          setupWeight.current = weightRef.current;
+        if (currentStage === 'brewer' && brewerReady) {
+          brewerWeight.current = weightRef.current;
           socket.emit('action', 'tare');
-          window.setTimeout(() => updateStage('recipe'), 350);
+          updateStage('coffee');
+          return;
+        }
+        if (currentStage === 'coffee' && coffeeReady) {
+          const measuredDose = weightRef.current;
+          setDoseG(Math.round(measuredDose));
+          setupWeight.current = brewerWeight.current + measuredDose;
+          socket.emit('action', 'tare');
+          updateStage('recipe');
           return;
         }
         if (currentStage === 'recipe') {
@@ -490,9 +494,6 @@ export const FreePourScreen = () => {
         if (currentStage === 'result') {
           dispatch(setScreen('freePourHistory'));
         }
-      },
-      pressDown() {
-        if (stageRef.current === 'ready') return;
       },
       context() {
         dispatch(setScreen('profileHome'));
@@ -518,21 +519,49 @@ export const FreePourScreen = () => {
           : '';
   const railPours = useMemo(() => pours, [pours]);
 
-  if (stage === 'dose') {
+  if (stage === 'brewer') {
     return (
-      <div className="free-pour-screen free-pour-dose-screen">
-        <Gauge
-          value={doseG}
-          minValue={5}
-          maxValue={40}
-          precision={0}
-          unit="gram"
-        />
-        <div className="free-pour-step">2 OF 7</div>
-        <div className="free-pour-dose-title">SET COFFEE DOSE</div>
+      <div className="free-pour-screen free-pour-setup-screen">
+        <div className="free-pour-step">2 OF 8</div>
+        <div className="free-pour-kicker">ADD BREWER</div>
+        <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
+        <div className="free-pour-stability">
+          {weight < 10
+            ? 'PLACE BREWER ON SERVER'
+            : brewerReady
+              ? 'WEIGHT STABLE'
+              : 'WAITING FOR STABLE WEIGHT'}
+        </div>
         <div
           className={`free-pour-dose-action ${
-            setupReady ? '' : 'free-pour-dose-action--disabled'
+            brewerReady ? '' : 'free-pour-dose-action--disabled'
+          }`}
+        >
+          <span>PRESS DIAL TO SAVE</span>
+          <strong>BREWER + TARE</strong>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'coffee') {
+    return (
+      <div className="free-pour-screen free-pour-setup-screen">
+        <div className="free-pour-step">3 OF 8</div>
+        <div className="free-pour-kicker">ADD COFFEE</div>
+        <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
+        <div className="free-pour-stability">
+          {weight < 5
+            ? 'ADD 5–40g COFFEE'
+            : weight > 40
+              ? 'DOSE MUST BE 5–40g'
+              : coffeeReady
+                ? 'DOSE READY'
+                : 'WAITING FOR STABLE WEIGHT'}
+        </div>
+        <div
+          className={`free-pour-dose-action ${
+            coffeeReady ? '' : 'free-pour-dose-action--disabled'
           }`}
         >
           <span>PRESS DIAL TO SAVE</span>
@@ -545,7 +574,7 @@ export const FreePourScreen = () => {
   if (stage === 'server') {
     return (
       <div className="free-pour-screen free-pour-setup-screen">
-        <div className="free-pour-step">1 OF 7</div>
+        <div className="free-pour-step">1 OF 8</div>
         <div className="free-pour-kicker">EMPTY SERVER</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
@@ -563,7 +592,7 @@ export const FreePourScreen = () => {
   if (stage === 'recipe') {
     return (
       <div className="free-pour-screen free-pour-recipe-screen">
-        <div className="free-pour-step">3 OF 7</div>
+        <div className="free-pour-step">4 OF 8</div>
         <div className="free-pour-name">FREE POUR</div>
         <div className="free-pour-recipe-dose">{doseG}g</div>
         <div className="free-pour-recipe-label">DOSE</div>
@@ -576,7 +605,7 @@ export const FreePourScreen = () => {
   if (liveState) {
     return (
       <div className="free-pour-screen free-pour-live-screen">
-        <div className="free-pour-step">{step} OF 7</div>
+        <div className="free-pour-step">{step} OF 8</div>
         <div className="free-pour-name">FREE POUR</div>
         <div className="free-pour-timer">{formatBrewTime(elapsedMs)}</div>
         <div className="free-pour-live-status">{statusLabel}</div>
@@ -606,7 +635,7 @@ export const FreePourScreen = () => {
   if (stage === 'finish-requested') {
     return (
       <div className="free-pour-screen free-pour-message-screen">
-        <div className="free-pour-step">6 OF 7</div>
+        <div className="free-pour-step">7 OF 8</div>
         <div className="free-pour-message-main">LIFT BREWER</div>
         <div className="free-pour-message-sub">KEEP SERVER ON SCALE</div>
       </div>
@@ -616,7 +645,7 @@ export const FreePourScreen = () => {
   if (stage === 'measuring') {
     return (
       <div className="free-pour-screen free-pour-message-screen">
-        <div className="free-pour-step">6 OF 7</div>
+        <div className="free-pour-step">7 OF 8</div>
         <div className="free-pour-message-main">
           MEASURING
           <br />
@@ -633,7 +662,7 @@ export const FreePourScreen = () => {
   if (stage === 'replace-server') {
     return (
       <div className="free-pour-screen free-pour-message-screen">
-        <div className="free-pour-step">6 OF 7</div>
+        <div className="free-pour-step">7 OF 8</div>
         <div className="free-pour-message-main">SERVER REMOVED</div>
         <div className="free-pour-message-sub">
           PUT BACK SERVER ONLY
@@ -650,7 +679,7 @@ export const FreePourScreen = () => {
   const beverage = result?.measurements.beverageG;
   return (
     <div className="free-pour-screen free-pour-result-screen">
-      <div className="free-pour-step">7 OF 7</div>
+      <div className="free-pour-step">8 OF 8</div>
       <div className="free-pour-kicker">FREE POUR COMPLETE</div>
       <div className="free-pour-result-value">
         {beverage === null || beverage === undefined

--- a/src/features/freePour/FreePourScreen.tsx
+++ b/src/features/freePour/FreePourScreen.tsx
@@ -17,15 +17,22 @@ import {
   FreePourCompletion,
   FreePourPour,
   FreePourSample,
-  FreePourSession
+  FreePourSession,
+  PourOverPourTarget,
+  PourOverProfile
 } from './types';
+import {
+  DEFAULT_FREE_POUR_TEMPERATURE_C,
+  MAX_FREE_POUR_TEMPERATURE_C,
+  MIN_FREE_POUR_TEMPERATURE_C
+} from './profile';
 import './free-pour.css';
 
 type Stage =
   | 'server'
   | 'brewer'
   | 'coffee'
-  | 'recipe'
+  | 'temperature'
   | 'ready'
   | 'pouring'
   | 'waiting'
@@ -57,14 +64,14 @@ const isValidSetupWeight = (stage: SetupStage, weight: number) => {
 const nextStageAfterTare = (stage: SetupStage): Stage => {
   if (stage === 'server') return 'brewer';
   if (stage === 'brewer') return 'coffee';
-  return 'recipe';
+  return 'ready';
 };
 
 const stepForStage = (stage: Stage) => {
-  if (stage === 'server') return 1;
-  if (stage === 'brewer') return 2;
-  if (stage === 'coffee') return 3;
-  if (stage === 'recipe') return 4;
+  if (stage === 'temperature') return 1;
+  if (stage === 'server') return 2;
+  if (stage === 'brewer') return 3;
+  if (stage === 'coffee') return 4;
   if (stage === 'ready' || stage === 'pouring') return 5;
   if (stage === 'waiting') return 6;
   if (stage === 'finish-requested' || stage === 'measuring') return 7;
@@ -103,8 +110,10 @@ const useStableWeight = (weight: number, resetKey: Stage) => {
   return stable;
 };
 
-const FlowMeter = ({ flow }: { flow: number }) => {
+const FlowMeter = ({ flow, target }: { flow: number; target?: number }) => {
   const displayedFlow = clamp(flow, 0, 10);
+  const displayedTarget =
+    target === undefined ? undefined : clamp(target, 0, 10);
   return (
     <div className="free-pour-flow-meter">
       <div className="free-pour-flow-title">
@@ -121,12 +130,58 @@ const FlowMeter = ({ flow }: { flow: number }) => {
             />
           </span>
         ))}
+        {displayedTarget !== undefined && (
+          <span
+            className="free-pour-flow-target"
+            style={{ left: `${displayedTarget * 10}%` }}
+          />
+        )}
       </div>
       <div className="free-pour-flow-axis">
         {Array.from({ length: 11 }, (_, index) => (
           <span key={index}>{index}</span>
         ))}
       </div>
+    </div>
+  );
+};
+
+const TargetPourRail = ({
+  targets,
+  currentPour,
+  pouring
+}: {
+  targets: PourOverPourTarget[];
+  currentPour: number;
+  pouring: boolean;
+}) => {
+  const visibleTargets = targets.slice(0, MAX_POURS);
+  const middle = (visibleTargets.length - 1) / 2;
+  return (
+    <div className="free-pour-rail free-pour-target-rail">
+      <div className="free-pour-rail-line free-pour-rail-line--complete" />
+      {visibleTargets.map((target, index) => {
+        const past = target.number < currentPour;
+        const active = target.number === currentPour;
+        return (
+          <div
+            className="free-pour-rail-point"
+            key={target.number}
+            style={{ transform: `translateX(${(index - middle) * 58}px)` }}
+          >
+            <span
+              className={`free-pour-dot ${
+                past
+                  ? 'free-pour-dot--past'
+                  : active && pouring
+                    ? 'free-pour-dot--active'
+                    : ''
+              }`}
+            />
+            <small>{formatBrewTime(target.startTimeMs)}</small>
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -182,15 +237,22 @@ const PourRail = ({
   );
 };
 
-export const FreePourScreen = () => {
+export const FreePourScreen = ({
+  profile
+}: {
+  profile?: PourOverProfile;
+} = {}) => {
   const dispatch = useAppDispatch();
   const socket = useSocket();
   const { resetTimer } = useIdleTimer();
   const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const weight = useAppSelector((state) => state.stats.sensors.w || 0);
   const gravimetricFlow = useAppSelector((state) => state.stats.sensors.g || 0);
-  const [stage, setStage] = useState<Stage>('server');
-  const [doseG, setDoseG] = useState(15);
+  const [stage, setStage] = useState<Stage>('temperature');
+  const [doseG, setDoseG] = useState(profile?.doseG ?? 15);
+  const [temperatureC, setTemperatureC] = useState(
+    profile?.temperatureC ?? DEFAULT_FREE_POUR_TEMPERATURE_C
+  );
   const [elapsedMs, setElapsedMs] = useState(0);
   const [pours, setPours] = useState<FreePourPour[]>([]);
   const [activePourView, setActivePourView] = useState<{
@@ -305,22 +367,26 @@ export const FreePourScreen = () => {
         globalThis.crypto?.randomUUID?.() ??
         `free-pour-${now.getTime()}-${Math.round(Math.random() * 100000)}`,
       brewType: 'pour_over',
-      mode: 'free_pour',
-      name: 'Free Pour',
+      mode: profile ? 'profile' : 'free_pour',
+      name: profile?.name ?? 'Free Pour',
       source: 'dial',
       startedAt: startedAtIso.current || now.toISOString(),
       completedAt: now.toISOString(),
       recipe: {
-        profileId: null,
-        profileName: 'Free Pour',
-        doseG,
-        targetWaterG: null,
-        pourTargets: []
+        profileId: profile?.id ?? null,
+        profileName: profile?.name ?? 'Free Pour',
+        doseG: profile?.doseG ?? doseG,
+        temperatureC: profile?.temperatureC ?? temperatureC,
+        targetWaterG: profile?.targetWaterG ?? null,
+        targetDurationMs: profile?.targetDurationMs ?? null,
+        pourTargets: profile?.pourTargets ?? []
       },
       measurements: {
         serverBaselineG: roundTo(serverWeight.current),
         brewerG: roundTo(brewerWeight.current),
         setupG: roundTo(setupWeight.current),
+        doseG: roundTo(doseG),
+        waterTemperatureC: temperatureC,
         waterPouredG,
         beverageG: measuredBeverage,
         retainedG,
@@ -339,6 +405,8 @@ export const FreePourScreen = () => {
       water_g: session.measurements.waterPouredG,
       beverage_g: session.measurements.beverageG,
       retained_g: session.measurements.retainedG,
+      temperature_c: session.measurements.waterTemperatureC,
+      profile_id: session.recipe.profileId,
       completion: session.completion
     });
     setResult(session);
@@ -370,7 +438,12 @@ export const FreePourScreen = () => {
   };
 
   useEffect(() => {
-    logFreePour('screen_entered', { runId, stage: 'server' });
+    logFreePour('screen_entered', {
+      runId,
+      stage: 'temperature',
+      mode: profile ? 'profile' : 'free_pour',
+      profile_id: profile?.id ?? null
+    });
     return () => {
       logFreePour('screen_exited', {
         runId,
@@ -686,8 +759,13 @@ export const FreePourScreen = () => {
           });
           return;
         }
-        if (currentStage === 'recipe') {
-          updateStage('ready');
+        if (currentStage === 'temperature') {
+          logFreePour('temperature_confirmed', {
+            runId,
+            temperature_c: temperatureC,
+            profile_target_c: profile?.temperatureC ?? null
+          });
+          updateStage('server');
           return;
         }
         if (currentStage === 'pouring' || currentStage === 'waiting') {
@@ -727,6 +805,18 @@ export const FreePourScreen = () => {
           runId,
           stage: stageRef.current
         });
+      },
+      left() {
+        if (stageRef.current !== 'temperature') return;
+        setTemperatureC((value) =>
+          Math.max(MIN_FREE_POUR_TEMPERATURE_C, value - 1)
+        );
+      },
+      right() {
+        if (stageRef.current !== 'temperature') return;
+        setTemperatureC((value) =>
+          Math.min(MAX_FREE_POUR_TEMPERATURE_C, value + 1)
+        );
       }
     },
     bubbleDisplay.interceptsGesture
@@ -737,22 +827,49 @@ export const FreePourScreen = () => {
   const roundedWeight = Math.max(0, Math.round(weight));
   const liveState =
     stage === 'ready' || stage === 'pouring' || stage === 'waiting';
+  const expectedPourCount = profile?.pourTargets.length ?? MAX_POURS;
+  const currentTargetNumber =
+    activePourView?.number ?? Math.min(pours.length + 1, expectedPourCount + 1);
+  const activeTarget = profile?.pourTargets.find(
+    (target) => target.number === currentTargetNumber
+  );
   const statusLabel =
     stage === 'ready'
       ? 'READY'
       : stage === 'pouring'
-        ? `POUR ${activePourView?.number ?? 1}`
+        ? `POUR ${activePourView?.number ?? 1}${
+            profile ? ` OF ${expectedPourCount}` : ''
+          }`
         : stage === 'waiting'
-          ? pours.length >= MAX_POURS
+          ? pours.length >= expectedPourCount
             ? 'DRAWDOWN'
             : 'WAITING'
           : '';
   const railPours = useMemo(() => pours, [pours]);
 
+  if (stage === 'temperature') {
+    return (
+      <div className="free-pour-screen free-pour-temperature-screen">
+        <div className="free-pour-step">1 OF 8</div>
+        <div className="free-pour-kicker">WATER TEMPERATURE</div>
+        <div className="free-pour-temperature-value">
+          {temperatureC}
+          <span>°C</span>
+        </div>
+        <div className="free-pour-temperature-adjust">
+          ROTATE DIAL TO ADJUST
+        </div>
+        <div className="free-pour-temperature-action">
+          PRESS DIAL TO CONTINUE
+        </div>
+      </div>
+    );
+  }
+
   if (stage === 'brewer') {
     return (
       <div className="free-pour-screen free-pour-setup-screen">
-        <div className="free-pour-step">2 OF 8</div>
+        <div className="free-pour-step">3 OF 8</div>
         <div className="free-pour-kicker">ADD BREWER</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
@@ -795,7 +912,7 @@ export const FreePourScreen = () => {
   if (stage === 'coffee') {
     return (
       <div className="free-pour-screen free-pour-setup-screen">
-        <div className="free-pour-step">3 OF 8</div>
+        <div className="free-pour-step">4 OF 8</div>
         <div className="free-pour-kicker">ADD COFFEE</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
@@ -810,7 +927,9 @@ export const FreePourScreen = () => {
                   : weight > 40
                     ? 'DOSE MUST BE 5–40g'
                     : coffeeReady
-                      ? 'DOSE READY'
+                      ? profile
+                        ? `TARGET ${Math.round(profile.doseG)}g · DOSE READY`
+                        : 'DOSE READY'
                       : 'WAITING FOR STABLE WEIGHT'}
         </div>
         <div
@@ -840,8 +959,8 @@ export const FreePourScreen = () => {
   if (stage === 'server') {
     return (
       <div className="free-pour-screen free-pour-setup-screen">
-        <div className="free-pour-step">1 OF 8</div>
-        <div className="free-pour-kicker">EMPTY SERVER</div>
+        <div className="free-pour-step">2 OF 8</div>
+        <div className="free-pour-kicker">WEIGH EMPTY SERVER</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
           {setupStatus === 'saving'
@@ -854,28 +973,20 @@ export const FreePourScreen = () => {
                   ? 'WEIGHT STABLE'
                   : 'WAITING FOR STABLE WEIGHT'}
         </div>
-        <div className="free-pour-setup-action">
-          {setupStatus === 'saving'
-            ? 'SAVING WEIGHT'
-            : setupStatus === 'taring'
-              ? 'TARING…'
-              : setupStatus === 'tare-timeout'
-                ? 'PRESS DIAL TO RETRY'
-                : 'PRESS DIAL TO SAVE + TARE'}
+        <div className="free-pour-dose-action">
+          {setupStatus === 'saving' ? (
+            <strong>SAVING WEIGHT</strong>
+          ) : setupStatus === 'taring' ? (
+            <strong>TARING…</strong>
+          ) : setupStatus === 'tare-timeout' ? (
+            <strong>PRESS DIAL TO RETRY</strong>
+          ) : (
+            <>
+              <span>PRESS DIAL TO</span>
+              <strong>SAVE WEIGHT + TARE</strong>
+            </>
+          )}
         </div>
-      </div>
-    );
-  }
-
-  if (stage === 'recipe') {
-    return (
-      <div className="free-pour-screen free-pour-recipe-screen">
-        <div className="free-pour-step">4 OF 8</div>
-        <div className="free-pour-name">FREE POUR</div>
-        <div className="free-pour-recipe-dose">{doseG}g</div>
-        <div className="free-pour-recipe-label">DOSE</div>
-        <div className="free-pour-recipe-ready">READY TO BREW</div>
-        <div className="free-pour-recipe-action">PRESS DIAL TO CONTINUE</div>
       </div>
     );
   }
@@ -884,22 +995,54 @@ export const FreePourScreen = () => {
     return (
       <div className="free-pour-screen free-pour-live-screen">
         <div className="free-pour-step">{step} OF 8</div>
-        <div className="free-pour-name">FREE POUR</div>
+        <div className="free-pour-name">{profile?.name ?? 'FREE POUR'}</div>
         <div className="free-pour-timer">{formatBrewTime(elapsedMs)}</div>
         <div className="free-pour-live-status">{statusLabel}</div>
-        <PourRail
-          pours={railPours}
-          activePour={activePourView}
-          waiting={stage === 'ready' || stage === 'waiting'}
-        />
-        <div className="free-pour-live-weight">{roundedWeight}g</div>
-        <FlowMeter flow={liveFlow} />
+        {profile ? (
+          <TargetPourRail
+            targets={profile.pourTargets}
+            currentPour={currentTargetNumber}
+            pouring={stage === 'pouring'}
+          />
+        ) : (
+          <PourRail
+            pours={railPours}
+            activePour={activePourView}
+            waiting={stage === 'ready' || stage === 'waiting'}
+          />
+        )}
+        {profile && activeTarget ? (
+          <div className="free-pour-profile-weight">
+            <div>
+              <span>CURRENT</span>
+              <strong>{roundedWeight}g</strong>
+            </div>
+            <i>→</i>
+            <div>
+              <span>STOP</span>
+              <strong>{Math.round(activeTarget.stopWeightG)}g</strong>
+            </div>
+          </div>
+        ) : (
+          <div className="free-pour-live-weight">{roundedWeight}g</div>
+        )}
+        <FlowMeter flow={liveFlow} target={activeTarget?.flowGps} />
         <div className="free-pour-live-instruction">
           {stage === 'ready' ? (
             'START POURING'
           ) : stage === 'waiting' ? (
             <>
-              {pours.length < MAX_POURS && <span>POUR AGAIN OR</span>}
+              {activeTarget ? (
+                <span>
+                  NEXT POUR · START {formatBrewTime(activeTarget.startTimeMs)}
+                </span>
+              ) : profile ? (
+                <span>
+                  DRAWDOWN · TARGET {formatBrewTime(profile.targetDurationMs)}
+                </span>
+              ) : (
+                pours.length < MAX_POURS && <span>POUR AGAIN OR</span>
+              )}
               <strong>LIFT BREWER TO FINISH</strong>
             </>
           ) : (

--- a/src/features/freePour/FreePourScreen.tsx
+++ b/src/features/freePour/FreePourScreen.tsx
@@ -3,11 +3,15 @@ import { useHandleGestures } from '../../hooks/useHandleGestures';
 import { useIdleTimer } from '../../hooks/useIdleTimer';
 import { useAppDispatch, useAppSelector } from '../../components/store/hooks';
 import { useSocket } from '../../components/store/SocketManager';
-import { setScreen } from '../../components/store/features/screens/screens-slice';
+import {
+  setBubbleDisplay,
+  setScreen
+} from '../../components/store/features/screens/screens-slice';
 import { colorDataBlueLight } from '../../constants/colors';
 import { clamp, formatBrewTime, roundTo } from './format';
 import { DetectorSample, PourDetector } from './pourDetector';
 import { saveFreePourSession } from './storage';
+import { logFreePour, logFreePourError } from './logging';
 import {
   FREE_POUR_SCHEMA_VERSION,
   FreePourCompletion,
@@ -30,8 +34,28 @@ type Stage =
   | 'replace-server'
   | 'result';
 
+type SetupStage = Extract<Stage, 'server' | 'brewer' | 'coffee'>;
+type SetupStatus = 'idle' | 'saving' | 'taring' | 'tare-timeout';
+
 const SAMPLE_INTERVAL_MS = 200;
 const MAX_POURS = 5;
+const TARE_CONFIRM_TOLERANCE_G = 0.6;
+const TARE_CONFIRM_TIMEOUT_MS = 5000;
+
+const isSetupStage = (stage: Stage): stage is SetupStage =>
+  stage === 'server' || stage === 'brewer' || stage === 'coffee';
+
+const isValidSetupWeight = (stage: SetupStage, weight: number) => {
+  if (stage === 'server') return weight >= 20;
+  if (stage === 'brewer') return weight >= 10;
+  return weight >= 5 && weight <= 40;
+};
+
+const nextStageAfterTare = (stage: SetupStage): Stage => {
+  if (stage === 'server') return 'brewer';
+  if (stage === 'brewer') return 'coffee';
+  return 'recipe';
+};
 
 const stepForStage = (stage: Stage) => {
   if (stage === 'server') return 1;
@@ -159,6 +183,7 @@ export const FreePourScreen = () => {
   const dispatch = useAppDispatch();
   const socket = useSocket();
   const { resetTimer } = useIdleTimer();
+  const bubbleDisplay = useAppSelector((state) => state.screen.bubbleDisplay);
   const weight = useAppSelector((state) => state.stats.sensors.w || 0);
   const gravimetricFlow = useAppSelector((state) => state.stats.sensors.g || 0);
   const [stage, setStage] = useState<Stage>('server');
@@ -170,6 +195,7 @@ export const FreePourScreen = () => {
     startTimeMs: number;
   } | null>(null);
   const [result, setResult] = useState<FreePourSession | null>(null);
+  const [setupStatus, setSetupStatus] = useState<SetupStatus>('idle');
   const stable = useStableWeight(weight, stage);
   const serverReady = stable && weight >= 20;
   const brewerReady = stable && weight >= 10;
@@ -198,12 +224,23 @@ export const FreePourScreen = () => {
   } | null>(null);
   const completion = useRef<FreePourCompletion>('brewer_removed');
   const finalizing = useRef(false);
+  const setupStatusRef = useRef(setupStatus);
+  const sessionSaved = useRef(false);
+  const [runId] = useState(
+    () =>
+      globalThis.crypto?.randomUUID?.() ??
+      `free-pour-run-${Date.now()}-${Math.round(Math.random() * 100000)}`
+  );
 
   stageRef.current = stage;
   weightRef.current = weight;
   flowRef.current = gravimetricFlow;
+  setupStatusRef.current = setupStatus;
 
   const updateStage = (next: Stage) => {
+    const previous = stageRef.current;
+    if (previous === next) return;
+    logFreePour('stage_changed', { runId, from: previous, to: next });
     stageRef.current = next;
     setStage(next);
   };
@@ -235,6 +272,15 @@ export const FreePourScreen = () => {
       averageFlowGps: roundTo(waterG / durationSeconds),
       peakFlowGps: roundTo(current.peakFlowGps)
     };
+    logFreePour('pour_ended', {
+      runId,
+      pour: finished.number,
+      start_ms: finished.startTimeMs,
+      end_ms: finished.endTimeMs,
+      water_g: finished.waterG,
+      average_flow_gps: finished.averageFlowGps,
+      peak_flow_gps: finished.peakFlowGps
+    });
     completedPours.current = [...completedPours.current, finished];
     setPours(completedPours.current);
     activePour.current = null;
@@ -283,11 +329,28 @@ export const FreePourScreen = () => {
       completion: completion.current,
       sync: { status: 'pending', attempts: 0 }
     };
+    logFreePour('session_completed', {
+      runId,
+      duration_ms: session.measurements.durationMs,
+      pours: session.pours.length,
+      water_g: session.measurements.waterPouredG,
+      beverage_g: session.measurements.beverageG,
+      retained_g: session.measurements.retainedG,
+      completion: session.completion
+    });
     setResult(session);
     updateStage('result');
-    saveFreePourSession(session).catch((error) => {
-      console.error('Failed to save Free Pour session', error);
-    });
+    saveFreePourSession(session)
+      .then(() => {
+        sessionSaved.current = true;
+        logFreePour('session_saved', { runId, sessionId: session.id });
+      })
+      .catch((error) => {
+        logFreePourError('session_save_failed', error, {
+          runId,
+          sessionId: session.id
+        });
+      });
   };
 
   const beginMeasurement = (timeMs: number) => {
@@ -295,8 +358,24 @@ export const FreePourScreen = () => {
     finalizing.current = true;
     if (activePour.current) finishActivePour(timeMs, peakWaterWeight.current);
     detector.current.reset();
+    logFreePour('brew_weight_measurement_started', {
+      runId,
+      elapsed_ms: Math.round(elapsedMsRef.current),
+      scale_g: roundTo(weightRef.current)
+    });
     updateStage('measuring');
   };
+
+  useEffect(() => {
+    logFreePour('screen_entered', { runId, stage: 'server' });
+    return () => {
+      logFreePour('screen_exited', {
+        runId,
+        stage: stageRef.current,
+        session_saved: sessionSaved.current
+      });
+    };
+  }, [runId]);
 
   useEffect(() => {
     const keepAwake = window.setInterval(resetTimer, 60_000);
@@ -321,6 +400,12 @@ export const FreePourScreen = () => {
           peakWaterWeight.current >= 20 &&
           currentWeight <= peakWaterWeight.current - removalThreshold
         ) {
+          logFreePour('brewer_removal_detected', {
+            runId,
+            scale_g: roundTo(currentWeight),
+            peak_water_g: roundTo(peakWaterWeight.current),
+            threshold_g: roundTo(removalThreshold)
+          });
           beginMeasurement(now);
           return;
         }
@@ -411,6 +496,13 @@ export const FreePourScreen = () => {
                 peakFlowGps: Math.max(0, event.sample.flowGps)
               };
           activePour.current = nextPour;
+          logFreePour('pour_started', {
+            runId,
+            pour: nextPour.number,
+            start_ms: Math.round(nextPour.startTimeMs),
+            start_weight_g: roundTo(nextPour.startWeightG),
+            flow_gps: roundTo(event.sample.flowGps)
+          });
           setActivePourView({ number: nextPour.number, startTimeMs });
           updateStage('pouring');
         } else if (event?.type === 'pour-end' && activePour.current) {
@@ -430,13 +522,29 @@ export const FreePourScreen = () => {
       candidateBeverage >= Math.max(8, water * 0.2) &&
       candidateBeverage <= water + 8;
     if (plausible) {
+      logFreePour('brew_weight_accepted', {
+        runId,
+        beverage_g: roundTo(candidateBeverage),
+        water_g: roundTo(water)
+      });
       createSession(candidateBeverage);
     } else if (candidateBeverage <= Math.max(5, water * 0.08)) {
+      logFreePour('server_missing_after_brewer_removal', {
+        runId,
+        candidate_beverage_g: roundTo(candidateBeverage),
+        water_g: roundTo(water)
+      });
       finalizing.current = false;
       updateStage('replace-server');
     } else if (candidateBeverage > water + 8) {
       // A transient bump can resemble a lift. Return to the live state once
       // the full setup is stable on the scale again.
+      logFreePour('brewer_removal_rejected', {
+        runId,
+        reason: 'weight_above_plausible_range',
+        candidate_beverage_g: roundTo(candidateBeverage),
+        water_g: roundTo(water)
+      });
       finalizing.current = false;
       updateStage('waiting');
     }
@@ -450,32 +558,129 @@ export const FreePourScreen = () => {
       candidateBeverage >= Math.max(8, water * 0.2) &&
       candidateBeverage <= water + 8
     ) {
+      logFreePour('replacement_server_accepted', {
+        runId,
+        beverage_g: roundTo(candidateBeverage),
+        water_g: roundTo(water)
+      });
       createSession(candidateBeverage);
     }
   }, [stable, stage, weight]);
 
+  useEffect(() => {
+    if (setupStatus !== 'saving' || !stable || !isSetupStage(stage)) return;
+
+    if (!isValidSetupWeight(stage, weight)) {
+      logFreePour('weight_save_cancelled', {
+        runId,
+        stage,
+        reason: 'weight_out_of_range',
+        weight_g: roundTo(weight)
+      });
+      setSetupStatus('idle');
+      return;
+    }
+
+    if (stage === 'server') {
+      serverWeight.current = weight;
+    } else if (stage === 'brewer') {
+      brewerWeight.current = weight;
+    } else {
+      const measuredDose = weight;
+      setDoseG(Math.round(measuredDose));
+      setupWeight.current = brewerWeight.current + measuredDose;
+    }
+
+    logFreePour('weight_saved', {
+      runId,
+      stage,
+      weight_g: roundTo(weight)
+    });
+    setSetupStatus('taring');
+    socket.emit('action', 'tare');
+    logFreePour('tare_requested', { runId, stage });
+  }, [setupStatus, stable, stage, weight, socket, runId]);
+
+  useEffect(() => {
+    if (
+      setupStatus !== 'taring' ||
+      !stable ||
+      !isSetupStage(stage) ||
+      Math.abs(weight) > TARE_CONFIRM_TOLERANCE_G
+    ) {
+      return;
+    }
+
+    logFreePour('tare_confirmed', {
+      runId,
+      stage,
+      weight_g: roundTo(weight)
+    });
+    setSetupStatus('idle');
+    updateStage(nextStageAfterTare(stage));
+  }, [setupStatus, stable, stage, weight, runId]);
+
+  useEffect(() => {
+    if (setupStatus !== 'taring' || !isSetupStage(stage)) return;
+
+    const taringStage = stage;
+    const timeout = window.setTimeout(() => {
+      logFreePour('tare_timed_out', {
+        runId,
+        stage: taringStage,
+        weight_g: roundTo(weightRef.current)
+      });
+      setSetupStatus('tare-timeout');
+    }, TARE_CONFIRM_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [setupStatus, stage, runId]);
+
   useHandleGestures(
     {
-      pressDown() {
+      click() {
         const currentStage = stageRef.current;
-        if (currentStage === 'server' && serverReady) {
-          serverWeight.current = weightRef.current;
-          socket.emit('action', 'tare');
-          updateStage('brewer');
-          return;
-        }
-        if (currentStage === 'brewer' && brewerReady) {
-          brewerWeight.current = weightRef.current;
-          socket.emit('action', 'tare');
-          updateStage('coffee');
-          return;
-        }
-        if (currentStage === 'coffee' && coffeeReady) {
-          const measuredDose = weightRef.current;
-          setDoseG(Math.round(measuredDose));
-          setupWeight.current = brewerWeight.current + measuredDose;
-          socket.emit('action', 'tare');
-          updateStage('recipe');
+        const currentWeight = weightRef.current;
+        const currentSetupStatus = setupStatusRef.current;
+        logFreePour('click_received', {
+          runId,
+          stage: currentStage,
+          setup_status: currentSetupStatus,
+          stable,
+          weight_g: roundTo(currentWeight)
+        });
+
+        if (isSetupStage(currentStage)) {
+          if (currentSetupStatus === 'tare-timeout') {
+            setSetupStatus('taring');
+            socket.emit('action', 'tare');
+            logFreePour('tare_retried', { runId, stage: currentStage });
+            return;
+          }
+          if (currentSetupStatus !== 'idle') {
+            logFreePour('click_ignored', {
+              runId,
+              stage: currentStage,
+              reason: currentSetupStatus
+            });
+            return;
+          }
+          if (!isValidSetupWeight(currentStage, currentWeight)) {
+            logFreePour('click_rejected', {
+              runId,
+              stage: currentStage,
+              reason: 'weight_out_of_range',
+              weight_g: roundTo(currentWeight)
+            });
+            return;
+          }
+          setSetupStatus('saving');
+          logFreePour('weight_save_requested', {
+            runId,
+            stage: currentStage,
+            stable,
+            weight_g: roundTo(currentWeight)
+          });
           return;
         }
         if (currentStage === 'recipe') {
@@ -488,18 +693,40 @@ export const FreePourScreen = () => {
           return;
         }
         if (currentStage === 'replace-server') {
+          logFreePour('brew_weight_skipped', { runId });
           createSession(null);
           return;
         }
         if (currentStage === 'result') {
+          logFreePour('review_opened', { runId });
           dispatch(setScreen('freePourHistory'));
+          return;
         }
+
+        logFreePour('click_ignored', {
+          runId,
+          stage: currentStage,
+          reason: 'no_action_for_stage'
+        });
+      },
+      doubleClick() {
+        const currentStage = stageRef.current;
+        logFreePour(currentStage === 'result' ? 'exited' : 'aborted', {
+          runId,
+          source: 'double_press',
+          stage: currentStage
+        });
+        dispatch(setBubbleDisplay({ visible: false, component: undefined }));
+        dispatch(setScreen('profileHome'));
       },
       context() {
-        dispatch(setScreen('profileHome'));
+        logFreePour('context_opened', {
+          runId,
+          stage: stageRef.current
+        });
       }
     },
-    false
+    bubbleDisplay.interceptsGesture
   );
 
   const step = stepForStage(stage);
@@ -526,19 +753,37 @@ export const FreePourScreen = () => {
         <div className="free-pour-kicker">ADD BREWER</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
-          {weight < 10
-            ? 'PLACE BREWER ON SERVER'
-            : brewerReady
-              ? 'WEIGHT STABLE'
-              : 'WAITING FOR STABLE WEIGHT'}
+          {setupStatus === 'saving'
+            ? 'KEEP SCALE STILL'
+            : setupStatus === 'taring'
+              ? 'WAITING FOR ZERO'
+              : setupStatus === 'tare-timeout'
+                ? 'TARE NOT CONFIRMED'
+                : weight < 10
+                  ? 'PLACE BREWER ON SERVER'
+                  : brewerReady
+                    ? 'WEIGHT STABLE'
+                    : 'WAITING FOR STABLE WEIGHT'}
         </div>
         <div
           className={`free-pour-dose-action ${
-            brewerReady ? '' : 'free-pour-dose-action--disabled'
+            setupStatus === 'idle' && weight < 10
+              ? 'free-pour-dose-action--disabled'
+              : ''
           }`}
         >
-          <span>PRESS DIAL TO SAVE</span>
-          <strong>BREWER + TARE</strong>
+          {setupStatus === 'saving' ? (
+            <strong>SAVING WEIGHT</strong>
+          ) : setupStatus === 'taring' ? (
+            <strong>TARING…</strong>
+          ) : setupStatus === 'tare-timeout' ? (
+            <strong>PRESS DIAL TO RETRY</strong>
+          ) : (
+            <>
+              <span>PRESS DIAL TO SAVE</span>
+              <strong>BREWER + TARE</strong>
+            </>
+          )}
         </div>
       </div>
     );
@@ -551,21 +796,39 @@ export const FreePourScreen = () => {
         <div className="free-pour-kicker">ADD COFFEE</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
-          {weight < 5
-            ? 'ADD 5–40g COFFEE'
-            : weight > 40
-              ? 'DOSE MUST BE 5–40g'
-              : coffeeReady
-                ? 'DOSE READY'
-                : 'WAITING FOR STABLE WEIGHT'}
+          {setupStatus === 'saving'
+            ? 'KEEP SCALE STILL'
+            : setupStatus === 'taring'
+              ? 'WAITING FOR ZERO'
+              : setupStatus === 'tare-timeout'
+                ? 'TARE NOT CONFIRMED'
+                : weight < 5
+                  ? 'ADD 5–40g COFFEE'
+                  : weight > 40
+                    ? 'DOSE MUST BE 5–40g'
+                    : coffeeReady
+                      ? 'DOSE READY'
+                      : 'WAITING FOR STABLE WEIGHT'}
         </div>
         <div
           className={`free-pour-dose-action ${
-            coffeeReady ? '' : 'free-pour-dose-action--disabled'
+            setupStatus === 'idle' && (weight < 5 || weight > 40)
+              ? 'free-pour-dose-action--disabled'
+              : ''
           }`}
         >
-          <span>PRESS DIAL TO SAVE</span>
-          <strong>DOSE + TARE</strong>
+          {setupStatus === 'saving' ? (
+            <strong>SAVING WEIGHT</strong>
+          ) : setupStatus === 'taring' ? (
+            <strong>TARING…</strong>
+          ) : setupStatus === 'tare-timeout' ? (
+            <strong>PRESS DIAL TO RETRY</strong>
+          ) : (
+            <>
+              <span>PRESS DIAL TO SAVE</span>
+              <strong>DOSE + TARE</strong>
+            </>
+          )}
         </div>
       </div>
     );
@@ -578,13 +841,27 @@ export const FreePourScreen = () => {
         <div className="free-pour-kicker">EMPTY SERVER</div>
         <div className="free-pour-setup-weight">{Math.round(weight)}g</div>
         <div className="free-pour-stability">
-          {weight < 20
-            ? 'PLACE EMPTY SERVER'
-            : serverReady
-              ? 'WEIGHT STABLE'
-              : 'WAITING FOR STABLE WEIGHT'}
+          {setupStatus === 'saving'
+            ? 'KEEP SCALE STILL'
+            : setupStatus === 'taring'
+              ? 'WAITING FOR ZERO'
+              : setupStatus === 'tare-timeout'
+                ? 'TARE NOT CONFIRMED'
+                : weight < 20
+                  ? 'PLACE EMPTY SERVER'
+                  : serverReady
+                    ? 'WEIGHT STABLE'
+                    : 'WAITING FOR STABLE WEIGHT'}
         </div>
-        <div className="free-pour-setup-action">PRESS DIAL TO SAVE + TARE</div>
+        <div className="free-pour-setup-action">
+          {setupStatus === 'saving'
+            ? 'SAVING WEIGHT'
+            : setupStatus === 'taring'
+              ? 'TARING…'
+              : setupStatus === 'tare-timeout'
+                ? 'PRESS DIAL TO RETRY'
+                : 'PRESS DIAL TO SAVE + TARE'}
+        </div>
       </div>
     );
   }

--- a/src/features/freePour/RepeatLastPourScreen.tsx
+++ b/src/features/freePour/RepeatLastPourScreen.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { LoadingScreen } from '../../components/LoadingScreen/LoadingScreen';
+import { setScreen } from '../../components/store/features/screens/screens-slice';
+import { useAppDispatch } from '../../components/store/hooks';
+import { FreePourScreen } from './FreePourScreen';
+import { logFreePourError } from './logging';
+import { createRepeatPourOverProfile } from './profile';
+import { getLatestFreePourOnlySession } from './storage';
+import { PourOverProfile } from './types';
+
+export const RepeatLastPourScreen = () => {
+  const dispatch = useAppDispatch();
+  const [profile, setProfile] = useState<PourOverProfile | null>();
+
+  useEffect(() => {
+    getLatestFreePourOnlySession()
+      .then((session) => {
+        const repeatProfile = session
+          ? createRepeatPourOverProfile(session)
+          : null;
+        if (!repeatProfile) {
+          dispatch(setScreen('profileHome'));
+          return;
+        }
+        setProfile(repeatProfile);
+      })
+      .catch((error) => {
+        logFreePourError('repeat_profile_load_failed', error);
+        dispatch(setScreen('profileHome'));
+      });
+  }, [dispatch]);
+
+  if (!profile) return <LoadingScreen />;
+  return <FreePourScreen profile={profile} />;
+};

--- a/src/features/freePour/brewWeightFilter.ts
+++ b/src/features/freePour/brewWeightFilter.ts
@@ -1,0 +1,67 @@
+export const BREWER_REMOVAL_CONFIRM_MS = 2000;
+
+const MAX_PLAUSIBLE_WATER_RISE_GPS = 15;
+const MAX_FILTER_INTERVAL_MS = 250;
+
+/**
+ * Advances a high-water mark no faster than a real pour can plausibly add
+ * water. A brief upward scale spike therefore cannot become the new brew peak.
+ */
+export const updatePlausiblePeakWeight = (
+  previousPeakG: number,
+  sampleWeightG: number,
+  elapsedMs: number
+) => {
+  if (sampleWeightG <= previousPeakG) return previousPeakG;
+
+  const boundedElapsedMs = Math.max(
+    0,
+    Math.min(elapsedMs, MAX_FILTER_INTERVAL_MS)
+  );
+  const allowedRiseG = (MAX_PLAUSIBLE_WATER_RISE_GPS * boundedElapsedMs) / 1000;
+  return Math.min(sampleWeightG, previousPeakG + allowedRiseG);
+};
+
+export type BrewerRemovalState =
+  | { type: 'idle' }
+  | { type: 'started'; startedAtMs: number }
+  | { type: 'pending'; startedAtMs: number; heldMs: number }
+  | { type: 'cancelled'; startedAtMs: number; heldMs: number }
+  | { type: 'confirmed'; startedAtMs: number; heldMs: number };
+
+/** Requires a removal-sized weight drop to persist before accepting it. */
+export class BrewerRemovalConfirmation {
+  private startedAtMs: number | null = null;
+
+  reset() {
+    this.startedAtMs = null;
+  }
+
+  update(isBelowRemovalThreshold: boolean, nowMs: number): BrewerRemovalState {
+    if (!isBelowRemovalThreshold) {
+      if (this.startedAtMs === null) return { type: 'idle' };
+
+      const startedAtMs = this.startedAtMs;
+      this.startedAtMs = null;
+      return {
+        type: 'cancelled',
+        startedAtMs,
+        heldMs: Math.max(0, nowMs - startedAtMs)
+      };
+    }
+
+    if (this.startedAtMs === null) {
+      this.startedAtMs = nowMs;
+      return { type: 'started', startedAtMs: nowMs };
+    }
+
+    const heldMs = Math.max(0, nowMs - this.startedAtMs);
+    if (heldMs < BREWER_REMOVAL_CONFIRM_MS) {
+      return { type: 'pending', startedAtMs: this.startedAtMs, heldMs };
+    }
+
+    const startedAtMs = this.startedAtMs;
+    this.startedAtMs = null;
+    return { type: 'confirmed', startedAtMs, heldMs };
+  }
+}

--- a/src/features/freePour/format.ts
+++ b/src/features/freePour/format.ts
@@ -1,0 +1,19 @@
+export const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+export const roundTo = (value: number, decimals = 1) => {
+  const multiplier = 10 ** decimals;
+  return Math.round(value * multiplier) / multiplier;
+};
+
+export const formatBrewTime = (milliseconds: number) => {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, '0')}`;
+};
+
+export const formatClockTime = (milliseconds: number) => {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return formatBrewTime(milliseconds);
+};

--- a/src/features/freePour/free-pour-history.css
+++ b/src/features/freePour/free-pour-history.css
@@ -1,0 +1,160 @@
+.free-pour-history {
+  position: relative;
+  width: 480px;
+  height: 480px;
+  overflow: hidden;
+  color: #e7e3da;
+  font-family: 'ABC Diatype', sans-serif;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.free-pour-history-title {
+  position: absolute;
+  top: 35px;
+  width: 100%;
+  font-size: 22px;
+  font-weight: 650;
+  letter-spacing: 2px;
+}
+
+.free-pour-history-subtitle {
+  position: absolute;
+  top: 67px;
+  width: 100%;
+  color: #8d9694;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 1.5px;
+}
+
+.free-pour-history-chart {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.free-pour-history-axis {
+  stroke: #596460;
+  stroke-width: 2;
+}
+
+.free-pour-history-grid {
+  stroke: #26312f;
+  stroke-width: 1;
+  stroke-dasharray: 3 7;
+}
+
+.free-pour-history-weight-line,
+.free-pour-history-flow-line {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.5;
+}
+
+.free-pour-history-weight-line {
+  stroke: #e7e3da;
+}
+
+.free-pour-history-flow-line {
+  stroke: #78d6ff;
+}
+
+.free-pour-history-cursor {
+  stroke: #f5c444;
+  stroke-width: 2;
+}
+
+.free-pour-history-pour {
+  fill: #e7e3da;
+}
+
+.free-pour-history-values {
+  position: absolute;
+  top: 277px;
+  left: 65px;
+  width: 350px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.free-pour-history-values div {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.free-pour-history-values span {
+  color: #8d9694;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+}
+
+.free-pour-history-values strong {
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 20px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.free-pour-history-turn {
+  position: absolute;
+  top: 358px;
+  width: 100%;
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: 2px;
+}
+
+.free-pour-history-legend {
+  position: absolute;
+  top: 391px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  color: #8d9694;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+}
+
+.free-pour-history-legend span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.free-pour-history-legend i {
+  width: 16px;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.free-pour-history-legend-weight {
+  background: #e7e3da;
+}
+
+.free-pour-history-legend-flow {
+  background: #78d6ff;
+}
+
+.free-pour-history--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 22px;
+}
+
+.free-pour-history--empty strong {
+  font-size: 24px;
+  letter-spacing: 2px;
+}
+
+.free-pour-history--empty span {
+  color: #8d9694;
+  font-size: 14px;
+  letter-spacing: 1.5px;
+}

--- a/src/features/freePour/free-pour.css
+++ b/src/features/freePour/free-pour.css
@@ -265,6 +265,32 @@
   box-shadow: 0 0 0 7px rgba(231, 227, 218, 0.12);
 }
 
+.free-pour-dot--due {
+  border-color: var(--free-pour-white);
+  background: var(--free-pour-white);
+  box-shadow: 0 0 0 7px rgba(231, 227, 218, 0.12);
+}
+
+@keyframes free-pour-cue-flash {
+  0%,
+  49% {
+    border-color: var(--free-pour-white);
+    background: var(--free-pour-white);
+    box-shadow: 0 0 0 7px rgba(231, 227, 218, 0.12);
+  }
+
+  50%,
+  100% {
+    border-color: #687370;
+    background: #050908;
+    box-shadow: none;
+  }
+}
+
+.free-pour-dot--cue {
+  animation: free-pour-cue-flash 1s steps(1, end) 5;
+}
+
 .free-pour-rail-point small {
   margin-top: 9px;
   color: var(--free-pour-muted);

--- a/src/features/freePour/free-pour.css
+++ b/src/features/freePour/free-pour.css
@@ -31,6 +31,7 @@
 }
 
 .free-pour-setup-screen,
+.free-pour-temperature-screen,
 .free-pour-result-screen,
 .free-pour-message-screen {
   display: flex;
@@ -98,6 +99,50 @@
 
 .free-pour-dose-action--disabled {
   opacity: 0.38;
+}
+
+.free-pour-temperature-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.free-pour-temperature-screen .free-pour-kicker {
+  margin-top: -54px;
+}
+
+.free-pour-temperature-value {
+  margin-top: 25px;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 104px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -8px;
+}
+
+.free-pour-temperature-value span {
+  margin-left: 8px;
+  color: var(--free-pour-muted);
+  font-size: 35px;
+  letter-spacing: -2px;
+}
+
+.free-pour-temperature-adjust {
+  margin-top: 25px;
+  color: var(--free-pour-muted);
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 13px;
+  letter-spacing: 2px;
+}
+
+.free-pour-temperature-action {
+  position: absolute;
+  bottom: 54px;
+  width: 100%;
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: 1.5px;
 }
 
 .free-pour-recipe-dose {
@@ -239,6 +284,46 @@
   letter-spacing: -5px;
 }
 
+.free-pour-profile-weight {
+  position: absolute;
+  top: 238px;
+  left: 80px;
+  width: 320px;
+  display: grid;
+  grid-template-columns: 1fr 34px 1fr;
+  align-items: end;
+}
+
+.free-pour-profile-weight div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.free-pour-profile-weight span {
+  margin-bottom: 5px;
+  color: var(--free-pour-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 2px;
+}
+
+.free-pour-profile-weight strong {
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 51px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -4px;
+}
+
+.free-pour-profile-weight i {
+  padding-bottom: 7px;
+  color: var(--free-pour-muted);
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 25px;
+  font-style: normal;
+}
+
 .free-pour-flow-meter {
   position: absolute;
   top: 325px;
@@ -258,11 +343,23 @@
 }
 
 .free-pour-flow-segments {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(10, 1fr);
   gap: 5px;
   height: 14px;
   margin-top: 10px;
+}
+
+.free-pour-flow-target {
+  position: absolute;
+  z-index: 5;
+  top: -7px;
+  width: 3px;
+  height: 28px;
+  border-radius: 2px;
+  background: var(--free-pour-white);
+  transform: translateX(-1px);
 }
 
 .free-pour-flow-segment {

--- a/src/features/freePour/free-pour.css
+++ b/src/features/freePour/free-pour.css
@@ -1,0 +1,383 @@
+.free-pour-screen {
+  --free-pour-white: #e7e3da;
+  --free-pour-muted: #8d9694;
+  position: relative;
+  width: 480px;
+  height: 480px;
+  overflow: hidden;
+  color: var(--free-pour-white);
+  font-family: 'ABC Diatype', sans-serif;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.free-pour-step {
+  position: absolute;
+  z-index: 80;
+  top: 31px;
+  left: 0;
+  width: 100%;
+  color: var(--free-pour-muted);
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 13px;
+  letter-spacing: 3px;
+}
+
+.free-pour-kicker {
+  color: var(--free-pour-muted);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 3px;
+}
+
+.free-pour-setup-screen,
+.free-pour-result-screen,
+.free-pour-message-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.free-pour-setup-screen .free-pour-kicker {
+  margin-top: -42px;
+}
+
+.free-pour-setup-weight {
+  margin-top: 17px;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 104px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -8px;
+}
+
+.free-pour-stability {
+  margin-top: 20px;
+  color: var(--free-pour-muted);
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 13px;
+  letter-spacing: 2px;
+}
+
+.free-pour-setup-action,
+.free-pour-result-action {
+  position: absolute;
+  bottom: 54px;
+  font-size: 17px;
+  font-weight: 650;
+  letter-spacing: 1.6px;
+}
+
+.free-pour-dose-title {
+  position: absolute;
+  z-index: 80;
+  top: 71px;
+  width: 100%;
+  color: var(--free-pour-muted);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 2.5px;
+}
+
+.free-pour-dose-action {
+  position: absolute;
+  z-index: 80;
+  bottom: 52px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  font-size: 16px;
+  line-height: 1.42;
+  letter-spacing: 1.4px;
+}
+
+.free-pour-dose-action strong {
+  font-weight: 700;
+}
+
+.free-pour-dose-action--disabled {
+  opacity: 0.38;
+}
+
+.free-pour-recipe-dose {
+  position: absolute;
+  top: 150px;
+  width: 100%;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 104px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -7px;
+}
+
+.free-pour-recipe-label {
+  position: absolute;
+  top: 258px;
+  width: 100%;
+  color: var(--free-pour-muted);
+  font-size: 14px;
+  letter-spacing: 3px;
+}
+
+.free-pour-recipe-ready {
+  position: absolute;
+  top: 312px;
+  width: 100%;
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: 2px;
+}
+
+.free-pour-recipe-action {
+  position: absolute;
+  bottom: 54px;
+  width: 100%;
+  font-size: 15px;
+  letter-spacing: 1.5px;
+}
+
+.free-pour-name {
+  position: absolute;
+  top: 53px;
+  width: 100%;
+  color: var(--free-pour-muted);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 2.7px;
+}
+
+.free-pour-timer {
+  position: absolute;
+  top: 72px;
+  width: 100%;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 81px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -5px;
+}
+
+.free-pour-live-status {
+  position: absolute;
+  top: 157px;
+  width: 100%;
+  color: var(--free-pour-white);
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: 3px;
+}
+
+.free-pour-rail {
+  position: absolute;
+  top: 192px;
+  left: 0;
+  width: 100%;
+  height: 48px;
+}
+
+.free-pour-rail-line {
+  position: absolute;
+  top: 7px;
+  left: 42px;
+  right: 232px;
+  height: 2px;
+  background: #34403e;
+}
+
+.free-pour-rail-line--complete {
+  left: 128px;
+  right: 128px;
+}
+
+.free-pour-rail-point {
+  position: absolute;
+  top: 0;
+  left: calc(50% - 8px);
+  width: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.free-pour-dot {
+  box-sizing: border-box;
+  width: 16px;
+  height: 16px;
+  border: 3px solid #687370;
+  border-radius: 50%;
+  background: #050908;
+}
+
+.free-pour-dot--past {
+  border-color: #687370;
+  background: #687370;
+}
+
+.free-pour-dot--active {
+  border-color: var(--free-pour-white);
+  background: var(--free-pour-white);
+  box-shadow: 0 0 0 7px rgba(231, 227, 218, 0.12);
+}
+
+.free-pour-rail-point small {
+  margin-top: 9px;
+  color: var(--free-pour-muted);
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.free-pour-live-weight {
+  position: absolute;
+  top: 238px;
+  width: 100%;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 77px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -5px;
+}
+
+.free-pour-flow-meter {
+  position: absolute;
+  top: 325px;
+  left: 91px;
+  width: 298px;
+}
+
+.free-pour-flow-title {
+  color: var(--free-pour-muted);
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: 2.2px;
+}
+
+.free-pour-flow-title span {
+  color: var(--free-pour-white);
+}
+
+.free-pour-flow-segments {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 5px;
+  height: 14px;
+  margin-top: 10px;
+}
+
+.free-pour-flow-segment {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #25312f;
+}
+
+.free-pour-flow-segment i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: block;
+  border-radius: inherit;
+}
+
+.free-pour-flow-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 7px;
+  color: var(--free-pour-muted);
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 12px;
+}
+
+.free-pour-live-instruction {
+  position: absolute;
+  bottom: 41px;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  font-weight: 550;
+  line-height: 1.35;
+  letter-spacing: 1.4px;
+}
+
+.free-pour-live-instruction strong {
+  font-weight: 750;
+}
+
+.free-pour-message-main {
+  margin-top: -20px;
+  font-size: 32px;
+  font-weight: 650;
+  line-height: 1.18;
+  letter-spacing: 1px;
+}
+
+.free-pour-message-sub {
+  margin-top: 22px;
+  color: var(--free-pour-muted);
+  font-size: 16px;
+  font-weight: 550;
+  line-height: 1.5;
+  letter-spacing: 1.7px;
+}
+
+.free-pour-message-stability {
+  position: absolute;
+  bottom: 73px;
+}
+
+.free-pour-skip {
+  position: absolute;
+  bottom: 52px;
+  width: 100%;
+  color: var(--free-pour-muted);
+  font-size: 12px;
+  letter-spacing: 1.2px;
+}
+
+.free-pour-result-screen .free-pour-kicker {
+  margin-top: -61px;
+}
+
+.free-pour-result-value {
+  margin-top: 10px;
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 94px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -7px;
+}
+
+.free-pour-result-label {
+  color: var(--free-pour-muted);
+  font-size: 14px;
+  letter-spacing: 3px;
+}
+
+.free-pour-result-stats {
+  width: 280px;
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 38px;
+}
+
+.free-pour-result-stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.free-pour-result-stats span {
+  color: var(--free-pour-muted);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  white-space: nowrap;
+}
+
+.free-pour-result-stats strong {
+  font-family: 'ABC Diatype Mono', monospace;
+  font-size: 25px;
+  font-weight: 400;
+}

--- a/src/features/freePour/logging.ts
+++ b/src/features/freePour/logging.ts
@@ -1,0 +1,33 @@
+type LogValue = string | number | boolean | null | undefined;
+
+type LogDetails = Record<string, LogValue>;
+
+const serializeError = (error: unknown) => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack
+    };
+  }
+
+  return { message: String(error) };
+};
+
+export const logFreePour = (event: string, details: LogDetails = {}) => {
+  console.info(`[FreePour] ${JSON.stringify({ event, ...details })}`);
+};
+
+export const logFreePourError = (
+  event: string,
+  error: unknown,
+  details: LogDetails = {}
+) => {
+  console.error(
+    `[FreePour] ${JSON.stringify({
+      event,
+      ...details,
+      error: serializeError(error)
+    })}`
+  );
+};

--- a/src/features/freePour/pourDetector.ts
+++ b/src/features/freePour/pourDetector.ts
@@ -1,0 +1,74 @@
+export interface DetectorSample {
+  timeMs: number;
+  weightG: number;
+  flowGps: number;
+}
+
+export type PourDetectorEvent =
+  | { type: 'pour-start'; sample: DetectorSample }
+  | { type: 'pour-end'; sample: DetectorSample };
+
+const START_FLOW_GPS = 0.65;
+const STOP_FLOW_GPS = 0.28;
+const START_HOLD_MS = 240;
+const STOP_HOLD_MS = 950;
+
+/** Small hysteresis-based detector; it allocates nothing in the hot path. */
+export class PourDetector {
+  private pouring = false;
+  private startCandidate: DetectorSample | null = null;
+  private stopCandidate: DetectorSample | null = null;
+  private previous: DetectorSample | null = null;
+
+  get isPouring() {
+    return this.pouring;
+  }
+
+  reset() {
+    this.pouring = false;
+    this.startCandidate = null;
+    this.stopCandidate = null;
+    this.previous = null;
+  }
+
+  process(sample: DetectorSample): PourDetectorEvent | null {
+    let derivedFlow = 0;
+    if (this.previous) {
+      const elapsedSeconds = (sample.timeMs - this.previous.timeMs) / 1000;
+      if (elapsedSeconds > 0) {
+        derivedFlow = (sample.weightG - this.previous.weightG) / elapsedSeconds;
+      }
+    }
+    this.previous = sample;
+
+    const effectiveFlow = Math.max(sample.flowGps, derivedFlow);
+    if (!this.pouring) {
+      if (effectiveFlow >= START_FLOW_GPS) {
+        this.startCandidate ??= sample;
+        if (sample.timeMs - this.startCandidate.timeMs >= START_HOLD_MS) {
+          this.pouring = true;
+          const startedAt = this.startCandidate;
+          this.startCandidate = null;
+          this.stopCandidate = null;
+          return { type: 'pour-start', sample: startedAt };
+        }
+      } else {
+        this.startCandidate = null;
+      }
+      return null;
+    }
+
+    if (effectiveFlow <= STOP_FLOW_GPS) {
+      this.stopCandidate ??= sample;
+      if (sample.timeMs - this.stopCandidate.timeMs >= STOP_HOLD_MS) {
+        this.pouring = false;
+        const endedAt = this.stopCandidate;
+        this.stopCandidate = null;
+        return { type: 'pour-end', sample: endedAt };
+      }
+    } else {
+      this.stopCandidate = null;
+    }
+    return null;
+  }
+}

--- a/src/features/freePour/profile.ts
+++ b/src/features/freePour/profile.ts
@@ -1,0 +1,34 @@
+import { roundTo } from './format';
+import { FreePourSession, PourOverProfile } from './types';
+
+export const DEFAULT_FREE_POUR_TEMPERATURE_C = 92;
+export const MIN_FREE_POUR_TEMPERATURE_C = 80;
+export const MAX_FREE_POUR_TEMPERATURE_C = 100;
+
+export const createRepeatPourOverProfile = (
+  session: FreePourSession
+): PourOverProfile | null => {
+  if (!session.pours.length) return null;
+
+  const measuredTemperature =
+    session.measurements.waterTemperatureC ??
+    session.recipe.temperatureC ??
+    DEFAULT_FREE_POUR_TEMPERATURE_C;
+  const measuredDose = session.measurements.doseG ?? session.recipe.doseG;
+
+  return {
+    id: `repeat-${session.id}`,
+    name: 'Repeat Last Pour',
+    sourceSessionId: session.id,
+    doseG: roundTo(measuredDose),
+    temperatureC: Math.round(measuredTemperature),
+    targetWaterG: roundTo(session.measurements.waterPouredG),
+    targetDurationMs: Math.round(session.measurements.durationMs),
+    pourTargets: session.pours.map((pour) => ({
+      number: pour.number,
+      startTimeMs: pour.startTimeMs,
+      stopWeightG: roundTo(pour.endWeightG),
+      flowGps: roundTo(pour.averageFlowGps)
+    }))
+  };
+};

--- a/src/features/freePour/storage.ts
+++ b/src/features/freePour/storage.ts
@@ -1,0 +1,68 @@
+import { FreePourSession } from './types';
+
+const DATABASE_NAME = 'meticulous-brew-history';
+const DATABASE_VERSION = 1;
+const STORE_NAME = 'brew-sessions';
+
+let databasePromise: Promise<IDBDatabase> | null = null;
+let memoryFallback: FreePourSession[] = [];
+let latestSessionCache: FreePourSession | null = null;
+
+const openDatabase = () => {
+  if (databasePromise) return databasePromise;
+  databasePromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        const store = database.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('completedAt', 'completedAt');
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  return databasePromise;
+};
+
+export const saveFreePourSession = async (session: FreePourSession) => {
+  latestSessionCache = session;
+  if (typeof indexedDB === 'undefined') {
+    memoryFallback = [
+      session,
+      ...memoryFallback.filter((item) => item.id !== session.id)
+    ];
+    return;
+  }
+  const database = await openDatabase();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+    transaction.objectStore(STORE_NAME).put(session);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+};
+
+export const getFreePourSessions = async (limit = 50) => {
+  if (typeof indexedDB === 'undefined') return memoryFallback.slice(0, limit);
+  const database = await openDatabase();
+  return new Promise<FreePourSession[]>((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readonly');
+    const index = transaction.objectStore(STORE_NAME).index('completedAt');
+    const sessions: FreePourSession[] = [];
+    const request = index.openCursor(null, 'prev');
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor || sessions.length >= limit) {
+        resolve(sessions);
+        return;
+      }
+      sessions.push(cursor.value as FreePourSession);
+      cursor.continue();
+    };
+    request.onerror = () => reject(request.error);
+  });
+};
+
+export const getLatestFreePourSession = async () =>
+  latestSessionCache ?? (await getFreePourSessions(1))[0] ?? null;

--- a/src/features/freePour/storage.ts
+++ b/src/features/freePour/storage.ts
@@ -66,3 +66,10 @@ export const getFreePourSessions = async (limit = 50) => {
 
 export const getLatestFreePourSession = async () =>
   latestSessionCache ?? (await getFreePourSessions(1))[0] ?? null;
+
+export const getLatestFreePourOnlySession = async () => {
+  if (latestSessionCache?.mode === 'free_pour') return latestSessionCache;
+  return (await getFreePourSessions()).find(
+    (session) => session.mode === 'free_pour'
+  );
+};

--- a/src/features/freePour/types.ts
+++ b/src/features/freePour/types.ts
@@ -1,4 +1,4 @@
-export const FREE_POUR_SCHEMA_VERSION = 1 as const;
+export const FREE_POUR_SCHEMA_VERSION = 2 as const;
 
 export type FreePourCompletion = 'brewer_removed' | 'dial_fallback';
 
@@ -55,6 +55,9 @@ export interface FreePourSession {
   };
   measurements: {
     emptyServerG: number;
+    /** Brewer weight without dry coffee. */
+    brewerG: number;
+    /** Brewer plus dry-coffee weight tared immediately before brewing. */
     setupG: number;
     waterPouredG: number;
     beverageG: number | null;

--- a/src/features/freePour/types.ts
+++ b/src/features/freePour/types.ts
@@ -1,0 +1,73 @@
+export const FREE_POUR_SCHEMA_VERSION = 1 as const;
+
+export type FreePourCompletion = 'brewer_removed' | 'dial_fallback';
+
+export interface FreePourSample {
+  /** Milliseconds from the start of the first pour. */
+  t: number;
+  /** Water weight shown during the brew. */
+  w: number;
+  /** Gravimetric flow in grams per second. */
+  f: number;
+  /** One-based pour number, or zero while waiting/drawing down. */
+  p: number;
+}
+
+export interface FreePourPour {
+  number: number;
+  startTimeMs: number;
+  endTimeMs: number;
+  startWeightG: number;
+  endWeightG: number;
+  waterG: number;
+  averageFlowGps: number;
+  peakFlowGps: number;
+}
+
+export interface PourOverPourTarget {
+  number: number;
+  startTimeMs: number;
+  stopWeightG: number;
+  flowGps?: number;
+  flowRangeGps?: [number, number];
+}
+
+/**
+ * A first-class brew record. Uploading is intentionally represented as data,
+ * not performed here, so community sync can consume the record independently.
+ */
+export interface FreePourSession {
+  schemaVersion: typeof FREE_POUR_SCHEMA_VERSION;
+  id: string;
+  brewType: 'pour_over';
+  mode: 'free_pour';
+  name: 'Free Pour';
+  source: 'dial';
+  startedAt: string;
+  completedAt: string;
+  recipe: {
+    /** Null for Free Pour; populated by future downloaded profiles. */
+    profileId: string | null;
+    profileName: string;
+    doseG: number;
+    targetWaterG: number | null;
+    pourTargets: PourOverPourTarget[];
+  };
+  measurements: {
+    emptyServerG: number;
+    setupG: number;
+    waterPouredG: number;
+    beverageG: number | null;
+    retainedG: number | null;
+    durationMs: number;
+    status: 'measured' | 'skipped';
+  };
+  pours: FreePourPour[];
+  samples: FreePourSample[];
+  completion: FreePourCompletion;
+  sync: {
+    status: 'pending' | 'uploaded' | 'failed';
+    attempts: number;
+    uploadedAt?: string;
+  };
+}

--- a/src/features/freePour/types.ts
+++ b/src/features/freePour/types.ts
@@ -1,4 +1,4 @@
-export const FREE_POUR_SCHEMA_VERSION = 3 as const;
+export const FREE_POUR_SCHEMA_VERSION = 4 as const;
 
 export type FreePourCompletion = 'brewer_removed' | 'dial_fallback';
 
@@ -32,6 +32,17 @@ export interface PourOverPourTarget {
   flowRangeGps?: [number, number];
 }
 
+export interface PourOverProfile {
+  id: string;
+  name: string;
+  sourceSessionId: string;
+  doseG: number;
+  temperatureC: number;
+  targetWaterG: number;
+  targetDurationMs: number;
+  pourTargets: PourOverPourTarget[];
+}
+
 /**
  * A first-class brew record. Uploading is intentionally represented as data,
  * not performed here, so community sync can consume the record independently.
@@ -40,8 +51,8 @@ export interface FreePourSession {
   schemaVersion: typeof FREE_POUR_SCHEMA_VERSION;
   id: string;
   brewType: 'pour_over';
-  mode: 'free_pour';
-  name: 'Free Pour';
+  mode: 'free_pour' | 'profile';
+  name: string;
   source: 'dial';
   startedAt: string;
   completedAt: string;
@@ -50,7 +61,9 @@ export interface FreePourSession {
     profileId: string | null;
     profileName: string;
     doseG: number;
+    temperatureC: number;
     targetWaterG: number | null;
+    targetDurationMs: number | null;
     pourTargets: PourOverPourTarget[];
   };
   measurements: {
@@ -60,6 +73,10 @@ export interface FreePourSession {
     brewerG: number;
     /** Brewer plus dry-coffee weight tared immediately before brewing. */
     setupG: number;
+    /** Measured dry-coffee dose used for this brew. */
+    doseG: number;
+    /** Water temperature entered by the brewer before starting. */
+    waterTemperatureC: number;
     waterPouredG: number;
     beverageG: number | null;
     retainedG: number | null;

--- a/src/features/freePour/types.ts
+++ b/src/features/freePour/types.ts
@@ -1,4 +1,4 @@
-export const FREE_POUR_SCHEMA_VERSION = 2 as const;
+export const FREE_POUR_SCHEMA_VERSION = 3 as const;
 
 export type FreePourCompletion = 'brewer_removed' | 'dial_fallback';
 
@@ -54,7 +54,8 @@ export interface FreePourSession {
     pourTargets: PourOverPourTarget[];
   };
   measurements: {
-    emptyServerG: number;
+    /** Signed scale reading captured before the server tare. */
+    serverBaselineG: number;
     /** Brewer weight without dry coffee. */
     brewerG: number;
     /** Brewer plus dry-coffee weight tared immediately before brewing. */

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -44,6 +44,8 @@ import { BrewSettings } from '../components/Settings/BrewSettings';
 import { TimeConfig } from '../components/Settings/Advanced/TimeDate/TimeConfig';
 import { DateConfig } from '../components/Settings/Advanced/TimeDate/DateConfig';
 import { ShotGraphScreen } from '../components/ShotGraph/ShotGraphScreen';
+import { FreePourScreen } from '../features/freePour/FreePourScreen';
+import { FreePourHistoryScreen } from '../features/freePour/FreePourHistoryScreen';
 import { ScrollDirectionSettings } from '../components/Settings/ScrollDirection';
 import { BrewCompleteScreen } from '../components/BrewCompleteScreen/BrewCompleteScreen';
 import { ProfileHomeScreen } from '../components/ProfileHomeScreen/ProfileHomeScreen';
@@ -417,6 +419,16 @@ export const routes: Record<ScreenType, Route> = {
     title: getActiveProfilesTitle,
     parent: 'profileHome',
     bottomStatusHidden: true
+  },
+  freePour: {
+    component: FreePourScreen,
+    bottomStatusHidden: true,
+    parent: 'profileHome'
+  },
+  freePourHistory: {
+    component: FreePourHistoryScreen,
+    bottomStatusHidden: true,
+    parent: 'profileHome'
   },
   idle: {
     component: IdleScreen,

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -45,6 +45,7 @@ import { TimeConfig } from '../components/Settings/Advanced/TimeDate/TimeConfig'
 import { DateConfig } from '../components/Settings/Advanced/TimeDate/DateConfig';
 import { ShotGraphScreen } from '../components/ShotGraph/ShotGraphScreen';
 import { FreePourScreen } from '../features/freePour/FreePourScreen';
+import { RepeatLastPourScreen } from '../features/freePour/RepeatLastPourScreen';
 import { FreePourHistoryScreen } from '../features/freePour/FreePourHistoryScreen';
 import { ScrollDirectionSettings } from '../components/Settings/ScrollDirection';
 import { BrewCompleteScreen } from '../components/BrewCompleteScreen/BrewCompleteScreen';
@@ -422,6 +423,11 @@ export const routes: Record<ScreenType, Route> = {
   },
   freePour: {
     component: FreePourScreen,
+    bottomStatusHidden: true,
+    parent: 'profileHome'
+  },
+  freePourRecipe: {
+    component: RepeatLastPourScreen,
     bottomStatusHidden: true,
     parent: 'profileHome'
   },


### PR DESCRIPTION
## Summary

- Add Free Pour as a first-class Home mode with an eight-step pour-over workflow.
- Capture water temperature, empty-server baseline, brewer weight, measured dose, live water weight, flow, detected pours, beverage weight, and retained water.
- Add a circular live-brew UI for one to five pours with an absolute timer, pour rail, flow meter, and automatic pour detection.
- Save local pour-over history and provide a dial-scrubbable chart with pour, time, water weight, and flow.
- Generate a **Repeat Last Pour** profile from the latest completed Free Pour, including dose, temperature, final-water and drawdown targets plus per-pour start time, stop weight, and average-flow targets.
- Add Free Pour context actions, double-press abort, lifecycle logging, and a diagnostic log collector.

## Why

The Dial previously treated brewing as espresso-only. Pour-over needs a simpler, first-class session model based on dose, temperature, cumulative water weight, absolute pour start times, flow, and drawdown rather than espresso stages.

This establishes the machine-side MVP while keeping the data model ready for downloaded Community recipes and later upload/sync work.

## Fixes included

- Use the Dial's resolved physical single-click event for setup actions while retaining double-press abort.
- Accept signed server baselines instead of assuming an arbitrary positive server weight.
- Detect the added brewer using a scale-noise guard instead of a product-weight assumption.
- Keep the shared espresso Tare-button behavior unchanged.
- Prevent the press that opens **Last Pour Over** from leaking through and immediately closing the history screen.
- Remove the duplicate pre-brew dose summary and make temperature the first setup step.

## User impact

Users can perform a complete Free Pour, review it locally, and replay the latest Free Pour as a guided recipe. Profile attempts remain separate from the source Free Pour so the recipe target does not drift after each attempt.

Automatic shot upload and Community ingestion remain intentionally outside this branch.

## Validation

- TypeScript type check
- ESLint
- Prettier format check
- Vite production build
- Repeat-profile conversion check
- 480×480 visual verification of temperature and five-pour recipe screens
- ARM64 Tauri cross-build and ELF verification
- Machine validation of the core setup, dial input, tare sequence, live brew, and beverage-weight flow
- Installer, rollback, log-collector, and package checksum verification
