### PR TITLE
Fix analog clock timezone refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "commit": "git-cz",
     "format": "prettier --config .prettierrc \"{src/**/,.github/**/,}*.{tsx,ts,md,js,css,html,json,yml}\" --write",
     "format:check": "prettier --config .prettierrc \"{src/**/,.github/**/,}*.{tsx,ts,md,js,css,html,json,yml}\" --check",
+    "test": "node --test --disable-warning=ExperimentalWarning --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types tests/*.test.mts",
     "types": "tsc --noEmit",
     "prepare": "husky",
     "lint": "eslint .",

--- a/src/components/IdleScreen/AnalogClock.tsx
+++ b/src/components/IdleScreen/AnalogClock.tsx
@@ -5,6 +5,7 @@ import { useNetworkConfig } from '../../hooks/useWifi';
 import { styled } from 'styled-components';
 
 import { WifiIndicator } from './WifiIndicator';
+import { getLocalClockTime, getTimezoneOffsetMs } from './analogClockTime';
 
 const CLOCK_DIAMETER = 480;
 const CLOCK_MAX_HAND_THICKNESS = 10;
@@ -95,9 +96,6 @@ function rotateString(degrees: number): string {
   return ROTATE_STRINGS[idx % 3600];
 }
 
-// getTimezoneOffset() returns UTC - local in minutes
-const TZ_OFFSET_MS = new Date().getTimezoneOffset() * 60 * 1000;
-
 export function AnalogClock() {
   const requestId = useRef<number>(-1);
   const hourRef = useRef(null);
@@ -106,21 +104,27 @@ export function AnalogClock() {
   const lastHour = useRef('');
   const lastMinute = useRef('');
   const lastSecond = useRef('');
+  const lastTimezoneCheckSecond = useRef(Number.NaN);
+  const timezoneOffsetMs = useRef(0);
 
   const animateTime = () => {
     if (!hourRef.current || !minuteRef.current || !secondRef.current) {
       return;
     }
 
-    // Use Date.now() + integer arithmetic instead of new Date() to avoid
-    // allocating a Date object every frame (~60/sec).
+    // Read the system timezone once per second so changes made after startup
+    // (automatic sync, manual selection, or DST) are reflected without
+    // allocating a Date object every animation frame.
     const now = Date.now();
-    const ms = (now - TZ_OFFSET_MS) % 86400000; // ms since midnight local time
-    const totalSeconds = ms / 1000;
-    const seconds = totalSeconds % 60;
-    const totalMinutes = totalSeconds / 60;
-    const minutes = totalMinutes % 60;
-    const hours = (totalMinutes / 60) % 12;
+    const currentSecond = Math.floor(now / 1000);
+    if (currentSecond !== lastTimezoneCheckSecond.current) {
+      timezoneOffsetMs.current = getTimezoneOffsetMs(now);
+      lastTimezoneCheckSecond.current = currentSecond;
+    }
+    const { seconds, minutes, hours } = getLocalClockTime(
+      now,
+      timezoneOffsetMs.current
+    );
 
     const hourRotation = hours * 30;
     const minuteRotation = minutes * 6;

--- a/src/components/IdleScreen/analogClockTime.ts
+++ b/src/components/IdleScreen/analogClockTime.ts
@@ -1,0 +1,24 @@
+const MILLISECONDS_PER_MINUTE = 60 * 1000;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function getTimezoneOffsetMs(timestampMs: number): number {
+  return new Date(timestampMs).getTimezoneOffset() * MILLISECONDS_PER_MINUTE;
+}
+
+export function getLocalClockTime(
+  timestampMs: number,
+  timezoneOffsetMs: number
+) {
+  const unwrappedLocalTimeMs = timestampMs - timezoneOffsetMs;
+  const localTimeMs =
+    ((unwrappedLocalTimeMs % MILLISECONDS_PER_DAY) + MILLISECONDS_PER_DAY) %
+    MILLISECONDS_PER_DAY;
+  const totalSeconds = localTimeMs / 1000;
+  const totalMinutes = totalSeconds / 60;
+
+  return {
+    seconds: totalSeconds % 60,
+    minutes: totalMinutes % 60,
+    hours: (totalMinutes / 60) % 12
+  };
+}

--- a/tests/analogClockTime.test.mts
+++ b/tests/analogClockTime.test.mts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getLocalClockTime,
+  getTimezoneOffsetMs
+} from '../src/components/IdleScreen/analogClockTime.ts';
+
+const TEST_TIME = Date.UTC(2026, 7, 17, 12, 34, 56, 500);
+
+function restoreTimezone(timezone: string | undefined) {
+  if (timezone === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = timezone;
+  }
+}
+
+test('reads a timezone change made after the clock starts', () => {
+  const originalTimezone = process.env.TZ;
+
+  try {
+    process.env.TZ = 'UTC';
+    assert.equal(getTimezoneOffsetMs(TEST_TIME), 0);
+
+    process.env.TZ = 'Europe/Zurich';
+    const zurichOffsetMs = getTimezoneOffsetMs(TEST_TIME);
+    assert.equal(zurichOffsetMs, -2 * 60 * 60 * 1000);
+
+    const time = getLocalClockTime(TEST_TIME, zurichOffsetMs);
+    assert.equal(Math.floor(time.hours), 2);
+    assert.equal(Math.floor(time.minutes), 34);
+    assert.equal(time.seconds, 56.5);
+  } finally {
+    restoreTimezone(originalTimezone);
+  }
+});
+
+test('reads the offset for the current daylight-saving period', () => {
+  const originalTimezone = process.env.TZ;
+
+  try {
+    process.env.TZ = 'Europe/Zurich';
+    assert.equal(
+      getTimezoneOffsetMs(Date.UTC(2026, 0, 17, 12)),
+      -1 * 60 * 60 * 1000
+    );
+    assert.equal(
+      getTimezoneOffsetMs(Date.UTC(2026, 7, 17, 12)),
+      -2 * 60 * 60 * 1000
+    );
+  } finally {
+    restoreTimezone(originalTimezone);
+  }
+});
+
+test('wraps local time correctly for timezones west of UTC', () => {
+  const fiveHoursWest = 5 * 60 * 60 * 1000;
+  const time = getLocalClockTime(
+    Date.UTC(2026, 7, 17, 2, 15, 0),
+    fiveHoursWest
+  );
+
+  assert.equal(Math.floor(time.hours), 9);
+  assert.equal(Math.floor(time.minutes), 15);
+  assert.equal(time.seconds, 0);
+});


### PR DESCRIPTION
## Summary

- refresh the analog clock's timezone offset once per second instead of capturing it at application startup
- retain the low-allocation animation path by avoiding a `Date` allocation on every frame
- normalize local-day arithmetic across positive and negative UTC offsets
- add regression coverage for a runtime UTC→Zurich change, daylight-saving periods, and timezones west of UTC

## Root cause

The analog clock cached `getTimezoneOffset()` when its module loaded. The machine's automatic Wi-Fi lookup can change the system timezone later, so the digital clock immediately reflected local time while the analog clock continued using its startup offset until the dial process restarted.

## Impact

The analog clock follows automatic synchronization, manual timezone changes, and DST changes within one second without requiring a restart.

Companion backend persistence fix: [MeticulousHome/meticulous-backend#394](https://github.com/MeticulousHome/meticulous-backend/pull/394)

## Validation

- `npm test`
- `npm run types`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- adversarial review covering runtime timezone changes, DST, negative local-day wrapping, and animation allocation behavior