### PR TITLE
Show pending Wi-Fi health probes as checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "commit": "git-cz",
     "format": "prettier --config .prettierrc \"{src/**/,.github/**/,}*.{tsx,ts,md,js,css,html,json,yml}\" --write",
     "format:check": "prettier --config .prettierrc \"{src/**/,.github/**/,}*.{tsx,ts,md,js,css,html,json,yml}\" --check",
+    "test:wifi-health": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\"}' tests/wifiHealthMessages.test.ts",
     "types": "tsc --noEmit",
     "prepare": "husky",
     "lint": "eslint .",

--- a/src/components/Wifi/WifiDetails.tsx
+++ b/src/components/Wifi/WifiDetails.tsx
@@ -8,6 +8,7 @@ import './wifiDetails.css';
 import { useNetworkConfig } from '../../hooks/useWifi';
 import {
   getWifiHealthMessage,
+  getWifiProbeStatusLabel,
   getWifiHealthStatusLabel,
   getWifiRecoveryMessage
 } from './wifiHealthMessages';
@@ -56,25 +57,25 @@ export const WifiDetails = (): JSX.Element => {
       health: getWifiHealthStatusLabel(wifiHealth, wifiStatus?.connected),
       gateway: isHotspotActive
         ? 'N/A'
-        : wifiHealth
-          ? wifiHealth.gateway_reachable
-            ? 'OK'
-            : 'FAILED'
-          : '',
+        : getWifiProbeStatusLabel(
+            wifiHealth?.gateway_reachable,
+            wifiHealth,
+            wifiStatus?.connected
+          ),
       dns: isHotspotActive
         ? 'N/A'
-        : wifiHealth
-          ? wifiHealth.dns_resolves
-            ? 'OK'
-            : 'FAILED'
-          : '',
+        : getWifiProbeStatusLabel(
+            wifiHealth?.dns_resolves,
+            wifiHealth,
+            wifiStatus?.connected
+          ),
       internet: isHotspotActive
         ? 'N/A'
-        : wifiHealth
-          ? wifiHealth.internet_reachable
-            ? 'OK'
-            : 'FAILED'
-          : '',
+        : getWifiProbeStatusLabel(
+            wifiHealth?.internet_reachable,
+            wifiHealth,
+            wifiStatus?.connected
+          ),
       last_error: getWifiHealthMessage(wifiHealth),
       recovery: getWifiRecoveryMessage(wifiHealth)
     };

--- a/src/components/Wifi/wifiHealthMessages.ts
+++ b/src/components/Wifi/wifiHealthMessages.ts
@@ -1,4 +1,36 @@
-import { WifiHealthStatus } from '../../api/wifi';
+import type { WifiHealthStatus } from '../../api/wifi';
+
+export function isWifiHealthCheckPending(
+  health?: WifiHealthStatus,
+  connected = true
+): boolean {
+  return Boolean(
+    connected &&
+    health?.link_connected &&
+    health.has_ipv4 &&
+    !health.degraded &&
+    !health.last_error &&
+    !health.gateway_reachable &&
+    !health.dns_resolves &&
+    !health.internet_reachable
+  );
+}
+
+export function getWifiProbeStatusLabel(
+  result?: boolean,
+  health?: WifiHealthStatus,
+  connected = true
+): string {
+  if (!health || result === undefined) {
+    return '';
+  }
+
+  if (result) {
+    return 'OK';
+  }
+
+  return isWifiHealthCheckPending(health, connected) ? 'CHECKING' : 'FAILED';
+}
 
 export function getWifiHealthMessage(health?: WifiHealthStatus): string {
   if (!health) {

--- a/tests/wifiHealthMessages.test.ts
+++ b/tests/wifiHealthMessages.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'node:assert';
+
+import type { WifiHealthStatus } from '../src/api/wifi';
+import {
+  getWifiProbeStatusLabel,
+  isWifiHealthCheckPending
+} from '../src/components/Wifi/wifiHealthMessages';
+
+function health(overrides: Partial<WifiHealthStatus> = {}): WifiHealthStatus {
+  return {
+    mode: 'client',
+    link_connected: true,
+    has_ipv4: true,
+    gateway_reachable: false,
+    dns_resolves: false,
+    internet_reachable: false,
+    ap_active: false,
+    degraded: false,
+    last_error: '',
+    last_recovery_action: '',
+    last_recovery_result: '',
+    ...overrides
+  };
+}
+
+const pending = health();
+assert.equal(isWifiHealthCheckPending(pending), true);
+assert.equal(getWifiProbeStatusLabel(false, pending), 'CHECKING');
+
+const healthy = health({
+  gateway_reachable: true,
+  dns_resolves: true,
+  internet_reachable: true
+});
+assert.equal(isWifiHealthCheckPending(healthy), false);
+assert.equal(getWifiProbeStatusLabel(true, healthy), 'OK');
+
+const dnsFailure = health({
+  gateway_reachable: true,
+  degraded: true,
+  last_error: 'dns_unreachable'
+});
+assert.equal(isWifiHealthCheckPending(dnsFailure), false);
+assert.equal(getWifiProbeStatusLabel(false, dnsFailure), 'FAILED');
+
+const internetFailure = health({
+  gateway_reachable: true,
+  dns_resolves: true,
+  degraded: true,
+  last_error: 'internet_unreachable'
+});
+assert.equal(getWifiProbeStatusLabel(false, internetFailure), 'FAILED');
+
+assert.equal(getWifiProbeStatusLabel(false, pending, false), 'FAILED');
+assert.equal(getWifiProbeStatusLabel(undefined, undefined), '');
+
+console.log('Wi-Fi health display regression tests passed.');


### PR DESCRIPTION
## Summary

Distinguish an untested Wi-Fi health snapshot from a conclusive failed gateway, DNS, or internet probe.

## Root cause

The backend's shallow health response represents probes that have not run yet with boolean `false` values. The Dial mapped every `false` directly to `FAILED`, so an initial or cache-refresh placeholder looked like a real network outage.

## What changed

- Detect the precise pending shape: link connected, IPv4 acquired, not degraded, no last error, and no probes completed.
- Display `CHECKING` for pending gateway, DNS, and internet rows.
- Continue displaying `OK` for successful probes.
- Continue displaying `FAILED` for conclusive deep failures such as `dns_unreachable`.
- Add a deterministic Wi-Fi health presentation regression script.

## Customer impact

The machine no longer tells customers DNS has failed before DNS was checked. Genuine DNS failures remain clearly visible.

## Validation

- `npm run test:wifi-health` passed
- `npm run types` passed
- `npm run lint` passed
- `npm run format:check` passed
- Production `npm run build` passed

The existing third-party `lottie-web` eval and bundle-size warnings remain warnings.